### PR TITLE
Fix broken links and anchors flagged by docusaurus build

### DIFF
--- a/en/docs/connectors/catalog/communication/intercom/action-reference.md
+++ b/en/docs/connectors/catalog/communication/intercom/action-reference.md
@@ -541,7 +541,7 @@ intercom:Ticket ticket = check intercomClient->/tickets.post({
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `ticketTypeId` | `string` | Yes | ID of the ticket type (see [Setup guide](setup-guide.md#step-6-optional-find-your-ticket-type-id)) |
+| `ticketTypeId` | `string` | Yes | ID of the ticket type (see [Setup guide](setup-guide.md#step-5-optional-find-your-ticket-type-id)) |
 | `contacts` | `CreateTicketRequestContacts[]` | Yes | Contacts associated with the ticket |
 | `companyId` | `string` | No | Company to associate with the ticket |
 

--- a/en/docs/connectors/catalog/communication/intercom/overview.md
+++ b/en/docs/connectors/catalog/communication/intercom/overview.md
@@ -49,4 +49,4 @@ Check the issue tracker for open issues that interest you. We look forward to re
 
 - [Setup guide](setup-guide.md) — Create an Intercom app and obtain your access token
 - [Action reference](action-reference.md) — Browse all available operations and sample code
-- [Connectors overview](../../overview.md) — Explore other available connectors
+- [Connectors overview](../../../overview.md) — Explore other available connectors

--- a/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
+++ b/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
@@ -31,7 +31,7 @@ See the **[Action Reference](action-reference.md)** for the full list of operati
 
 ## Documentation
 
-* **[Setup Guide](setup-guide.md)**: This guide walks you through obtaining the Twilio credentials required to use the Ballerina Twilio connector.
+* **[Setup Guide](../setup-guide.md)**: This guide walks you through obtaining the Twilio credentials required to use the Ballerina Twilio connector.
 
 * **[Action Reference](action-reference.md)**: Full reference for all clients — operations, parameters, return types, and sample code.
 

--- a/en/docs/connectors/catalog/database/mssql/example.md
+++ b/en/docs/connectors/catalog/database/mssql/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the MSSQL integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the MSSQL connector
 

--- a/en/docs/connectors/catalog/database/redis/example.md
+++ b/en/docs/connectors/catalog/database/redis/example.md
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Setting up the Redis integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../getting-started/create-integration.md) guide to set up your project first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your project first, then return here to add the connector.
 
 ## Adding the Redis connector
 

--- a/en/docs/develop/integration-artifacts/event/azure-service-bus.md
+++ b/en/docs/develop/integration-artifacts/event/azure-service-bus.md
@@ -211,4 +211,4 @@ The `onMessage` handler receives an `asb:Message` parameter with the message con
 - [RabbitMQ](rabbitmq.md) — consume messages from RabbitMQ queues
 - [Kafka](kafka.md) — consume messages from Apache Kafka topics
 - [Connections](../supporting/connections.md) — reuse Azure Service Bus connection strings across services
-- [Azure Service Bus connector reference](../../../connectors/catalog/messaging/azure-service-bus/overview.md) — full connector API reference
+- [Azure Service Bus connector reference](../../../connectors/catalog/messaging/asb/overview.md) — full connector API reference

--- a/en/docs/develop/integration-artifacts/file/high-availability.md
+++ b/en/docs/develop/integration-artifacts/file/high-availability.md
@@ -185,4 +185,4 @@ If the coordination database is temporarily unavailable:
 
 - [FTP / SFTP](ftp-sftp.md) — service configuration, authentication, and file handlers
 - [Resiliency](resiliency.md) — automatic retry and circuit breaker for FTP client operations
-- [Scaling and high availability](../../../../deploy-operate/deploy/scaling-ha.md) — deployment-level scaling and HA strategies
+- [Scaling and high availability](../../../deploy-operate/deploy/scaling-ha.md) — deployment-level scaling and HA strategies

--- a/en/docs/get-started/key-concepts.md
+++ b/en/docs/get-started/key-concepts.md
@@ -18,7 +18,7 @@ A workspace that contains your integration code, dependencies, configuration, an
 
 ## Library
 
-A shareable collection of reusable components, functions, and connectors packaged for distribution. Libraries let you build once and use across multiple projects or share with your team. For more information, see [Organize code](/docs/develop/organize-code/).
+A shareable collection of reusable components, functions, and connectors packaged for distribution. Libraries let you build once and use across multiple projects or share with your team. For more information, see [Organize code](/docs/develop/organize-code/overview).
 
 ## Services and listeners
 

--- a/en/docs/reference/overview.md
+++ b/en/docs/reference/overview.md
@@ -59,7 +59,7 @@ Command-line tools reference:
 ## Specifications & Formats
 
 - **[Supported Protocols](protocols.md)** — Complete protocol support table
-- **[Supported Data Formats](data-formats.md)** — Complete data format support table
+- **[Supported Data Formats](data-formats/index.md)** — Complete data format support table
 - **[Ballerina by Example](by-example.md)** — 200+ runnable examples
 - **[Ballerina Specifications](specifications.md)** — Language, library, and platform specs
 

--- a/en/docs/reference/protocols.md
+++ b/en/docs/reference/protocols.md
@@ -199,4 +199,4 @@ service "emailObserver" on imapListener {
 
 - [Ballerina API Documentation](api/ballerina-api-docs.md) -- Full API docs for all modules
 - [Connectors Catalog](/docs/connectors/catalog) -- Protocol connector guides
-- [Data Formats](data-formats.md) -- Supported data formats
+- [Data Formats](data-formats/index.md) -- Supported data formats


### PR DESCRIPTION
## Why
`npm run build` was warning on 9 broken markdown links and 1 broken anchor. Anchor fixes from a recent merge covered two of them; this PR closes the rest so the production build runs clean.

## What
Markdown link path corrections (relative paths now point at existing files):
- `intercom/overview` → connectors overview was off by one `..`
- `twilio/4.0.x/overview` → setup-guide lives at the parent `twilio/` dir, not in the version subdir
- `database/mssql/example` & `database/redis/example` → both now point at the real `develop/create-integrations/create-new-integration`
- `event/azure-service-bus` → connector dir is `asb/`, not `azure-service-bus/`
- `file/high-availability` → one extra `../` was escaping `/docs/`
- `reference/overview` & `reference/protocols` → `data-formats.md` is a directory; pointed to its `index.md`

Anchor:
- `intercom/action-reference` → setup-guide step renumbered from `step-6-…` to `step-5-…`

Page link:
- `get-started/key-concepts` → `/docs/develop/organize-code/` had no index page; pointed at `/docs/develop/organize-code/overview`

No content rewrites — only the link targets/relative paths.

## Verify
`npm run build` runs clean: no broken-link / broken-anchor warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)