### PR TITLE
Fix broken links and auto-collapse sidebar on section navigation

### DIFF
--- a/en/docs/connectors/catalog/ai-ml/index.md
+++ b/en/docs/connectors/catalog/ai-ml/index.md
@@ -30,8 +30,3 @@ description: "AI and machine learning connectors available in WSO2 Integrator."
 | [pgvector](ai.pgvector/overview.md) | Vector similarity search in PostgreSQL with dense, sparse, and hybrid embeddings | Add, Query, Delete | Username/Password |
 | [Pinecone](ai.pinecone/overview.md) | Vector database with dense, sparse, and hybrid similarity search | Add, Query, Delete | API Key |
 | [Weaviate](ai.weaviate/overview.md) | Vector database with semantic search, metadata filtering, and embedding storage | Add, Query, Delete | API Key |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/cloud-infrastructure/azure.functions/trigger-reference.md
+++ b/en/docs/connectors/catalog/cloud-infrastructure/azure.functions/trigger-reference.md
@@ -16,7 +16,7 @@ Three components work together:
 | `af:CosmosDBListener` | Subscribes to the CosmosDB change feed and invokes `onUpdate` when documents are created or updated. |
 | `af:TimerListener` | Fires on a CRON schedule and invokes `onTrigger` at each scheduled interval. |
 
-For action-based record operations, see the [Action Reference](action-reference.md).
+For action-based record operations, see the [Overview](overview.md).
 
 ---
 

--- a/en/docs/connectors/catalog/cloud-infrastructure/index.md
+++ b/en/docs/connectors/catalog/cloud-infrastructure/index.md
@@ -16,8 +16,3 @@ description: "Cloud and infrastructure connectors available in WSO2 Integrator."
 | [AWS Marketplace MPM](aws.marketplace.mpm/overview.md) | AWS Marketplace metering for customer resolution and usage billing | Resolve Customer, Batch Meter Usage | AWS Access Key |
 | [Azure Functions](azure.functions/overview.md) | Serverless Azure Functions framework with HTTP, Queue, Blob, CosmosDB, and Timer triggers | HTTP Trigger, Queue Trigger, Blob Trigger, CosmosDB Trigger, Timer Trigger, Output Bindings | Azure App Settings (storage connection strings, function keys, CosmosDB connection strings) |
 | [Elastic Cloud](elastic.elasticcloud/overview.md) | Elastic Cloud management with deployments, traffic filters, organizations, API keys, and stack versions | Create, List, Search, Update, Shutdown, Restore, Delete | API Key |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/communication/index.md
+++ b/en/docs/connectors/catalog/communication/index.md
@@ -18,8 +18,3 @@ description: "Communication connectors available in WSO2 Integrator."
 | [Twilio](twilio/overview.md) | Cloud communications platform for SMS, voice calls, WhatsApp, and messaging APIs | Create Message, Fetch Message, List Messages, Create Call, Fetch Call, List Calls, Manage Recordings | HTTP Basic (Account SID + Auth Token) / API Key |
 | [Zoom Meetings](zoom.meetings/overview.md) | Video conferencing platform for scheduling, managing, and reporting on meetings and webinars | Create, Read, Update, Delete, List, Register, Record, Report | OAuth 2.0 |
 | [Zoom Scheduler](zoom.scheduler/overview.md) | Zoom scheduling service for managing availability windows, meeting schedules, and bookings | Create, Read, Update, Delete, List, Analytics | OAuth 2.0 |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
+++ b/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
@@ -32,9 +32,6 @@ See the **[Action Reference](action-reference.md)** for the full list of operati
 
 ## Twilio connector documentation
 
-* **[Twilio Connector Setup Guide](setup-guide.md)**: This guide walks you through obtaining the Twilio credentials required to use the Ballerina Twilio connector.
-
-
 * **[Action Reference](action-reference.md)**: Full reference for all clients — operations, parameters, return types, and sample code.
 
 ## How to contribute

