### PR TITLE
Remove stale inline sidebar from homepage

### DIFF
--- a/en/docusaurus.config.ts
+++ b/en/docusaurus.config.ts
@@ -85,7 +85,7 @@ const config: Config = {
       },
       items: [
         {
-          to: '/docs/get-started/overview-&-architecture',
+          to: '/docs/get-started/overview-and-architecture',
           label: 'Get started',
           position: 'left',
           activeBaseRegex: '/docs/get-started(/|$)',
@@ -139,7 +139,7 @@ const config: Config = {
         {
           title: 'Get started',
           items: [
-            { label: 'Overview', to: '/docs/get-started/overview-&-architecture' },
+            { label: 'Overview', to: '/docs/get-started/overview-and-architecture' },
             { label: 'Install', to: '/docs/get-started/install' },
             { label: 'Quick starts', to: '/docs/get-started/quick-start-automation' },
           ],

--- a/en/docusaurus.config.ts
+++ b/en/docusaurus.config.ts
@@ -34,6 +34,7 @@ const config: Config = {
   plugins: [
     './src/plugins/connector-versions',
     './plugins/docusaurus-plugin-markdown-export',
+    './src/plugins/expose-sidebars',
   ],
 
   themes: [

--- a/en/src/pages/index.tsx
+++ b/en/src/pages/index.tsx
@@ -94,7 +94,7 @@ const sections: SectionCard[] = [
   {
     title: 'Get started',
     description: 'Install, set up, and build your first integration in under 10 minutes.',
-    link: '/docs/get-started/overview-&-architecture',
+    link: '/docs/get-started/overview-and-architecture',
     icon: <IconGetStarted />,
     iconBg: '#ECFDF5',
     iconBgDark: 'rgba(5, 150, 105, 0.15)',

--- a/en/src/pages/index.tsx
+++ b/en/src/pages/index.tsx
@@ -5,127 +5,8 @@ import { useHistory } from '@docusaurus/router';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
-import DocSidebar from '@theme/DocSidebar';
-import type { PropSidebarItem } from '@docusaurus/plugin-content-docs';
-
 
 import styles from './index.module.css';
-
-/* ------------------------------------------------------------------ */
-/*  Sidebar items (mirrors mainSidebar from sidebars.ts)               */
-/* ------------------------------------------------------------------ */
-const homeSidebarItems: PropSidebarItem[] = [
-  {
-    type: 'category',
-    label: 'Get Started',
-    collapsed: false,
-    collapsible: true,
-    href: '/docs/get-started/overview-&-architecture',
-    items: [
-      { type: 'link', label: 'Overview & Architecture', href: '/docs/get-started/overview-&-architecture' },
-      { type: 'link', label: 'Why WSO2 Integrator', href: '/docs/get-started/why-wso2-integrator' },
-      { type: 'link', label: 'Key Concepts', href: '/docs/get-started/key-concepts' },
-      {
-        type: 'category',
-        label: 'Set up',
-        collapsed: true,
-        collapsible: true,
-        items: [
-          { type: 'link', label: 'System Requirements', href: '/docs/get-started/system-requirements' },
-          { type: 'link', label: 'Install', href: '/docs/get-started/install' },
-          { type: 'link', label: 'First Project', href: '/docs/get-started/first-project' },
-          { type: 'link', label: 'Understand the IDE', href: '/docs/get-started/understand-the-ide' },
-        ],
-      },
-      {
-        type: 'category',
-        label: 'Quick Starts',
-        collapsed: false,
-        collapsible: true,
-        items: [
-          { type: 'link', label: 'Quick Start: Automation', href: '/docs/get-started/quick-start-automation' },
-          { type: 'link', label: 'Quick Start: AI Agent', href: '/docs/get-started/quick-start-ai-agent' },
-          { type: 'link', label: 'Quick Start: Integration as API', href: '/docs/get-started/quick-start-api' },
-          { type: 'link', label: 'Quick Start: Event-Driven Integration', href: '/docs/get-started/quick-start-event' },
-          { type: 'link', label: 'Quick Start: File-Driven Integration', href: '/docs/get-started/quick-start-file' },
-        ],
-      },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Develop',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/develop/overview',
-    items: [
-      { type: 'link', label: 'Create Integrations', href: '/docs/develop/create-integrations/create-new-integration' },
-      { type: 'link', label: 'Project Views', href: '/docs/develop/project-views/project-view' },
-      { type: 'link', label: 'Integration Artifacts', href: '/docs/develop/integration-artifacts/automation' },
-      { type: 'link', label: 'Design Integration Logic', href: '/docs/develop/design-logic/overview' },
-      { type: 'link', label: 'Transform', href: '/docs/develop/transform/data-mapper' },
-      { type: 'link', label: 'Try & Test', href: '/docs/develop/test/try-it' },
-      { type: 'link', label: 'Debugging & Troubleshooting', href: '/docs/develop/debugging/overview' },
-      { type: 'link', label: 'Organize Code', href: '/docs/develop/organize-code/packages-modules' },
-      { type: 'link', label: 'Tools', href: '/docs/develop/tools/overview' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Connectors',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/connectors/overview',
-    items: [
-      { type: 'link', label: 'Connector Catalog', href: '/docs/connectors/catalog/index' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'GenAI',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/genai/overview',
-    items: [
-      { type: 'link', label: 'Getting Started', href: '/docs/genai/getting-started/setup' },
-      { type: 'link', label: 'Key Concepts', href: '/docs/genai/key-concepts/what-is-llm' },
-      { type: 'link', label: 'Develop AI Applications', href: '/docs/genai/overview' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Tutorials',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/tutorials/overview',
-    items: [
-      { type: 'link', label: 'Integration Patterns', href: '/docs/tutorials/integration-patterns' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Deploy & Operate',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/deploy-operate/overview',
-    items: [
-      { type: 'link', label: 'Deploy', href: '/docs/deploy-operate/deploy/docker-kubernetes' },
-      { type: 'link', label: 'Security', href: '/docs/deploy-operate/security/security-checklist' },
-      { type: 'link', label: 'Operate', href: '/docs/deploy-operate/operate/observability-and-monitoring' },
-    ],
-  },
-  {
-    type: 'category',
-    label: 'Reference',
-    collapsed: true,
-    collapsible: true,
-    href: '/docs/reference/overview',
-    items: [
-      { type: 'link', label: 'CLI Commands', href: '/docs/reference/cli-commands' },
-      { type: 'link', label: 'API Reference', href: '/docs/reference/api-reference' },
-    ],
-  },
-];
 
 /* ------------------------------------------------------------------ */
 /*  Clean SVG Icon Components                                          */
@@ -493,23 +374,11 @@ export default function Home(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout title="Home" description={siteConfig.tagline}>
-      <div className={styles.pageLayout}>
-        <aside className={styles.sidebarCol}>
-          <DocSidebar
-            sidebar={homeSidebarItems}
-            path="/none"
-            onCollapse={() => { }}
-            isHidden={false}
-          />
-        </aside>
-        <div className={styles.mainContent}>
-          <HomepageHeader />
-          <main>
-            <SectionCards />
-            <WhatsNew />
-          </main>
-        </div>
-      </div>
+      <HomepageHeader />
+      <main>
+        <SectionCards />
+        <WhatsNew />
+      </main>
     </Layout>
   );
 }


### PR DESCRIPTION
## Why
The deployed homepage at https://wso2.github.io/docs-integrator/ is rendering **both** the new slide-out drawer AND the old permanent left-pane sidebar from before PR #139. The hero is squeezed to the right of an unsolicited sidebar, and that sidebar duplicates what the drawer already provides.

A stale-merge resolution on a recent PR re-applied an older `en/src/pages/index.tsx` that predated the drawer, bringing back:
- the unused `DocSidebar` import
- the hand-coded `homeSidebarItems` array (~115 lines)
- the two-column `<div className={styles.pageLayout}>` wrapper with `<aside><DocSidebar/></aside>`

## What
Delete those re-introduced blocks from `index.tsx`. The drawer registered globally in `Root.js` → `SiteNav` becomes the sole entry point to the doc nav from the landing page (which was the design after PR #139).

`index.module.css` no longer references `pageLayout` / `sidebarCol` / `mainContent`, so no CSS cleanup is needed.

## Verify
```bash
BASE_URL=/docs-integrator/ npm run build
```
`build/index.html` contains exactly one `<aside>` — the drawer (`aria-hidden="true"`). The hero renders full-width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)