### PR TITLE
Fix broken reference links and edit-page URL

### DIFF
--- a/en/docs/reference/api/ballerina-api-docs.md
+++ b/en/docs/reference/api/ballerina-api-docs.md
@@ -136,6 +136,6 @@ The WSO2 Integrator VS Code extension provides inline API documentation:
 
 ## See Also
 
-- [Standard Library Functions](/reference/language/stdlib.md) -- Functions by category
-- [Protocols Reference](/reference/protocols.md) -- Supported protocols and modules
+- [Standard Library Functions](/docs/reference/language/stdlib) -- Functions by category
+- [Protocols Reference](/docs/reference/protocols) -- Supported protocols and modules
 - [Connectors Index](/docs/connectors/overview) -- Connector guides and configuration

--- a/en/docs/reference/appendix/system-requirements.md
+++ b/en/docs/reference/appendix/system-requirements.md
@@ -149,6 +149,6 @@ For ahead-of-time compilation to native executables:
 
 ## See Also
 
-- [Installation Guide](/get-started/install.md) -- Step-by-step installation instructions
-- [Docker and Kubernetes Deployment](/deploy-operate/deploy/docker-kubernetes.md) -- Container deployment guide
+- [Installation Guide](/docs/get-started/install) -- Step-by-step installation instructions
+- [Docker and Kubernetes Deployment](/docs/deploy-operate/deploy/docker-kubernetes) -- Container deployment guide
 - [Troubleshooting](troubleshooting.md) -- Common issues and solutions

--- a/en/docs/reference/appendix/troubleshooting.md
+++ b/en/docs/reference/appendix/troubleshooting.md
@@ -364,6 +364,6 @@ bal clean && bal build
 ## See Also
 
 - [System Requirements](system-requirements.md) -- Platform and version requirements
-- [Installation Guide](/get-started/install.md) -- Installation instructions
-- [Error Codes Reference](/reference/error-codes.md) -- All error codes with resolution steps
-- [FAQ](/reference/faq.md) -- Frequently asked questions
+- [Installation Guide](/docs/get-started/install) -- Installation instructions
+- [Error Codes Reference](/docs/reference/error-codes) -- All error codes with resolution steps
+- [FAQ](/docs/reference/faq) -- Frequently asked questions