--- a/en/docs/connectors/catalog/crm-sales/index.md
+++ b/en/docs/connectors/catalog/crm-sales/index.md
@@ -40,8 +40,3 @@ description: "CRM and sales connectors available in WSO2 Integrator."
 | [HubSpot CRM Schemas](hubspot.crm.obj.schemas/overview) | Manage HubSpot custom object schemas, properties, and inter-object associations | Create, Read, Update, Delete, Associate | OAuth 2.0, Bearer Token, API Key |
 | [HubSpot CRM Tickets](hubspot.crm.obj.tickets/overview.md) | CRM platform for managing customer support ticket records with pipeline and priority tracking | Create, Read, Update, Delete, Search, Merge, Batch Create, Batch Read, Batch Update | OAuth 2.0 |
 | [Salesforce](salesforce/overview.md) | CRM platform with records, queries, bulk data operations, and change event triggers | Create, Read, Update, Delete, Query, Bulk, Events | OAuth 2.0 |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/database/index.md
+++ b/en/docs/connectors/catalog/database/index.md
@@ -22,8 +22,3 @@ description: "Database connectors available in WSO2 Integrator."
 | [PostgreSQL](postgresql/overview.md) | Object-relational database with SQL queries, batch operations, stored procedures, and CDC triggers | Query, Execute, Batch Execute, Call, CDC | Username/Password |
 | [Redis](redis/overview.md) | In-memory data store with string, list, set, sorted set, and hash operations | Get, Set, List, Hash, Set, Sorted Set, Key Management | Password / ACL |
 | [Snowflake](snowflake/overview.md) | Cloud data warehouse with SQL queries, DML/DDL execution, batch operations, and stored procedures | Query, Execute, Batch Execute, Call | Basic Auth, Key-Pair Auth |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/developer-tools/index.md
+++ b/en/docs/connectors/catalog/developer-tools/index.md
@@ -18,8 +18,3 @@ description: "Developer tools connectors available in WSO2 Integrator."
 | [Moesif](moesif/overview.md) | API observability provider for forwarding distributed traces and metrics to Moesif | Distributed Tracing, Metrics Reporting | API Key (Application ID) |
 | [New Relic](newrelic/overview.md) | Observability extension that auto-exports Ballerina runtime metrics and distributed traces to New Relic | Metrics Export, Distributed Tracing, Multi-account Fan-out | API Key (License Key) |
 | [WSO2 APIM Catalog](wso2.apim.catalog/overview.md) | WSO2 API Manager Service Catalog for registering and managing backend service definitions | Create, Read, Update, Delete, Import, Export, Settings | OAuth 2.0 Password Grant |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/ecommerce/index.md
+++ b/en/docs/connectors/catalog/ecommerce/index.md
@@ -13,8 +13,3 @@ description: "E-commerce connectors available in WSO2 Integrator."
 |-----------|-------------|------------|----------------|
 | [SAP Commerce](sap.commerce.webservices/overview.md) | E-commerce platform with product catalog, cart management, orders, and B2B procurement | Products, Carts, Orders, Customers, Stores, Tickets, Quotes | OAuth 2.0 (Client Credentials) |
 | [Shopify Admin](shopify.admin/overview.md) | E-commerce platform with product, order, customer, fulfillment, and webhook management | Create, Read, Update, List, Search | API Key |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/erp-business/index.md
