### PR TITLE
Add ballerina syntax highlighting

### DIFF
--- a/en/src/css/custom.css
+++ b/en/src/css/custom.css
@@ -400,14 +400,25 @@ code {
   color: #E2E8F0;
 }
 
+/* Ballerina class-name tokens (module:Type, PascalCaseType) */
+.token.class-name {
+  color: #6f42c1;
+}
+
+[data-theme='dark'] .token.class-name {
+  color: #bd93f9;
+}
+
 /* Code blocks — override inline code style */
 .prism-code {
   border-radius: var(--ifm-code-border-radius);
-  border: 1px solid #E2E8F0;
+  border: 1px solid #CBD5E1;
+  background-color: #F1F5F9 !important;
 }
 
 [data-theme='dark'] .prism-code {
   border-color: #1E293B;
+  background-color: #0D1526 !important;
 }
 
 .prism-code code {

--- a/en/src/theme/Root.js
+++ b/en/src/theme/Root.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Prism } from 'prism-react-renderer';
+
+// Make Prism available globally so extensions can reach it
+(typeof global !== 'undefined' ? global : window).Prism = Prism;
+
+Prism.languages.ballerina = {
+  comment: [
+    { pattern: /\/\/.*$/m, greedy: true },
+    { pattern: /\/\*[\s\S]*?\*\//, greedy: true },
+  ],
+
+  string: [
+    { pattern: /`(?:[^\\`]|\\.)*`/, greedy: true },        // template strings
+    { pattern: /"(?:[^\\"\r\n]|\\.)*"/, greedy: true },    // regular strings
+  ],
+
+  annotation: {
+    pattern: /@(?:[\w.]+)/,
+    alias: 'builtin',
+  },
+
+  // Module-qualified types: devant:BinaryDataLoader, twilio:Client, http:Listener
+  'class-name': /\b[a-z]\w*:[A-Z]\w*\b/,
+
+  // Standalone PascalCase user-defined types and records
+  'type-name': {
+    pattern: /\b[A-Z]\w*\b/,
+    alias: 'class-name',
+  },
+
+  keyword: /\b(?:import|as|public|private|external|final|service|resource|function|object|record|annotation|type|typedesc|new|map|future|error|stream|table|transaction|from|on|returns|return|match|foreach|in|while|do|if|else|fork|worker|wait|start|flush|send|receive|check|checkpanic|trap|panic|fail|is|typeof|var|const|configurable|isolated|transactional|rollback|commit|retry|lock|enum|class|distinct|readonly|any|anydata|never|byte|int|float|boolean|string|decimal|json|xml|handle|xmlns|listener|client|let|where|select|limit|join|outer|order|by|ascending|descending|equals|conflict|version)\b/,
+
+  boolean: /\b(?:true|false)\b/,
+
+  nil: {
+    pattern: /\(\s*\)/,
+    alias: 'constant',
+  },
+
+  number: /\b0[xX][\da-fA-F]+\b|\b0[oO][0-7]+\b|\b0[bB][01]+\b|(?:\b\d+\.?\d*|\B\.\d+)(?:[eE][+-]?\d+)?(?:d|f)?\b/,
+
+  operator: /->|=>|::|\.\.\.?|[+\-*/%^&|~!=<>?:]+/,
+
+  punctuation: /[{}[\];(),.:]/,
+};
+
+export default function Root({ children }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
This pull request introduces syntax highlighting support for the Ballerina language in code blocks and improves the visual appearance of code blocks in both light and dark themes.

<img width="886" height="308" alt="image" src="https://github.com/user-attachments/assets/955fa481-4933-4607-8c7b-1b4ca19cdb56" />