--- a/en/docs/reference/by-example.md
+++ b/en/docs/reference/by-example.md
@@ -227,6 +227,6 @@ Alternatively, use the "Run" button on each example page at [ballerina.io/learn/
 
 ## See Also
 
-- [Ballerina Syntax Quick Reference](/reference/language/syntax.md) -- Language cheat sheet
+- [Ballerina Syntax Quick Reference](/docs/reference/language/syntax) -- Language cheat sheet
 - [Ballerina API Documentation](api/ballerina-api-docs.md) -- Full API docs
 - [Specifications](specifications.md) -- Language and platform specifications

--- a/en/docs/reference/cli/bal-edi.md
+++ b/en/docs/reference/cli/bal-edi.md
@@ -199,5 +199,5 @@ public function main() returns error? {
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [EDI Data Transformation](/develop/transform/edi.md) -- Working with EDI data
-- [Data Formats Reference](/reference/data-formats.md) -- All supported data formats
+- [EDI Data Transformation](/docs/develop/transform/edi) -- Working with EDI data
+- [Data Formats Reference](/docs/reference/data-formats) -- All supported data formats

--- a/en/docs/reference/cli/bal-graphql.md
+++ b/en/docs/reference/cli/bal-graphql.md
@@ -213,4 +213,4 @@ bal graphql -i service.bal --mode schema -o specs/
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [Ballerina by Example](/reference/by-example.md) -- Runnable examples
+- [Ballerina by Example](/docs/reference/by-example) -- Runnable examples

--- a/en/docs/reference/cli/bal-grpc.md
+++ b/en/docs/reference/cli/bal-grpc.md
@@ -214,5 +214,5 @@ service "OrderService" on ep {
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [Protocols Reference](/reference/protocols.md) -- Supported protocols including gRPC
-- [Ballerina by Example](/reference/by-example.md) -- Runnable gRPC examples
+- [Protocols Reference](/docs/reference/protocols) -- Supported protocols including gRPC
+- [Ballerina by Example](/docs/reference/by-example) -- Runnable gRPC examples

--- a/en/docs/reference/cli/bal-health.md
+++ b/en/docs/reference/cli/bal-health.md
@@ -197,5 +197,5 @@ service /fhir/r4 on new http:Listener(9090) {
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [Healthcare HL7/FHIR Tutorial](/tutorials/healthcare-hl7-fhir.md) -- End-to-end healthcare integration
-- [Data Formats Reference](/reference/data-formats.md) -- All supported data formats including FHIR and HL7
+- [Healthcare HL7/FHIR Tutorial](/docs/tutorials/healthcare-hl7-fhir) -- End-to-end healthcare integration
+- [Data Formats Reference](/docs/reference/data-formats) -- All supported data formats including FHIR and HL7

--- a/en/docs/reference/cli/bal-openapi.md
+++ b/en/docs/reference/cli/bal-openapi.md
@@ -205,4 +205,4 @@ service /api/v1 on new http:Listener(8080) {
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [Ballerina by Example](/reference/by-example.md) -- Runnable examples
+- [Ballerina by Example](/docs/reference/by-example) -- Runnable examples

--- a/en/docs/reference/cli/bal-persist.md
+++ b/en/docs/reference/cli/bal-persist.md
@@ -233,5 +233,5 @@ bal persist push --datastore mysql --module db
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [Ballerina.toml Reference](/reference/config/ballerina-toml.md) -- Project configuration
+- [Ballerina.toml Reference](/docs/reference/config/ballerina-toml) -- Project configuration
 - [Databases Connector Guide](/docs/connectors/catalog/database) -- Database connectivity

--- a/en/docs/reference/cli/scan-tool.md
+++ b/en/docs/reference/cli/scan-tool.md
@@ -234,5 +234,5 @@ Scan results are also written to `target/report/scan-results.json` for CI/CD int
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [Unit Testing](/develop/test/unit-testing.md) -- Testing Ballerina projects
-- [CI/CD Integration](/deploy-operate/cicd/github-actions.md) -- Continuous integration workflows
+- [Unit Testing](/docs/develop/test/unit-testing) -- Testing Ballerina projects
+- [CI/CD Integration](/docs/deploy-operate/cicd/github-actions) -- Continuous integration workflows

--- a/en/docs/reference/cli/update-tool.md
+++ b/en/docs/reference/cli/update-tool.md
@@ -249,5 +249,5 @@ bal build
 ## See Also
 
 - [bal Command Reference](bal-commands.md) -- All bal subcommands
-- [Installation Guide](/get-started/install.md) -- Initial installation
-- [System Requirements](/reference/appendix/system-requirements.md) -- Supported platforms and prerequisites
+- [Installation Guide](/docs/get-started/install) -- Initial installation
+- [System Requirements](/docs/reference/appendix/system-requirements) -- Supported platforms and prerequisites

--- a/en/docs/reference/data-formats/index.md
+++ b/en/docs/reference/data-formats/index.md
@@ -41,8 +41,8 @@ Common format-to-format transformation patterns supported in WSO2 Integrator:
 
 ## See also
 
-- [Data Transformation - JSON](/develop/transform/json.md) -- JSON transformation guide
-- [Data Transformation - XML](/develop/transform/xml.md) -- XML transformation guide
-- [Data Transformation - CSV](/develop/transform/csv-flat-file.md) -- CSV processing guide
-- [Data Transformation - EDI](/develop/transform/edi.md) -- EDI processing guide
+- [Data Transformation - JSON](/docs/develop/transform/json) -- JSON transformation guide
+- [Data Transformation - XML](/docs/develop/transform/xml) -- XML transformation guide
+- [Data Transformation - CSV](/docs/develop/transform/csv-flat-file) -- CSV processing guide
+- [Data Transformation - EDI](/docs/develop/transform/edi) -- EDI processing guide
 - [Ballerina API Documentation](../api/ballerina-api-docs.md) -- Full API docs for all modules

--- a/en/docs/reference/language/concurrency.md
+++ b/en/docs/reference/language/concurrency.md
@@ -345,4 +345,4 @@ function processMessages(kafka:Consumer consumer, int workerId) returns error? {
 - [Ballerina Syntax Quick Reference](syntax.md) -- Core language syntax
 - [Error Handling](error-handling.md) -- Error handling patterns
 - [Integration-Specific Features](integration-features.md) -- Services, clients, listeners
-- [Ballerina by Example](/reference/by-example.md) -- Runnable concurrency examples
+- [Ballerina by Example](/docs/reference/by-example) -- Runnable concurrency examples

--- a/en/docs/reference/language/error-handling.md
+++ b/en/docs/reference/language/error-handling.md
@@ -361,4 +361,4 @@ function validateOrder(Order order) returns error? {
 - [Ballerina Syntax Quick Reference](syntax.md) -- Core language syntax
 - [Concurrency](concurrency.md) -- Workers, transactions, and error handling in concurrent code
 - [Integration-Specific Features](integration-features.md) -- Services, clients, listeners
-- [Ballerina by Example](/reference/by-example.md) -- Runnable error handling examples
+- [Ballerina by Example](/docs/reference/by-example) -- Runnable error handling examples

--- a/en/docusaurus.config.ts
+++ b/en/docusaurus.config.ts
@@ -57,7 +57,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/wso2/docs-integrator/tree/main/',
+          editUrl: 'https://github.com/wso2/docs-integrator/tree/main/en/',
           showLastUpdateTime: true,
         },
         blog: false,


### PR DESCRIPTION
Fix 27 broken absolute-path markdown links across reference docs that were missing the /docs/ prefix and had .md extensions (e.g. /reference/protocols.md -> /docs/reference/protocols). Update the Docusaurus editUrl to include the /en/ subdirectory so the "Edit this page" links resolve to real files on GitHub instead of 404.