+++ b/en/docs/connectors/catalog/erp-business/index.md
@@ -24,8 +24,3 @@ description: "ERP and business operations connectors available in WSO2 Integrato
 | [SAP Sales Quotation](sap.s4hana.api_sales_quotation_srv/overview.md) | SAP S/4HANA Sales Quotation API with full CRUD, partners, pricing, texts, process flow, and approval actions | Create, Read, Update, Delete, Approve, Reject, Batch | Basic Auth |
 | [SAP SD Incoterms](sap.s4hana.api_sd_incoterms_srv/overview.md) | SAP S/4HANA OData API for reading Incoterms classification and version master data with multilingual text support | List, Read | Basic Authentication |
 | [SAP SD Sold-to-Party Determination](sap.s4hana.api_sd_sa_soldtopartydetn/overview.md) | SAP S/4HANA OData service for querying sold-to party assignments in sales scheduling agreements | Read, List | Basic Auth |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/finance-accounting/index.md
+++ b/en/docs/connectors/catalog/finance-accounting/index.md
@@ -16,8 +16,3 @@ description: "Finance and accounting connectors available in WSO2 Integrator."
 | [PayPal Payments](paypal.payments/overview.md) | Payment platform with authorization, capture, void, and refund operations | Authorize, Capture, Void, Refund, Show Details | OAuth 2.0 (Client Credentials) |
 | [PayPal Subscriptions](paypal.subscriptions/overview.md) | PayPal recurring billing platform for creating subscription plans and managing subscription lifecycles | Create, Read, Update, Activate, Deactivate, Suspend, Cancel, Revise, Capture, List | OAuth 2.0 |
 | [Stripe](stripe/overview.md) | Payment processing platform with customers, charges, invoices, subscriptions, and payouts | Create, Read, Update, Delete, List | API Key (Bearer Token) |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/healthcare/index.md
+++ b/en/docs/connectors/catalog/healthcare/index.md
@@ -11,8 +11,3 @@ description: "Healthcare connectors available in WSO2 Integrator."
 
 | Connector | Description | Operations | Authentication |
 |-----------|-------------|------------|----------------|
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/hrms/index.md
+++ b/en/docs/connectors/catalog/hrms/index.md
@@ -12,8 +12,3 @@ description: "HRMS connectors available in WSO2 Integrator."
 | Connector | Description | Operations | Authentication |
 |-----------|-------------|------------|----------------|
 | [People HR](peoplehr/overview.md) | HR management system with employee records, holidays, salaries, vacancies, applicants, and appraisals | Create, Read, Update, Delete, Query | API Key |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/marketing-social/index.md
+++ b/en/docs/connectors/catalog/marketing-social/index.md
@@ -21,8 +21,3 @@ description: "Marketing and social media connectors available in WSO2 Integrator
 | [Mailchimp Transactional](mailchimp.transactional/overview.md) | Transactional email service with message sending, templates, webhooks, and delivery analytics | Send, Search, Templates, Webhooks, Tags, Senders, Rejects | API Key |
 | [Salesforce Marketing Cloud](salesforce.marketingcloud/overview.md) | Digital marketing platform with journeys, campaigns, contacts, data extensions, assets, and transactional email | Create, Read, Update, Delete, Search, Send, Import | OAuth 2.0 (Client Credentials) |
 | [Twitter](twitter/overview.md) | Social media platform with tweet management, user lookup, DMs, likes, retweets, bookmarks, and lists | Create, Read, Delete, Search, Like, Retweet, Bookmark, DM, Follow | OAuth 2.0 (PKCE / App-Only Bearer Token) |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/messaging/index.md
+++ b/en/docs/connectors/catalog/messaging/index.md
@@ -22,8 +22,3 @@ description: "Messaging connectors available in WSO2 Integrator."
 | [NATS](nats/overview.md) | High-performance pub/sub and persistent JetStream messaging with publish, subscribe, request-reply, and stream management | Publish, Subscribe, Request-Reply, Stream Create/Update/Delete/Purge, Consume, Ack/Nak | None / Username-Password / Token / Mutual TLS |
 | [RabbitMQ](rabbitmq/overview.md) | AMQP 0-9-1 message broker with queue/exchange management, pub/sub, and consumer services | Publish, Consume, Queue Declare, Exchange Declare, Bind, Ack, Nack | Username / Password |
 | [Solace](solace/overview.md) | Event broker with publish/subscribe, queuing, durable subscriptions, and listener triggers | Send, Receive, Acknowledge, Commit, Rollback | Basic Auth, Kerberos, OAuth 2.0 |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/productivity-collaboration/index.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/index.md
