### PR TITLE
Enhance PDF processing documentation and update sidebar

### DIFF
--- a/en/docs/connectors/catalog/built-in/pdf/action-reference.md
+++ b/en/docs/connectors/catalog/built-in/pdf/action-reference.md
@@ -34,7 +34,7 @@ Converts an HTML document to PDF bytes. Supports configurable page size, margins
 | `html` | <code>string</code> | Yes | The HTML document to render. Inline CSS and data-URL images are supported. |
 | `options` | <code>*ConversionOptions</code> | No | Included-record options — see the [ConversionOptions](#conversionoptions) record below. |
 
-**Returns:** `byte[]|Error`
+**Returns:** `byte[]|Error` — the rendered PDF as a byte array.
 
 **Sample code:**
 

--- a/en/docs/connectors/catalog/built-in/pdf/action-reference.md
+++ b/en/docs/connectors/catalog/built-in/pdf/action-reference.md
@@ -227,15 +227,26 @@ Options for `parseHtml`, passed as an included record (named arguments).
 
 ### `PageSize`
 
-Union type: `StandardPageSize | CustomPageSize`.
+Describes the paper dimensions used when rendering. Use a `StandardPageSize` value for common paper formats, or a `CustomPageSize` record to set explicit width and height. For landscape orientation with a standard size, switch to a `CustomPageSize` with the height and width swapped.
+
+| Member | Description |
+|--------|-------------|
+| `StandardPageSize` | Enum of common paper formats — `A4`, `LETTER`, `LEGAL`. |
+| `CustomPageSize` | Record with explicit `width` and `height` in points. |
 
 ### `StandardPageSize`
 
-Enum. Members: `A4`, `LETTER`, `LEGAL`.
+Enum of the common paper sizes supported out of the box.
+
+| Member | Description |
+|--------|-------------|
+| `A4` | ISO A4 — 210 × 297 mm. This is the default. |
+| `LETTER` | US Letter — 8.5 × 11 inches. |
+| `LEGAL` | US Legal — 8.5 × 14 inches. |
 
 ### `CustomPageSize`
 
-Custom page dimensions in points. For landscape orientation, swap `width` and `height`.
+Custom page dimensions in points (1 point = 1/72 inch). For landscape orientation, swap `width` and `height`.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/en/docs/develop/integration-artifacts/service/http-service.md
+++ b/en/docs/develop/integration-artifacts/service/http-service.md
@@ -432,4 +432,3 @@ resource function get orders/[string id]() returns Order|http:NotFound {
 - [gRPC Service](grpc-service.md) — define services using Protocol Buffers
 - [Connections](../supporting/connections.md) — configure HTTP client connections to call external services
 - [Data Mapper](../supporting/data-mapper.md) — transform request/response payloads between formats
-- [PDF Generation Service](../../../tutorials/pdf-generation-service.md) — tutorial: HTTP service that renders HTML templates to PDF

--- a/en/docs/develop/transform/pdf.md
+++ b/en/docs/develop/transform/pdf.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
 title: PDF Processing
-description: Render HTML to PDF, extract text, and convert PDF pages to images in Ballerina integrations.
+description: Extract text, convert pages to images, and render HTML to PDF in Ballerina integrations.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,91 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # PDF Processing
 
-Generate PDF documents from HTML, extract text from existing PDFs, and convert PDF pages to images. The `ballerina/pdf` module provides a single-call API for each task — rendering and parsing run locally, with no external service or headless browser required.
-
-## HTML to PDF Rendering
-
-Convert parameterized HTML templates into PDF bytes suitable for download, email attachments, or storage. The rendering engine covers document-style HTML and CSS — tables, inline images, fonts, colored cells, and injected stylesheets — without depending on a headless browser.
-
-### Rendering an HTML String
-
-Read or build an HTML string, then pass it to `pdf:parseHtml` to obtain the PDF bytes.
-
-<Tabs>
-<TabItem value="ui" label="Visual Designer" default>
-
-1. **Add a Variable step for the HTML** — In the flow designer, click **+** and select **Statement** → **Declare Variable**. Set the type to `string` and the name to `html`. Switch the toggle from **Record** to **Expression** and enter the HTML string (use a `string \`...\`` template to interpolate parameters).
-
-2. **Add a Function Call step for rendering** — Click **+** and select **Call Function**. Search for `parseHtml` under **pdf** and configure:
-   - **html***: `html`
-   - **Result***: `pdfBytes`
-   - **Type**: `byte[]`
-
-3. **Add a Function Call step for output** — Click **+** and select **Call Function**. Call `io:fileWriteBytes("./output.pdf", pdfBytes)` to save the PDF to disk, or assign `pdfBytes` to an `http:Response` payload to return it from a service.
-
-</TabItem>
-<TabItem value="code" label="Ballerina Code">
-
-```ballerina
-import ballerina/io;
-import ballerina/pdf;
-
-public function main() returns error? {
-    string html = string `<!DOCTYPE html>
-<html>
-  <body style="font-family: 'Liberation Sans'; padding: 24px;">
-    <h1>Invoice #1042</h1>
-    <p>Amount due: $240.00</p>
-  </body>
-</html>`;
-
-    byte[] pdfBytes = check pdf:parseHtml(html);
-    check io:fileWriteBytes("./invoice.pdf", pdfBytes);
-}
-```
-
-</TabItem>
-</Tabs>
-
-### Customizing Page Size, Margins, and Fonts
-
-`parseHtml` accepts a set of named options — page size, margins, a `maxPages` cap, custom fonts for non-Latin scripts, and extra CSS injected into every render.
-
-<Tabs>
-<TabItem value="ui" label="Visual Designer" default>
-
-1. **Add a Variable step for the font bytes (optional)** — If you need to render non-Latin scripts such as Chinese, Japanese, Korean, Arabic, or Devanagari, click **+** and select **Call Function**. Call `io:fileReadBytes("./resources/NotoSansSC.ttf")` and assign the result to a `byte[] & readonly` variable named `fontBytes`.
-
-2. **Add a Function Call step for rendering with options** — Click **+** and select **Call Function**. Search for `parseHtml` under **pdf** and add the named arguments:
-   - **html***: `html`
-   - **pageSize**: `pdf:LETTER`
-   - **margins**: `{top: 36, bottom: 36, left: 40, right: 40}`
-   - **customFonts**: `[{family: "NotoSansSC", content: fontBytes}]`
-   - **maxPages**: `50`
-   - **Result***: `pdfBytes`
-
-</TabItem>
-<TabItem value="code" label="Ballerina Code">
-
-```ballerina
-import ballerina/io;
-import ballerina/pdf;
-
-final byte[] & readonly fontBytes = check io:fileReadBytes("./resources/NotoSansSC.ttf");
-
-public function renderWithOptions(string html) returns byte[]|error {
-    return pdf:parseHtml(html,
-        pageSize = pdf:LETTER,
-        margins = {top: 36, bottom: 36, left: 40, right: 40},
-        customFonts = [{family: "NotoSansSC", content: fontBytes}],
-        maxPages = 50);
-}
-```
-
-</TabItem>
-</Tabs>
-
-For the complete list of options, the `StandardPageSize` enum, the `CustomPageSize` record, and the `Font` record, see the [ballerina/pdf action reference](../../connectors/catalog/built-in/pdf/action-reference.md#conversionoptions).
+Extract text from existing PDFs, convert PDF pages to images, and generate PDF documents from HTML. The `ballerina/pdf` module provides a single-call API for each task — parsing and rendering run locally, with no external service or headless browser required.
 
 ## Text Extraction
 
@@ -208,7 +124,91 @@ public function main() returns error? {
 </TabItem>
 </Tabs>
 
-## Supported HTML and CSS
+## HTML to PDF Rendering
+
+Convert parameterized HTML templates into PDF bytes suitable for download, email attachments, or storage. The rendering engine covers document-style HTML and CSS — tables, inline images, fonts, colored cells, and injected stylesheets — without depending on a headless browser.
+
+### Rendering an HTML String
+
+Read or build an HTML string, then pass it to `pdf:parseHtml` to obtain the PDF bytes.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Add a Variable step for the HTML** — In the flow designer, click **+** and select **Statement** → **Declare Variable**. Set the type to `string` and the name to `html`. Switch the toggle from **Record** to **Expression** and enter the HTML string (use a `string \`...\`` template to interpolate parameters).
+
+2. **Add a Function Call step for rendering** — Click **+** and select **Call Function**. Search for `parseHtml` under **pdf** and configure:
+   - **html***: `html`
+   - **Result***: `pdfBytes`
+   - **Type**: `byte[]`
+
+3. **Add a Function Call step for output** — Click **+** and select **Call Function**. Call `io:fileWriteBytes("./output.pdf", pdfBytes)` to save the PDF to disk, or assign `pdfBytes` to an `http:Response` payload to return it from a service.
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/io;
+import ballerina/pdf;
+
+public function main() returns error? {
+    string html = string `<!DOCTYPE html>
+<html>
+  <body style="font-family: 'Liberation Sans'; padding: 24px;">
+    <h1>Invoice #1042</h1>
+    <p>Amount due: $240.00</p>
+  </body>
+</html>`;
+
+    byte[] pdfBytes = check pdf:parseHtml(html);
+    check io:fileWriteBytes("./invoice.pdf", pdfBytes);
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Customizing Page Size, Margins, and Fonts
+
+`parseHtml` accepts a set of named options — page size, margins, a `maxPages` cap, custom fonts for non-Latin scripts, and extra CSS injected into every render.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Add a Variable step for the font bytes (optional)** — If you need to render non-Latin scripts such as Chinese, Japanese, Korean, Arabic, or Devanagari, click **+** and select **Call Function**. Call `io:fileReadBytes("./resources/NotoSansSC.ttf")` and assign the result to a `byte[] & readonly` variable named `fontBytes`.
+
+2. **Add a Function Call step for rendering with options** — Click **+** and select **Call Function**. Search for `parseHtml` under **pdf** and add the named arguments:
+   - **html***: `html`
+   - **pageSize**: `pdf:LETTER`
+   - **margins**: `{top: 36, bottom: 36, left: 40, right: 40}`
+   - **customFonts**: `[{family: "NotoSansSC", content: fontBytes}]`
+   - **maxPages**: `50`
+   - **Result***: `pdfBytes`
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/io;
+import ballerina/pdf;
+
+final byte[] & readonly fontBytes = check io:fileReadBytes("./resources/NotoSansSC.ttf");
+
+public function renderWithOptions(string html) returns byte[]|error {
+    return pdf:parseHtml(html,
+        pageSize = pdf:LETTER,
+        margins = {top: 36, bottom: 36, left: 40, right: 40},
+        customFonts = [{family: "NotoSansSC", content: fontBytes}],
+        maxPages = 50);
+}
+```
+
+</TabItem>
+</Tabs>
+
+For the complete list of options, the `StandardPageSize` enum, the `CustomPageSize` record, and the `Font` record, see the [ballerina/pdf action reference](../../connectors/catalog/built-in/pdf/action-reference.md#conversionoptions).
+
+### Supported HTML and CSS
 
 The renderer covers the subset of HTML and CSS needed for document-style templates — headings, paragraphs, tables with `colspan`, solid borders, background colors, percentage widths, inline images, and embedded data URLs all work as expected. Two bundled fonts, `Liberation Sans` and `Liberation Serif`, cover most Western European scripts. For other scripts, load a font via `customFonts`.
 
@@ -280,14 +280,14 @@ For a full step-by-step walkthrough covering templates, custom fonts for non-Lat
 
 ## Best Practices
 
-- **Parameterize templates with string templates** — use Ballerina's `string \`...\`` syntax for interpolation rather than string concatenation; it is safer and more readable.
-- **Escape untrusted input** — any value that ends up in the HTML must be escaped for angle brackets, quotes, and ampersands. Treat query parameters, form inputs, and user-supplied data as untrusted.
+- **Prefer `file*` and `url*` variants when the input location is fixed** — they skip the intermediate `byte[]` and reduce one step of plumbing.
+- **Parameterize HTML templates with string templates** — use Ballerina's `string \`...\`` syntax for interpolation rather than string concatenation; it is safer and more readable.
+- **Escape untrusted input before rendering** — any value that ends up in the HTML must be escaped for angle brackets, quotes, and ampersands. Treat query parameters, form inputs, and user-supplied data as untrusted.
 - **Load custom fonts once at module level** — font files are several megabytes each. Read them into a `readonly` module-level variable at startup so every render reuses the same bytes.
 - **Set `maxPages` on user-driven renders** — cap the number of pages rendered from any template that takes external input to avoid runaway documents and memory pressure.
-- **Prefer `file*` and `url*` variants when the input location is fixed** — they skip the intermediate `byte[]` and reduce one step of plumbing.
 
 ## What's Next
 
-- [PDF Generation Service](../../tutorials/pdf-generation-service.md) — end-to-end tutorial covering templates, custom fonts, and production considerations.
 - [ballerina/pdf action reference](../../connectors/catalog/built-in/pdf/action-reference.md) — full signatures, supporting records, and error types.
+- [PDF Generation Service](../../tutorials/pdf-generation-service.md) — end-to-end tutorial covering HTML templates, custom fonts, and production considerations.
 - [HTTP Service](../integration-artifacts/service/http-service.md) — return PDFs as binary payloads from an HTTP resource.

--- a/en/docs/develop/transform/pdf.md
+++ b/en/docs/develop/transform/pdf.md
@@ -1,0 +1,293 @@
+---
+sidebar_position: 6
+title: PDF Processing
+description: Render HTML to PDF, extract text, and convert PDF pages to images in Ballerina integrations.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# PDF Processing
+
+Generate PDF documents from HTML, extract text from existing PDFs, and convert PDF pages to images. The `ballerina/pdf` module provides a single-call API for each task — rendering and parsing run locally, with no external service or headless browser required.
+
+## HTML to PDF Rendering
+
+Convert parameterized HTML templates into PDF bytes suitable for download, email attachments, or storage. The rendering engine covers document-style HTML and CSS — tables, inline images, fonts, colored cells, and injected stylesheets — without depending on a headless browser.
+
+### Rendering an HTML String
+
+Read or build an HTML string, then pass it to `pdf:parseHtml` to obtain the PDF bytes.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Add a Variable step for the HTML** — In the flow designer, click **+** and select **Statement** → **Declare Variable**. Set the type to `string` and the name to `html`. Switch the toggle from **Record** to **Expression** and enter the HTML string (use a `string \`...\`` template to interpolate parameters).
+
+2. **Add a Function Call step for rendering** — Click **+** and select **Call Function**. Search for `parseHtml` under **pdf** and configure:
+   - **html***: `html`
+   - **Result***: `pdfBytes`
+   - **Type**: `byte[]`
+
+3. **Add a Function Call step for output** — Click **+** and select **Call Function**. Call `io:fileWriteBytes("./output.pdf", pdfBytes)` to save the PDF to disk, or assign `pdfBytes` to an `http:Response` payload to return it from a service.
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/io;
+import ballerina/pdf;
+
+public function main() returns error? {
+    string html = string `<!DOCTYPE html>
+<html>
+  <body style="font-family: 'Liberation Sans'; padding: 24px;">
+    <h1>Invoice #1042</h1>
+    <p>Amount due: $240.00</p>
+  </body>
+</html>`;
+
+    byte[] pdfBytes = check pdf:parseHtml(html);
+    check io:fileWriteBytes("./invoice.pdf", pdfBytes);
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Customizing Page Size, Margins, and Fonts
+
+`parseHtml` accepts a set of named options — page size, margins, a `maxPages` cap, custom fonts for non-Latin scripts, and extra CSS injected into every render.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Add a Variable step for the font bytes (optional)** — If you need to render non-Latin scripts such as Chinese, Japanese, Korean, Arabic, or Devanagari, click **+** and select **Call Function**. Call `io:fileReadBytes("./resources/NotoSansSC.ttf")` and assign the result to a `byte[] & readonly` variable named `fontBytes`.
+
+2. **Add a Function Call step for rendering with options** — Click **+** and select **Call Function**. Search for `parseHtml` under **pdf** and add the named arguments:
+   - **html***: `html`
+   - **pageSize**: `pdf:LETTER`
+   - **margins**: `{top: 36, bottom: 36, left: 40, right: 40}`
+   - **customFonts**: `[{family: "NotoSansSC", content: fontBytes}]`
+   - **maxPages**: `50`
+   - **Result***: `pdfBytes`
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/io;
+import ballerina/pdf;
+
+final byte[] & readonly fontBytes = check io:fileReadBytes("./resources/NotoSansSC.ttf");
+
+public function renderWithOptions(string html) returns byte[]|error {
+    return pdf:parseHtml(html,
+        pageSize = pdf:LETTER,
+        margins = {top: 36, bottom: 36, left: 40, right: 40},
+        customFonts = [{family: "NotoSansSC", content: fontBytes}],
+        maxPages = 50);
+}
+```
+
+</TabItem>
+</Tabs>
+
+For the complete list of options, the `StandardPageSize` enum, the `CustomPageSize` record, and the `Font` record, see the [ballerina/pdf action reference](../../connectors/catalog/built-in/pdf/action-reference.md#conversionoptions).
+
+## Text Extraction
+
+Read the textual content of a PDF one page at a time. The module provides three entry points — choose the one that matches where the PDF originates.
+
+### Extracting from PDF Bytes
+
+Use `pdf:extractText` when the PDF is already in memory — for example, when it arrives as an HTTP request payload or comes from another connector call.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Add a Variable step for the PDF bytes** — In the flow designer, click **+** and select **Variable**. If the PDF arrives in an HTTP request, set the type to `byte[]` and assign the request payload.
+
+2. **Add a Function Call step for extraction** — Click **+** and select **Call Function**. Search for `extractText` under **pdf** and configure:
+   - **pdf***: `pdfBytes`
+   - **Result***: `pages`
+   - **Type**: `string[]`
+
+3. **Add a Foreach step** — Click **+** and select **Foreach** under **Control**. Set the **Collection** to `pages` and the **Variable Name** to `pageText`. Inside the loop, process each page's text — index it, search it, or forward it to a downstream service.
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/io;
+import ballerina/pdf;
+
+public function main() returns error? {
+    byte[] pdfBytes = check io:fileReadBytes("./report.pdf");
+    string[] pages = check pdf:extractText(pdfBytes);
+
+    foreach int i in 0 ..< pages.length() {
+        io:println(string `--- Page ${i + 1} ---`);
+        io:println(pages[i]);
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Extracting from a File or URL
+
+When the PDF lives on disk or behind a URL, skip the intermediate `byte[]` and use `fileExtractText` or `urlExtractText` directly.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Add a Function Call step for file extraction** — Click **+** and select **Call Function**. Search for `fileExtractText` under **pdf** and set the input to a file path string such as `"./report.pdf"`. Assign the `string[]` result to a variable named `pages`.
+
+2. **Add a Function Call step for URL extraction** — For PDFs served over HTTP, search for `urlExtractText` under **pdf** instead. Set the input to the URL string. The module fetches the document and returns the same `string[]` shape.
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/pdf;
+
+public function main() returns error? {
+    // From a local file path
+    string[] pagesFromFile = check pdf:fileExtractText("./report.pdf");
+
+    // From a URL
+    string[] pagesFromUrl = check pdf:urlExtractText("https://example.com/report.pdf");
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Image Conversion
+
+Render each page of a PDF to a Base64-encoded PNG. Useful for page previews, thumbnails, archival snapshots, or feeding pages to an OCR or vision model.
+
+### Converting from a PDF
+
+The three variants mirror text extraction — bytes, file path, or URL. Each returns a `string[]` where every element is a Base64-encoded PNG for one page.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Add a Function Call step for conversion** — Click **+** and select **Call Function**. Depending on your input, choose one of:
+   - `pdf:toImages` — input is `byte[]`
+   - `pdf:fileToImages` — input is a file path `string`
+   - `pdf:urlToImages` — input is a URL `string`
+
+   Assign the `string[]` result to a variable named `pageImages`.
+
+2. **Add a Foreach step** — Click **+** and select **Foreach** under **Control**. Set the **Collection** to `pageImages` and the **Variable Name** to `pageImage`.
+
+3. **Decode and write each image** — Inside the loop, click **+** and select **Call Function**. Call `array:fromBase64(pageImage)` to obtain the raw PNG bytes, then call `io:fileWriteBytes` to save each page as a separate PNG file.
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/io;
+import ballerina/lang.array;
+import ballerina/pdf;
+
+public function main() returns error? {
+    string[] pageImages = check pdf:fileToImages("./report.pdf");
+
+    foreach int i in 0 ..< pageImages.length() {
+        byte[] pngBytes = check array:fromBase64(pageImages[i]);
+        check io:fileWriteBytes(string `./page-${i + 1}.png`, pngBytes);
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Supported HTML and CSS
+
+The renderer covers the subset of HTML and CSS needed for document-style templates — headings, paragraphs, tables with `colspan`, solid borders, background colors, percentage widths, inline images, and embedded data URLs all work as expected. Two bundled fonts, `Liberation Sans` and `Liberation Serif`, cover most Western European scripts. For other scripts, load a font via `customFonts`.
+
+The renderer does not support CSS flex, CSS Grid, `position: fixed`, `@font-face` rules, inline `<svg>`, `rowspan`, or non-solid border styles. Unsupported features are silently dropped rather than raising an error — always preview new templates visually before shipping.
+
+For the full list of supported and unsupported features with recommended workarounds, see the [PDF Generation Service tutorial](../../tutorials/pdf-generation-service.md#limitations-and-supported-subset).
+
+## Integration Example: PDF Generation Service
+
+Build an HTTP service that renders a parameterized template into a PDF and returns it as a binary response. The same pattern fits invoices, certificates, boarding passes, and receipts.
+
+<Tabs>
+<TabItem value="ui" label="Visual Designer" default>
+
+1. **Create the HTTP service** — Add an HTTP service with a named path such as `/invoices` and add a resource `GET /render` that accepts query parameters (`customer`, `amount`, `dueDate`).
+
+2. **Change the resource return type** — Set the return type to `http:Response|error`. The PDF is a binary payload, so you need `http:Response` to attach a `byte[]` body and set `Content-Type: application/pdf`.
+
+3. **Add a Function Call step to build the HTML** — Click **+** and select **Call Function**. Call your template function (for example, `buildInvoiceHtml(customer, amount, dueDate)`) and assign the result to a string variable `html`.
+
+4. **Add a Function Call step for rendering** — Click **+** and select **Call Function**. Call `pdf:parseHtml(html)` and assign the result to `pdfBytes`.
+
+5. **Add a Variable step for the response** — Declare an `http:Response` named `response`, then call `response.setBinaryPayload(pdfBytes)` and `response.setContentType("application/pdf")` in follow-up Function Call steps. Return `response`.
+
+</TabItem>
+<TabItem value="code" label="Ballerina Code">
+
+```ballerina
+import ballerina/http;
+import ballerina/pdf;
+
+configurable int port = 8290;
+
+service /invoices on new http:Listener(port) {
+
+    resource function get render(
+            string customer,
+            decimal amount,
+            string dueDate) returns http:Response|error {
+
+        string html = buildInvoiceHtml(customer, amount, dueDate);
+        byte[] pdfBytes = check pdf:parseHtml(html);
+
+        http:Response response = new;
+        response.setBinaryPayload(pdfBytes);
+        response.setContentType("application/pdf");
+        return response;
+    }
+}
+
+function buildInvoiceHtml(string customer, decimal amount, string dueDate)
+        returns string {
+    return string `<!DOCTYPE html>
+<html>
+  <body style="font-family: 'Liberation Sans'; padding: 24px;">
+    <h1>Invoice</h1>
+    <p>Customer: ${customer}</p>
+    <p>Amount due: $${amount}</p>
+    <p>Due by: ${dueDate}</p>
+  </body>
+</html>`;
+}
+```
+
+</TabItem>
+</Tabs>
+
+For a full step-by-step walkthrough covering templates, custom fonts for non-Latin scripts, and the full list of supported features, follow the [PDF Generation Service tutorial](../../tutorials/pdf-generation-service.md).
+
+## Best Practices
+
+- **Parameterize templates with string templates** — use Ballerina's `string \`...\`` syntax for interpolation rather than string concatenation; it is safer and more readable.
+- **Escape untrusted input** — any value that ends up in the HTML must be escaped for angle brackets, quotes, and ampersands. Treat query parameters, form inputs, and user-supplied data as untrusted.
+- **Load custom fonts once at module level** — font files are several megabytes each. Read them into a `readonly` module-level variable at startup so every render reuses the same bytes.
+- **Set `maxPages` on user-driven renders** — cap the number of pages rendered from any template that takes external input to avoid runaway documents and memory pressure.
+- **Prefer `file*` and `url*` variants when the input location is fixed** — they skip the intermediate `byte[]` and reduce one step of plumbing.
+
+## What's Next
+
+- [PDF Generation Service](../../tutorials/pdf-generation-service.md) — end-to-end tutorial covering templates, custom fonts, and production considerations.
+- [ballerina/pdf action reference](../../connectors/catalog/built-in/pdf/action-reference.md) — full signatures, supporting records, and error types.
+- [HTTP Service](../integration-artifacts/service/http-service.md) — return PDFs as binary payloads from an HTTP resource.

--- a/en/docs/tutorials/pdf-generation-service.md
+++ b/en/docs/tutorials/pdf-generation-service.md
@@ -226,7 +226,7 @@ Update the template's CSS to include the custom font at the front of the cascade
 
 ```ballerina
 // template.bal — only the <style> body line changes
-body { font-family: 'NotoSansCJK', 'Liberation Sans', sans-serif; padding: 20px; color: #111; }
+body { font-family: 'NotoSansSC', 'Liberation Sans', sans-serif; padding: 20px; color: #111; }
 ```
 
 Load the font bytes once at module init and pass them to every call:
@@ -254,7 +254,7 @@ service /boardingpass on new http:Listener(port) {
                 passengerName, flightNumber, seat, gate, boardingTime);
 
         byte[] pdfBytes = check pdf:parseHtml(html, customFonts = [{
-            family: "NotoSansCJK",
+            family: "NotoSansSC",
             content: cjkFontBytes,
             bold: false,
             italic: false
@@ -300,9 +300,9 @@ Pass any of these as named arguments to `pdf:parseHtml`:
 | `pageSize` | `StandardPageSize` or `CustomPageSize` | `A4` | `A4`, `LETTER`, `LEGAL`, or a `{width, height}` record in points. Swap width and height for landscape — there is no separate `orientation` field. |
 | `margins` | `PageMargins` | `{top: 0, right: 0, bottom: 0, left: 0}` | Page margins in points |
 | `fallbackFontSize` | `float` | `12.0` | Font size used when CSS doesn't specify one |
-| `customFonts` | `Font[]` | (none) | Array of `{family, content, bold, italic}` entries for fonts to load |
-| `additionalCss` | `string` | (none) | Extra CSS injected into every render |
-| `maxPages` | `int` | (none) | Cap on the number of pages rendered — rejects documents larger than this |
+| `customFonts` | `Font[]?` | `()` | Array of `{family, content, bold, italic}` entries for fonts to load |
+| `additionalCss` | `string?` | `()` | Extra CSS injected into every render |
+| `maxPages` | `int?` | `()` | Cap on the number of pages rendered — must be greater than 0 if set. Rejects documents larger than this |
 
 ## Production Considerations
 

--- a/en/sidebars.ts
+++ b/en/sidebars.ts
@@ -172,6 +172,7 @@ const sidebars: SidebarsConfig = {
             'develop/transform/xml',
             'develop/transform/csv-flat-file',
             'develop/transform/edi',
+            'develop/transform/pdf',
             'develop/transform/yaml-toml',
             'develop/transform/type-system',
             'develop/transform/query-expressions',


### PR DESCRIPTION
## Purpose
> Following up on [PR: 143](https://github.com/wso2/docs-integrator/pull/143) to enhance the PDF processing documentation and update the sidebar. 

## Goals
Address post-merge review feedback on PR #143, and add the general Develop → Transform PDF Processing page that was explicitly deferred to a follow-up.                                                   
                                                                                                       
 ## Approach                                                                                             
Modeled the new develop/transform/pdf.md on the existing yaml-toml.md page per the reviewer's reference, then wired it into the Transform sidebar after EDI. 

## Test environment
macOS
