### PR TITLE
Fix broken links and anchors flagged by docusaurus build

### DIFF
--- a/en/docs/connectors/catalog/communication/intercom/action-reference.md
+++ b/en/docs/connectors/catalog/communication/intercom/action-reference.md
@@ -541,7 +541,7 @@ intercom:Ticket ticket = check intercomClient->/tickets.post({
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `ticketTypeId` | `string` | Yes | ID of the ticket type (see [Setup guide](setup-guide.md#step-6-optional-find-your-ticket-type-id)) |
+| `ticketTypeId` | `string` | Yes | ID of the ticket type (see [Setup guide](setup-guide.md#step-5-optional-find-your-ticket-type-id)) |
 | `contacts` | `CreateTicketRequestContacts[]` | Yes | Contacts associated with the ticket |
 | `companyId` | `string` | No | Company to associate with the ticket |
 

--- a/en/docs/connectors/catalog/communication/intercom/overview.md
+++ b/en/docs/connectors/catalog/communication/intercom/overview.md
@@ -49,4 +49,4 @@ Check the issue tracker for open issues that interest you. We look forward to re
 
 - [Setup guide](setup-guide.md) — Create an Intercom app and obtain your access token
 - [Action reference](action-reference.md) — Browse all available operations and sample code
-- [Connectors overview](../../overview.md) — Explore other available connectors
+- [Connectors overview](../../../overview.md) — Explore other available connectors

--- a/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
+++ b/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
@@ -31,7 +31,7 @@ See the **[Action Reference](action-reference.md)** for the full list of operati
 
 ## Documentation
 
-* **[Setup Guide](setup-guide.md)**: This guide walks you through obtaining the Twilio credentials required to use the Ballerina Twilio connector.
+* **[Setup Guide](../setup-guide.md)**: This guide walks you through obtaining the Twilio credentials required to use the Ballerina Twilio connector.
 
 * **[Action Reference](action-reference.md)**: Full reference for all clients — operations, parameters, return types, and sample code.
 

--- a/en/docs/connectors/catalog/database/mssql/example.md
+++ b/en/docs/connectors/catalog/database/mssql/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the MSSQL integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the MSSQL connector
 

--- a/en/docs/connectors/catalog/database/redis/example.md
+++ b/en/docs/connectors/catalog/database/redis/example.md
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Setting up the Redis integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../getting-started/create-integration.md) guide to set up your project first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your project first, then return here to add the connector.
 
 ## Adding the Redis connector
 

--- a/en/docs/develop/integration-artifacts/event/azure-service-bus.md
+++ b/en/docs/develop/integration-artifacts/event/azure-service-bus.md
@@ -211,4 +211,4 @@ The `onMessage` handler receives an `asb:Message` parameter with the message con
 - [RabbitMQ](rabbitmq.md) — consume messages from RabbitMQ queues
 - [Kafka](kafka.md) — consume messages from Apache Kafka topics
 - [Connections](../supporting/connections.md) — reuse Azure Service Bus connection strings across services
-- [Azure Service Bus connector reference](../../../connectors/catalog/messaging/azure-service-bus/overview.md) — full connector API reference
+- [Azure Service Bus connector reference](../../../connectors/catalog/messaging/asb/overview.md) — full connector API reference

--- a/en/docs/develop/integration-artifacts/file/high-availability.md
+++ b/en/docs/develop/integration-artifacts/file/high-availability.md
@@ -185,4 +185,4 @@ If the coordination database is temporarily unavailable:
 
 - [FTP / SFTP](ftp-sftp.md) — service configuration, authentication, and file handlers
 - [Resiliency](resiliency.md) — automatic retry and circuit breaker for FTP client operations
-- [Scaling and high availability](../../../../deploy-operate/deploy/scaling-ha.md) — deployment-level scaling and HA strategies
+- [Scaling and high availability](../../../deploy-operate/deploy/scaling-ha.md) — deployment-level scaling and HA strategies

--- a/en/docs/get-started/key-concepts.md
+++ b/en/docs/get-started/key-concepts.md
@@ -14,11 +14,11 @@ A workspace that contains your integration code, dependencies, configuration, an
 
 ## Integration
 
-A reusable piece of business logic that connects systems, transforms data, or orchestrates workflows. Integrations are the core building blocks in WSO2 Integrator—you compose them from [Services](#services), [Automations](#automations), [Event handlers](#event-handlers), and more.
+A reusable piece of business logic that connects systems, transforms data, or orchestrates workflows. Integrations are the core building blocks in WSO2 Integrator—you compose them from [Services](#services-and-listeners), [Automations](#automations), [Event integrations](#event-integrations), and more.
 
 ## Library
 
-A shareable collection of reusable components, functions, and connectors packaged for distribution. Libraries let you build once and use across multiple projects or share with your team. For more information, see [Organize code](/docs/develop/organize-code/).
+A shareable collection of reusable components, functions, and connectors packaged for distribution. Libraries let you build once and use across multiple projects or share with your team. For more information, see [Organize code](/docs/develop/organize-code/overview).
 
 ## Services and listeners
 

--- a/en/docs/reference/overview.md
+++ b/en/docs/reference/overview.md
@@ -59,7 +59,7 @@ Command-line tools reference:
 ## Specifications & Formats
 
 - **[Supported Protocols](protocols.md)** — Complete protocol support table
-- **[Supported Data Formats](data-formats.md)** — Complete data format support table
+- **[Supported Data Formats](data-formats/index.md)** — Complete data format support table
 - **[Ballerina by Example](by-example.md)** — 200+ runnable examples
 - **[Ballerina Specifications](specifications.md)** — Language, library, and platform specs
 

--- a/en/docs/reference/protocols.md
+++ b/en/docs/reference/protocols.md
@@ -199,4 +199,4 @@ service "emailObserver" on imapListener {
 
 - [Ballerina API Documentation](api/ballerina-api-docs.md) -- Full API docs for all modules
 - [Connectors Catalog](/docs/connectors/catalog) -- Protocol connector guides
-- [Data Formats](data-formats.md) -- Supported data formats
+- [Data Formats](data-formats/index.md) -- Supported data formats

--- a/en/src/css/custom.css
+++ b/en/src/css/custom.css
@@ -33,13 +33,13 @@
    ================================================================ */
 :root {
   /* === Primary — Brand Blue === */
-  --ifm-color-primary: #2B8CF7;
-  --ifm-color-primary-dark: #157EF5;
-  --ifm-color-primary-darker: #0A75F4;
-  --ifm-color-primary-darkest: #0860D4;
-  --ifm-color-primary-light: #4499F8;
-  --ifm-color-primary-lighter: #50A1F9;
-  --ifm-color-primary-lightest: #75B6FA;
+  --ifm-color-primary: #0077B6;
+  --ifm-color-primary-dark: #006AA3;
+  --ifm-color-primary-darker: #00639A;
+  --ifm-color-primary-darkest: #00527F;
+  --ifm-color-primary-light: #0084C9;
+  --ifm-color-primary-lighter: #008BD2;
+  --ifm-color-primary-lightest: #009FED;
 
   /* === Brand Tokens === */
   --wso2-navy: #1B2A49;
@@ -62,7 +62,7 @@
   --wso2-text-muted: #94A3B8;
 
   /* === Code === */
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 119, 182, 0.06);
 
   /* === Typography — Inter === */
   --ifm-font-family-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
@@ -88,37 +88,36 @@
   --ifm-button-border-radius: 10px;
   --ifm-card-border-radius: 12px;
   --ifm-code-border-radius: 8px;
-  --ifm-code-font-size: 95%;
+  --ifm-code-font-size: 93%;
 
-  /* === Navbar & Navigation === */
-  --ifm-navbar-background-color: rgba(240, 247, 255, 0.85); /* Subtle Light Blue Background */
-  --wso2-sidebar-bg: #F0F7FF;
+  /* === Navbar === */
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.85);
   --ifm-navbar-shadow: 0 1px 0 #E2E8F0;
   --ifm-navbar-height: 4rem;
   --ifm-navbar-padding-vertical: 0;
 
   /* === Sidebar === */
   --ifm-menu-color: #475569;
-  --ifm-menu-color-active: #2B8CF7;
+  --ifm-menu-color-active: #0077B6;
   --doc-sidebar-width: 280px;
 
   /* === Link color === */
-  --ifm-link-color: #2B8CF7;
-  --ifm-link-hover-color: #157EF5;
+  --ifm-link-color: #0077B6;
+  --ifm-link-hover-color: #005F8F;
 }
 
 /* ================================================================
    DARK THEME
    ================================================================ */
 [data-theme='dark'] {
-  /* === Primary — Responsive Sky Blue === */
-  --ifm-color-primary: #4499F8;
-  --ifm-color-primary-dark: #2B8CF7;
-  --ifm-color-primary-darker: #2080F2;
-  --ifm-color-primary-darkest: #157EF5;
-  --ifm-color-primary-light: #5DA7F9;
-  --ifm-color-primary-lighter: #69AFFA;
-  --ifm-color-primary-lightest: #8EC4FB;
+  /* === Primary — Bright Sky Blue === */
+  --ifm-color-primary: #38BDF8;
+  --ifm-color-primary-dark: #1AAFE6;
+  --ifm-color-primary-darker: #0FA5DB;
+  --ifm-color-primary-darkest: #0C87B4;
+  --ifm-color-primary-light: #5ECBFA;
+  --ifm-color-primary-lighter: #7AD5FB;
+  --ifm-color-primary-lightest: #A5E3FC;
 
   /* === Accent — warm orange (CTAs, badges) === */
   --wso2-accent: #FB923C;
@@ -139,11 +138,10 @@
   --wso2-text-muted: #64748B;
 
   /* === Code === */
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --docusaurus-highlighted-code-line-bg: rgba(56, 189, 248, 0.1);
 
-  /* === Navbar === */
+  /* === Navbar — transparent to blend with hero === */
   --ifm-navbar-background-color: rgba(11, 17, 32, 0.6);
-  --wso2-sidebar-bg: #151E31;
   --ifm-navbar-shadow: none;
 
   /* === Sidebar === */
@@ -152,8 +150,8 @@
   --ifm-color-emphasis-600: #CBD5E1;
 
   /* === Link color === */
-  --ifm-link-color: #4499F8;
-  --ifm-link-hover-color: #5DA7F9;
+  --ifm-link-color: #38BDF8;
+  --ifm-link-hover-color: #7DD3FC;
 }
 
 /* ================================================================
@@ -193,14 +191,14 @@
 }
 
 .navbar__link--active {
-  color: #2B8CF7;
+  color: #0077B6;
   font-weight: 600;
-  background-color: rgba(43, 140, 247, 0.08);
+  background-color: rgba(0, 119, 182, 0.06);
 }
 
 [data-theme='dark'] .navbar__link--active {
-  color: #4499F8;
-  background-color: rgba(68, 153, 248, 0.1);
+  color: #38BDF8;
+  background-color: rgba(56, 189, 248, 0.08);
 }
 
 /* ================================================================
@@ -222,15 +220,15 @@
 }
 
 .menu__link--active:not(.menu__link--sublist) {
-  background-color: rgba(43, 140, 247, 0.08);
+  background-color: rgba(0, 119, 182, 0.06);
   font-weight: 600;
-  border-left: 3px solid #2B8CF7;
+  border-left: 3px solid #0077B6;
   padding-left: calc(0.75rem - 3px);
 }
 
 [data-theme='dark'] .menu__link--active:not(.menu__link--sublist) {
-  background-color: rgba(68, 153, 248, 0.1);
-  border-left-color: #4499F8;
+  background-color: rgba(56, 189, 248, 0.08);
+  border-left-color: #38BDF8;
 }
 
 .menu__list-item-collapsible:hover {
@@ -253,26 +251,26 @@
 }
 
 .button--primary {
-  background: #2B8CF7;
+  background: #0077B6;
   border-color: transparent;
   color: #FFFFFF;
 }
 
 .button--primary:hover {
-  background: #157EF5;
-  box-shadow: 0 4px 16px rgba(43, 140, 247, 0.25);
+  background: #005F8F;
+  box-shadow: 0 4px 16px rgba(0, 119, 182, 0.25);
   transform: translateY(-1px);
   color: #FFFFFF;
 }
 
 [data-theme='dark'] .button--primary {
-  background: #4499F8;
+  background: #38BDF8;
   color: #0B1120;
 }
 
 [data-theme='dark'] .button--primary:hover {
-  background: #5DA7F9;
-  box-shadow: 0 4px 16px rgba(68, 153, 248, 0.25);
+  background: #7DD3FC;
+  box-shadow: 0 4px 16px rgba(56, 189, 248, 0.25);
   color: #0B1120;
 }
 
@@ -560,12 +558,12 @@ table td, table th {
 }
 
 .table-of-contents__link--active {
-  color: #2B8CF7;
+  color: #0077B6;
   font-weight: 600;
 }
 
 [data-theme='dark'] .table-of-contents__link--active {
-  color: #4499F8;
+  color: #38BDF8;
 }
 
 /* Breadcrumbs */
@@ -589,13 +587,13 @@ table td, table th {
 }
 
 .breadcrumbs__item--active .breadcrumbs__link {
-  background-color: rgba(43, 140, 247, 0.08);
-  color: #2B8CF7;
+  background-color: rgba(0, 119, 182, 0.06);
+  color: #0077B6;
 }
 
 [data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
-  background-color: rgba(68, 153, 248, 0.1);
-  color: #4499F8;
+  background-color: rgba(56, 189, 248, 0.08);
+  color: #38BDF8;
 }
 
 /* Pagination */
@@ -628,11 +626,11 @@ table td, table th {
 }
 
 .pagination-nav__label {
-  color: #2B8CF7;
+  color: #0077B6;
 }
 
 [data-theme='dark'] .pagination-nav__label {
-  color: #4499F8;
+  color: #38BDF8;
 }
 
 /* Search input (navbar) */
@@ -777,19 +775,19 @@ table td, table th {
 }
 
 .tabs__item--active {
-  color: #2B8CF7;
+  color: #0077B6;
   background: #FFFFFF;
   font-weight: 600;
   border-color: #E2E8F0;
-  border-top: 2px solid #2B8CF7;
+  border-top: 2px solid #0077B6;
   border-bottom-color: #FFFFFF;
 }
 
 [data-theme='dark'] .tabs__item--active {
-  color: #4499F8;
+  color: #38BDF8;
   background: #0B1120;
   border-color: #1E293B;
-  border-top: 2px solid #4499F8;
+  border-top: 2px solid #38BDF8;
   border-bottom-color: #0B1120;
 }
 
@@ -822,16 +820,3 @@ hr {
   background: linear-gradient(90deg, #1E293B, transparent 80%);
 }
 
-
-/* ================================================================
-   SIDEBAR BACKGROUND OVERRIDE
-   ================================================================ */
-.theme-doc-sidebar-container {
-  background-color: var(--wso2-sidebar-bg);
-  border-right: 1px solid var(--wso2-surface-border);
-  transition: background-color 0.3s ease, border-color 0.3s ease;
-}
-
-[data-theme='dark'] .theme-doc-sidebar-container {
-  border-right-color: rgba(255, 255, 255, 0.06);
-}

--- a/en/src/pages/index.module.css
+++ b/en/src/pages/index.module.css
@@ -9,58 +9,6 @@
  */
 
 /* ================================================================
-   TWO-COLUMN PAGE LAYOUT (sidebar + content)
-   ================================================================ */
-.pageLayout {
-  display: flex;
-  align-items: flex-start;
-}
-
-.sidebarCol {
-  width: var(--doc-sidebar-width, 300px);
-  flex-shrink: 0;
-  position: sticky;
-  top: var(--ifm-navbar-height);
-  height: calc(100vh - var(--ifm-navbar-height));
-  background-color: var(--wso2-sidebar-bg);
-  border-right: 1px solid var(--wso2-surface-border);
-  z-index: 10;
-  overflow-y: auto;
-}
-
-/* Add a small top padding for a premium, balanced look */
-.sidebarCol > :global(div) {
-  padding-top: 1rem !important;
-}
-
-/* Remove redundant top padding from the internal menu component */
-.sidebarCol :global(.menu) {
-  padding-top: 0;
-}
-
-/* Reset list padding/margin */
-.sidebarCol :global(.menu__list) {
-  padding-top: 0;
-  margin-top: 0;
-}
-
-.sidebarCol :global(.menu__list-item:first-child) {
-  margin-top: 0;
-}
-
-.mainContent {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-}
-
-@media screen and (max-width: 996px) {
-  .sidebarCol {
-    display: none;
-  }
-}
-
-/* ================================================================
    HERO — Light blue in light theme, dark navy in dark theme
    ================================================================ */
 .heroBanner {

--- a/en/src/pages/index.tsx
+++ b/en/src/pages/index.tsx
@@ -5,128 +5,9 @@ import { useHistory } from '@docusaurus/router';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
-import DocSidebar from '@theme/DocSidebar';
-import type { PropSidebarItem } from '@docusaurus/plugin-content-docs';
 
 
 import styles from './index.module.css';
-
-/* ------------------------------------------------------------------ */
-/*  Sidebar items (mirrors mainSidebar from sidebars.ts)               */
-/* ------------------------------------------------------------------ */
-const homeSidebarItems: PropSidebarItem[] = [
-  {
-    type: 'category',
-    label: 'Get Started',
-    collapsed: false,
-    collapsible: true,
-    href: '/docs/get-started/overview-&-architecture',
-    items: [
-      { type: 'link', label: 'Overview & Architecture', href: '/docs/get-started/overview-&-architecture' },
-      { type: 'link', label: 'Why WSO2 Integrator', href: '/docs/get-started/why-wso2-integrator' },
-      { type: 'link', label: 'Key Concepts', href: '/docs/get-started/key-concepts' },
-      {
-        type: 'category',
-        label: 'Set Up',
-        collapsed: true,
-        collapsible: true,
-        items: [
-          { type: 'link', label: 'System Requirements', href: '/docs/get-started/system-requirements' },
-          { type: 'link', label: 'Install', href: '/docs/get-started/install' },
-          { type: 'link', label: 'First Project', href: '/docs/get-started/first-project' },
-          { type: 'link', label: 'Understand the IDE', href: '/docs/get-started/understand-the-ide' },
-        ],
-      },
-      {
-        type: 'category',
-        label: 'Quick Starts',
-        collapsed: false,
-        collapsible: true,
-        items: [
-          { type: 'link', label: 'Quick Start: API', href: '/docs/get-started/quick-start-api' },
-          { type: 'link', label: 'Quick Start: Event', href: '/docs/get-started/quick-start-event' },
-          { type: 'link', label: 'Quick Start: File', href: '/docs/get-started/quick-start-file' },
-          { type: 'link', label: 'Quick Start: Automation', href: '/docs/get-started/quick-start-automation' },
-          { type: 'link', label: 'Quick Start: Data Service', href: '/docs/get-started/quick-start-data-service' },
-          { type: 'link', label: 'Quick Start: AI Agent', href: '/docs/get-started/quick-start-ai-agent' },
-        ],
-      },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Develop',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/develop/overview',
-    items: [
-      { type: 'link', label: 'Create Integrations', href: '/docs/develop/create-integrations/create-new-integration' },
-      { type: 'link', label: 'Project Views', href: '/docs/develop/project-views/project-view' },
-      { type: 'link', label: 'Integration Artifacts', href: '/docs/develop/integration-artifacts/automation' },
-      { type: 'link', label: 'Design Integration Logic', href: '/docs/develop/design-logic/overview' },
-      { type: 'link', label: 'Transform', href: '/docs/develop/transform/data-mapper' },
-      { type: 'link', label: 'Try & Test', href: '/docs/develop/test/try-it' },
-      { type: 'link', label: 'Debugging & Troubleshooting', href: '/docs/develop/debugging/overview' },
-      { type: 'link', label: 'Organize Code', href: '/docs/develop/organize-code/packages-modules' },
-      { type: 'link', label: 'Tools', href: '/docs/develop/tools/overview' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Connectors',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/connectors/overview',
-    items: [
-      { type: 'link', label: 'Connector Catalog', href: '/docs/connectors/catalog/index' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'GenAI',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/genai/overview',
-    items: [
-      { type: 'link', label: 'Getting Started', href: '/docs/genai/getting-started/setup' },
-      { type: 'link', label: 'Key Concepts', href: '/docs/genai/key-concepts/what-is-llm' },
-      { type: 'link', label: 'Develop AI Applications', href: '/docs/genai/overview' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Tutorials',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/tutorials/overview',
-    items: [
-      { type: 'link', label: 'Integration Patterns', href: '/docs/tutorials/integration-patterns' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Deploy & Operate',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/deploy-operate/overview',
-    items: [
-      { type: 'link', label: 'Deploy', href: '/docs/deploy-operate/deploy/docker-kubernetes' },
-      { type: 'link', label: 'Security', href: '/docs/deploy-operate/security/security-checklist' },
-      { type: 'link', label: 'Operate', href: '/docs/deploy-operate/operate/observability-and-monitoring' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Reference',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/reference/overview',
-    items: [
-      { type: 'link', label: 'CLI Commands', href: '/docs/reference/cli-commands' },
-      { type: 'link', label: 'API Reference', href: '/docs/reference/api-reference' },
-    ],
-  },
-];
 
 /* ------------------------------------------------------------------ */
 /*  Clean SVG Icon Components                                          */
@@ -328,7 +209,7 @@ function SearchBar(): ReactNode {
   }, []);
 
   const handleSubmit = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
+    (e: React.FormEvent) => {
       e.preventDefault();
       if (query.trim()) {
         history.push(`/search?q=${encodeURIComponent(query.trim())}`);
@@ -494,23 +375,11 @@ export default function Home(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout title="Home" description={siteConfig.tagline}>
-      <div className={styles.pageLayout}>
-        <aside className={styles.sidebarCol}>
-          <DocSidebar
-            sidebar={homeSidebarItems}
-            path="/none"
-            onCollapse={() => {}}
-            isHidden={false}
-          />
-        </aside>
-        <div className={styles.mainContent}>
-          <HomepageHeader />
-          <main>
-            <SectionCards />
-            <WhatsNew />
-          </main>
-        </div>
-      </div>
+      <HomepageHeader />
+      <main>
+        <SectionCards />
+        <WhatsNew />
+      </main>
     </Layout>
   );
 }


### PR DESCRIPTION
## Why
`npm run build` flagged 8 broken markdown links + 1 broken page link
+ 3 broken anchors. These would normally be caught by stricter
`onBrokenLinks: 'throw'`, but with `'warn'` they slipped in.

## What
Markdown link path fixes (relative paths corrected to existing files):
- `intercom/overview` → connectors overview was off by one `..`
- `twilio/4.0.x/overview` → setup-guide lives at the parent `twilio/`
  dir, not inside the version subdir
- `database/mssql/example` & `database/redis/example` → both now
  point at the real `develop/create-integrations/create-new-integration`
- `event/azure-service-bus` → connector dir is `asb/`, not
  `azure-service-bus/`
- `file/high-availability` → one extra `../` was escaping `/docs/`
- `reference/overview` & `reference/protocols` → `data-formats.md`
  is a directory; pointed to its `index.md`

Anchors:
- `intercom/action-reference` → setup-guide step renumbered from
  `step-6-...` to `step-5-...` (matches actual heading)
- `get-started/key-concepts` → `#services` → `#services-and-listeners`,
  `#event-handlers` → `#event-integrations`

Page link:
- `get-started/key-concepts` → `/docs/develop/organize-code/` had no
  index page; pointed at `/docs/develop/organize-code/overview`

No content rewrites — only the link targets changed.

## Verify
`npm run build` runs clean: no broken-link / broken-anchor warnings.