@@ -20,8 +20,3 @@ description: "Productivity and collaboration connectors available in WSO2 Integr
 | [Jira](jira/overview.md) | Project tracking and issue management with JQL search, workflows, and full CRUD operations | Create, Read, Update, Delete, Search, Transition, Bulk | Basic Auth (API Token) / OAuth 2.0 |
 | [Smartsheet](smartsheet/overview.md) | Work management platform with sheets, rows, columns, folders, workspaces, and collaboration | Create, Read, Update, Delete, Share, Search, Webhooks | API Token / OAuth 2.0 |
 | [Trello](trello/overview.md) | Project management with boards, lists, cards, checklists, and team collaboration | Create, Read, Update, Delete, Search | API Key + Token |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/security-identity/index.md
+++ b/en/docs/connectors/catalog/security-identity/index.md
@@ -13,8 +13,3 @@ description: "Security and identity connectors available in WSO2 Integrator."
 |-----------|-------------|------------|----------------|
 | [AWS Secrets Manager](aws.secretmanager/overview.md) | Secrets management service for retrieving and describing AWS secrets | Describe, Get Secret Value, Batch Get | AWS Access Keys / IAM Role |
 | [SCIM](scim/overview.md) | SCIM 2.0 identity provisioning with user, group, and bulk management operations | Create, Read, Update, Delete, Search, Bulk | OAuth 2.0 (Client Credentials) |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/catalog/storage-file/aws.s3/action-reference.md
+++ b/en/docs/connectors/catalog/storage-file/aws.s3/action-reference.md
@@ -7,7 +7,7 @@ The `ballerinax/aws.s3` package exposes the following clients:
 
 | Client | Purpose |
 |--------|---------|
-| [`Client`](#s3client) | Provides operations to manage S3 buckets and objects via the Amazon S3 REST API. |
+| [`Client`](#client) | Provides operations to manage S3 buckets and objects via the Amazon S3 REST API. |
 
 ---
 

--- a/en/docs/connectors/catalog/storage-file/index.md
+++ b/en/docs/connectors/catalog/storage-file/index.md
@@ -14,8 +14,3 @@ description: "Storage and file management connectors available in WSO2 Integrato
 | [Alfresco](alfresco/overview.md) | Enterprise content management platform with document CRUD, versioning, shared links, and collaboration features | Create, Read, Update, Delete, Upload, Download, Copy, Move, Search | Basic Authentication |
 | [AWS S3](aws.s3/overview.md) | Object storage with bucket management, object CRUD, presigned URLs, and multipart uploads | Create, Read, Delete, List, Presign, Multipart Upload | AWS Access Keys / IAM Role |
 | [Microsoft OneDrive](microsoft.onedrive/overview.md) | Cloud file storage with drive/item CRUD, content upload/download, sharing, and search | List, Create, Read, Update, Delete, Upload, Download, Copy, Share, Search | OAuth 2.0 |
-
-## What's next
-
-- [Connection Configuration](configuration.md) — How to set up connections
-- [Authentication Methods](authentication.md) — Supported auth types

--- a/en/docs/connectors/configuration.md
+++ b/en/docs/connectors/configuration.md
@@ -29,4 +29,4 @@ Connections define how your integration communicates with external systems — t
 
 ## What's next
 
-- [Authentication Methods](authentication.md) — Secure your connections
+- [Build Your Own Connector](build-your-own/) — Create custom connectors

--- a/en/docs/connectors/publish-to-central.md
+++ b/en/docs/connectors/publish-to-central.md
@@ -21,4 +21,4 @@ Share your custom connector with the community by publishing it to Ballerina Cen
 
 ## What's next
 
-- [Custom Connector Development](custom-development.md) — Build more connectors
+- [Custom Connector Development](build-your-own/custom-development.md) — Build more connectors

--- a/en/docs/develop/design-logic/overview.md
+++ b/en/docs/develop/design-logic/overview.md
@@ -117,5 +117,5 @@ service /api on new http:Listener(8090) {
 
 ## What's next
 
-- [Integration Artifacts](/docs/develop/integration-artifacts) — Understand the artifact types that contain your logic
+- [Integration Artifacts](/docs/develop/integration-artifacts/overview) — Understand the artifact types that contain your logic
 - [Test](/docs/develop/test/try-it) — Validate your logic with the built-in Try-It tool

--- a/en/docs/develop/design-logic/query-expressions.md
+++ b/en/docs/develop/design-logic/query-expressions.md
@@ -282,4 +282,4 @@ function reconcileInventory(
 
 - [Expressions](expressions.md) — Inline expressions used within query clauses
 - [Functions](functions.md) — Wrap query expressions in reusable functions
-- [Data Persistence](/docs/develop/integration-artifacts/data-persistence) — Query over persisted data
+- [Data Persistence](/docs/develop/integration-artifacts/supporting/data-persistence) — Query over persisted data

--- a/en/docs/reference/cli/bal-persist.md
+++ b/en/docs/reference/cli/bal-persist.md
@@ -234,4 +234,4 @@ bal persist push --datastore mysql --module db
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
 - [Ballerina.toml Reference](/reference/config/ballerina-toml.md) -- Project configuration
-- [Databases Connector Guide](/connectors/databases.md) -- Database connectivity
+- [Databases Connector Guide](/docs/connectors/catalog/database) -- Database connectivity

--- a/en/docs/reference/protocols.md
+++ b/en/docs/reference/protocols.md
@@ -198,5 +198,5 @@ service "emailObserver" on imapListener {
 ## See Also
 
 - [Ballerina API Documentation](api/ballerina-api-docs.md) -- Full API docs for all modules
-- [Connectors - Protocols](/connectors/protocols.md) -- Protocol connector guides
+- [Connectors Catalog](/docs/connectors/catalog) -- Protocol connector guides
 - [Data Formats](data-formats.md) -- Supported data formats

--- a/en/docs/tutorials/walkthroughs/cdc-service.md
+++ b/en/docs/tutorials/walkthroughs/cdc-service.md
@@ -369,6 +369,6 @@ UPDATE orders SET status = 'shipped' WHERE id = 1;
 
 ## What's Next
 
-- [Databases Connectors](../../connectors/databases.md) -- Database connector reference
-- [Messaging Connectors](../../connectors/messaging.md) -- Kafka, RabbitMQ, and more
+- [Databases Connectors](../../connectors/catalog/database) -- Database connector reference
+- [Messaging Connectors](../../connectors/catalog/messaging) -- Kafka, RabbitMQ, and more
 - [Kafka Event Processing Pipeline](../kafka-event-pipeline.md) -- Full Kafka tutorial

--- a/en/docs/tutorials/walkthroughs/edi-ftp-processing.md
+++ b/en/docs/tutorials/walkthroughs/edi-ftp-processing.md
@@ -473,6 +473,6 @@ Check the service logs for processing status and verify the file was moved to th
 
 ## What's Next
 
-- [Data Formats & Standards Connectors](../../connectors/data-formats-standards.md) -- EDI, FHIR, and SOAP connectors
+- [Data Formats & Standards Connectors](../../connectors/catalog) -- EDI, FHIR, and SOAP connectors
 - [EDI Transformation](../../develop/transform/edi.md) -- EDI data transformation reference
 - [FTP EDI to Salesforce](../pre-built/ftp-edi-salesforce.md) -- Pre-built sample for EDI to Salesforce

--- a/en/docs/tutorials/walkthroughs/email-notification-service.md
+++ b/en/docs/tutorials/walkthroughs/email-notification-service.md
@@ -316,5 +316,5 @@ curl http://localhost:8090/notifications/templates
 
 ## What's Next
 
-- [Communication Connectors](../../connectors/communication.md) -- Email, SMS, and Slack connectors
+- [Communication Connectors](../../connectors/catalog/communication) -- Email, SMS, and Slack connectors
 - [Content-Based Routing](content-based-routing.md) -- Route notifications by type

--- a/en/docusaurus.config.ts
+++ b/en/docusaurus.config.ts
@@ -115,7 +115,7 @@ const config: Config = {
           activeBaseRegex: '/docs/genai(/|$)',
         },
         {
-          to: '/docs/tutorials',
+          to: '/docs/tutorials/overview',
           label: 'Tutorials',
           position: 'left',
           activeBaseRegex: '/docs/tutorials(/|$)',

--- a/en/src/theme/Root.js
+++ b/en/src/theme/Root.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useLocation } from '@docusaurus/router';
 import { Prism } from 'prism-react-renderer';
 
@@ -58,9 +58,23 @@ const sectionPaths = [
   '/docs/reference',
 ];
 
+// Map section paths to their sidebar label text for matching.
+const sectionLabels = {
+  '/docs/get-started': 'Get Started',
+  '/docs/develop': 'Develop',
+  '/docs/connectors': 'Connectors',
+  '/docs/genai': 'GenAI',
+  '/docs/tutorials': 'Tutorials',
+  '/docs/deploy-operate': 'Deploy & Operate',
+  '/docs/reference': 'Reference',
+};
+
 function useNavbarActiveState() {
   const { pathname } = useLocation();
+  const prevSectionRef = useRef(null);
+
   useEffect(() => {
+    // Update navbar active link highlights
     const links = document.querySelectorAll('.navbar__items .navbar__link');
     links.forEach((link) => {
       const href = link.getAttribute('href');
@@ -72,6 +86,35 @@ function useNavbarActiveState() {
         link.classList.remove('navbar__link--active');
       }
     });
+
+    // Collapse non-active top-level sidebar categories when section changes
+    const currentSection = sectionPaths.find((p) => pathname.startsWith(p));
+    if (currentSection && currentSection !== prevSectionRef.current) {
+      prevSectionRef.current = currentSection;
+      // Small delay to let Docusaurus render the sidebar first
+      requestAnimationFrame(() => {
+        const topItems = document.querySelectorAll(
+          '.theme-doc-sidebar-menu > .theme-doc-sidebar-item-category-level-1'
+        );
+        topItems.forEach((li) => {
+          const labelEl = li.querySelector(
+            ':scope > .menu__list-item-collapsible .menu__link'
+          );
+          const label = labelEl?.textContent?.trim();
+          const isActive = label === sectionLabels[currentSection];
+          const toggleBtn = li.querySelector(
+            ':scope > .menu__list-item-collapsible .clean-btn'
+          );
+          const isCollapsed = li.classList.contains('menu__list-item--collapsed');
+
+          if (!isActive && !isCollapsed && toggleBtn) {
+            toggleBtn.click();
+          } else if (isActive && isCollapsed && toggleBtn) {
+            toggleBtn.click();
+          }
+        });
+      });
+    }
   }, [pathname]);
 }
 


### PR DESCRIPTION
**Summary**
Fix broken markdown links and remove invalid sidebar link references across connector catalog, develop, reference, and tutorial docs (28 files)
Add auto-collapse behavior to the left sidebar — when navigating via the top navbar, the active section expands and all others collapse automatically
Fix the Tutorials navbar link to point to the overview page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated connector catalog documentation links to reflect new organizational structure
  * Reorganized navigation across connector category overview pages
  * Improved internal documentation cross-references for consistency
  * Enhanced navigation flow in tutorials and reference guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->