### PR TITLE
Add file integration documentation

### DIFF
--- a/en/docs/develop/integration-artifacts/file/csv-fault-tolerance.md
+++ b/en/docs/develop/integration-artifacts/file/csv-fault-tolerance.md
@@ -17,7 +17,7 @@ Real-world CSV files rarely arrive perfectly clean. A single bad row — a stray
 | **Off** (default) | The first malformed row trips data binding | An `error` instead of content | Moves to the **After Error** destination |
 | **On** | The row is dropped before the handler is called | Only valid rows, as usual | Moves to the **After Success** destination |
 
-:::note Fault tolerance needs a typed row schema
+:::note[Fault tolerance needs a typed row schema]
 Fault tolerance only skips rows that fail **typed binding**. If your handler is generated with the default `string[][]` content type, every row is valid as a string array and nothing is ever dropped.
 
 On the **Add File Handler** form, click **+ Define Row Schema** and describe each column as a field on a Ballerina record. This flips the handler parameter to a typed array (for example `Order[]`), and rows that don't match trigger binding errors that fault tolerance can skip. See the [row-schema step in Streaming large files](streaming-large-files.md#enabling-streaming) for a walkthrough.
@@ -28,7 +28,7 @@ Fault tolerance combines cleanly with:
 - **Streaming** — works with [streamed CSV](streaming-large-files.md). A bad row no longer terminates the stream; processing continues through the rest of the file.
 - **Move / Delete post-processing** — because the handler completes successfully, the file follows the **After Success** action as it would for a clean run.
 
-## Enabling it
+## Configuration
 
 Fault tolerance is a **listener-level** setting. Turn it on once per listener and every CSV handler attached to that service inherits the behaviour. It is part of the listener's regular configuration, not tucked under Advanced.
 
@@ -104,7 +104,7 @@ The `_error.log` filename, location, and JSON layout are the built-in defaults f
 
 ## Routing files with dropped rows
 
-:::note Dropped rows don't flip the file to After Error
+:::note[Dropped rows don't flip the file to After Error]
 The listener's **After Success** and **After Error** branches are picked based on whether the handler returned an error. A dropped row is not itself an error — even if every row in the file gets dropped, the handler still receives an empty typed array and the file takes the **After Success** path by default.
 :::
 
@@ -135,9 +135,9 @@ remote function onFileCsv(Order[] orders, ftp:FileInfo fileInfo, ftp:Caller call
         return;
     }
 
-    string prefix = fileInfo.name;
-    int? dot = prefix.indexOf(".");
-    if dot is int { prefix = prefix.substring(0, dot); }
+    string name = fileInfo.name;
+    int? dot = name.lastIndexOf(".");
+    string prefix = dot is int ? name.substring(0, dot) : name;
 
     if check file:test(prefix + "_error.log", file:EXISTS) {
         // Every row was dropped by fault tolerance.

--- a/en/docs/develop/integration-artifacts/file/file-dependency-triggers.md
+++ b/en/docs/develop/integration-artifacts/file/file-dependency-triggers.md
@@ -17,7 +17,7 @@ The `fileNamePattern` field accepts a regex that filters which files trigger the
 <Tabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-On the **Service Configuration** panel, open the **Record Configuration** builder for the **Service Configuration** field, tick **fileNamePattern**, and enter a regex (for example, `.*\.csv`).
+On the **FTP Integration Configuration** panel, open the **Record Configuration** builder for the **Service Configuration** field, tick **fileNamePattern**, and enter a regex (for example, `.*\.csv`).
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">
@@ -51,7 +51,7 @@ The `fileAgeFilter` field prevents processing files that are too new (still bein
 <Tabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-On the **Service Configuration** panel, open the **Record Configuration** builder for the **Service Configuration** field, tick **fileAgeFilter**, and set **minAge** and/or **maxAge** in seconds.
+On the **FTP Integration Configuration** panel, open the **Record Configuration** builder for the **Service Configuration** field, tick **fileAgeFilter**, and set **minAge** and/or **maxAge** in seconds.
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">
@@ -87,7 +87,7 @@ The `fileDependencyConditions` field blocks processing until one or more related
 <Tabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-On the **Service Configuration** panel, open the **Record Configuration** builder for the **Service Configuration** field, tick **fileDependencyConditions**, and add an entry. Set the target pattern to match the data file, and list the required files that must be present before processing triggers.
+On the **FTP Integration Configuration** panel, open the **Record Configuration** builder for the **Service Configuration** field, tick **fileDependencyConditions**, and add an entry. Set the target pattern to match the data file, and list the required files that must be present before processing triggers.
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">

--- a/en/docs/develop/integration-artifacts/file/ftp-sftp.md
+++ b/en/docs/develop/integration-artifacts/file/ftp-sftp.md
@@ -144,7 +144,7 @@ part of the configuration.
    configuration — at minimum a truststore or certificate path so the
    client can verify the server:
 
-   ```
+   ```ballerina
    {
        cert: {path: "/path/to/truststore.jks", password: "changeit"}
    }
@@ -222,18 +222,18 @@ Use this flow for SFTP (FTP over SSH). Default port: `22`. The form collects the
    | **Host** | Hostname or IP address of the remote server (e.g., `sftp.example.com`). |
    | **Port Number** | Port to connect on. Set to `22` for SFTP. |
 
-4. Choose **Certificate Based Authentication** under **authentication method**. This reveals the **Private Key** and **Username** fields.
+4. Choose **Certificate-Based Authentication** under **authentication method**. This reveals the **Private Key** and **Username** fields.
 
 5. Enter the **Private Key** record. Click **Record** on the field and supply:
 
-   ```
+   ```ballerina
    {path: "/path/to/private_key"}
    ```
 
    If the private key is passphrase-protected, include the passphrase
    in the record:
 
-   ```
+   ```ballerina
    {path: "/path/to/private_key", password: "my-passphrase"}
    ```
 
@@ -341,7 +341,7 @@ In the **Service Designer**, click **+ Add File Handler** and pick **onCreate**,
 | Field | Description |
 |---|---|
 | **File Format** | (onCreate only) The format of incoming files. Determines the handler function name and the type of the `content` parameter. Options: **TEXT**, **JSON**, **XML**, **CSV**, **RAW**. See [Content types](#content-types). |
-| **Rows** | (CSV only) Content schema contains a row of CSV Row type. |
+| **Rows** | (CSV only) The content schema is defined per row — each CSV row maps to a record type (Row schema). |
 | **Stream (Large Files)** | (CSV and RAW) Process the file content in chunks instead of loading it all into memory. See [Typed content and streaming](#typed-content-and-streaming). |
 | **+ Define Row Schema** | (CSV only) Map CSV rows to a typed record. See [Typed content and streaming](#typed-content-and-streaming). |
 | **+ Define Content Schema** | (JSON, XML only) Map the document to a typed record. See [Typed content and streaming](#typed-content-and-streaming). |

--- a/en/docs/develop/integration-artifacts/file/high-availability.md
+++ b/en/docs/develop/integration-artifacts/file/high-availability.md
@@ -92,6 +92,22 @@ service on ftpListener {
 </TabItem>
 </Tabs>
 
+:::warning[Each instance needs a unique Member ID]
+The runtime trusts the Member ID you provide — it does **not** check that the value is unique across your cluster. If two pods come up with the same Member ID in the same Coordination Group, **both become active and process every file twice**.
+
+Wire a distinct value into each pod from your deployment template. In Kubernetes, the pod name from the downward API works well:
+
+```yaml
+env:
+  - name: MEMBER_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+```
+
+Read it with `configurable string memberId = ?;` and pass it to the listener.
+:::
+
 ### Database schema
 
 Create the coordination tables in your MySQL or PostgreSQL database **before starting the first instance** — the runtime does not create them for you. Both dialects are supported; use whichever your ops team already runs.
@@ -145,6 +161,10 @@ Coordination depends on the shared database being reachable. If the database goe
 - **Standby nodes** also cannot take over until the database is reachable again. On recovery, a standby promotes itself within one liveness-check interval and begins polling.
 
 Treat the coordination database as critical infrastructure on the data path: plan replicas, backups, and failover to the same standard as your FTP/SFTP source.
+
+:::warning[Monitor the coordination database directly]
+The coordination database sits on the file-processing data path: its availability directly determines whether files are picked up. Add it to your infrastructure monitoring (uptime checks, query latency, connection counts) alongside the FTP/SFTP source itself, so your operators are alerted by the database, not by files piling up at the source.
+:::
 
 ## What's next
 

--- a/en/docs/develop/integration-artifacts/file/high-availability.md
+++ b/en/docs/develop/integration-artifacts/file/high-availability.md
@@ -8,15 +8,15 @@ import TabItem from '@theme/TabItem';
 
 # High Availability and Coordination
 
-When you deploy several copies of the same FTP/SFTP integration — for example, one per pod in a Kubernetes cluster — every copy would normally connect to the same remote directory and pick up every file. That causes duplicate processing, race conditions, and inconsistent downstream state.
+When you deploy several instances of the same FTP/SFTP integration — for example, one per pod in a Kubernetes cluster — every instance would normally connect to the same remote directory and pick up every file. That causes duplicate processing, race conditions, and inconsistent downstream state.
 
-Turning on **Coordination** fixes this. One copy is elected as the active node and polls the server; the others stay as warm standbys and take over automatically if the active one goes down. You only need one extra thing — a shared database the nodes use to elect a leader and exchange heartbeats.
+Turning on **Coordination** fixes this. One instance is elected as the active node and polls the server; the others stay as warm standbys and take over automatically if the active one goes down. You only need one extra thing — a shared database the nodes use to elect a leader and exchange heartbeats.
 
 ## How it works
 
 | Step | What happens |
 |---|---|
-| **1. Leader election** | On startup, every copy in the same `coordinationGroup` registers with the shared database. One copy is elected active. |
+| **1. Leader election** | On startup, every node in the same `coordinationGroup` registers with the shared database. One node is elected active. |
 | **2. Heartbeat** | Every node in the group — active and standby — writes its own heartbeat row at the `heartbeatFrequency` interval. This advertises liveness so any node can be promoted when needed. |
 | **3. Liveness check** | Standby nodes periodically check the active node's heartbeat. If the heartbeat goes stale, the active node is considered dead. |
 | **4. Failover** | A standby is promoted to active and starts polling immediately — no manual intervention. |
@@ -35,16 +35,16 @@ The pattern is **active-passive**: at most one node polls at a time. Per-file lo
 
    | Field | What to enter |
    |---|---|
-   | **Member Id** | A unique name for this copy of the integration. Every pod/instance must have a different value. Typically sourced from a `configurable` so each deployment can set its own. |
-   | **Coordination Group** | A shared name that all copies of the same listener use. Copies with matching group names coordinate; copies with different group names are independent. |
+   | **Member Id** | A unique name for this instance of the integration. Every pod/instance must have a different value. Typically sourced from a `configurable` so each deployment can set its own. |
+   | **Coordination Group** | A shared name that all instances of the same listener use. Instances with matching group names coordinate; instances with different group names are independent. |
    | **Database Config** | Connection details (host, port, user, password, database) for the shared MySQL or PostgreSQL database used to track leader election. |
 
-4. Save the listener. Deploy each copy with a different **Member Id**.
+4. Save the listener. Deploy each instance with a different **Member Id**.
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">
 
-Add a `coordination` record to the `ftp:Listener` configuration. Source `memberId` from a `configurable` so each deployment sets its own value; keep `coordinationGroup` identical across copies you want to coordinate.
+Add a `coordination` record to the `ftp:Listener` configuration. Source `memberId` from a `configurable` so each deployment sets its own value; keep `coordinationGroup` identical across instances you want to coordinate.
 
 ```ballerina
 import ballerina/ftp;
@@ -74,7 +74,7 @@ listener ftp:Listener ftpListener = new ({
 
 service on ftpListener {
     remote function onFileText(string content, ftp:FileInfo fileInfo) returns error? {
-        // Only one copy in the cluster executes this handler per file.
+        // Only one instance in the cluster executes this handler per file.
     }
 }
 ```

--- a/en/docs/develop/integration-artifacts/file/high-availability.md
+++ b/en/docs/develop/integration-artifacts/file/high-availability.md
@@ -94,18 +94,6 @@ service on ftpListener {
 
 :::warning[Each instance needs a unique Member ID]
 The runtime trusts the Member ID you provide — it does **not** check that the value is unique across your cluster. If two pods come up with the same Member ID in the same Coordination Group, **both become active and process every file twice**.
-
-Wire a distinct value into each pod from your deployment template. In Kubernetes, the pod name from the downward API works well:
-
-```yaml
-env:
-  - name: MEMBER_ID
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.name
-```
-
-Read it with `configurable string memberId = ?;` and pass it to the listener.
 :::
 
 ### Database schema

--- a/en/docs/develop/integration-artifacts/file/streaming-large-files.md
+++ b/en/docs/develop/integration-artifacts/file/streaming-large-files.md
@@ -8,11 +8,11 @@ import TabItem from '@theme/TabItem';
 
 # Streaming Large Files
 
-By default, a file handler loads the whole file into memory before it runs. For files in the hundreds of megabytes or larger, that can exhaust the integration's memory budget. Turning on **Stream (Large Files)** when you add a handler changes this: the runtime delivers the content to the handler a row (CSV) or chunk (RAW) at a time, so memory use stays flat no matter how big the file is.
+By default, a file handler loads the whole file into memory before it runs. For files in the hundreds of megabytes or larger, that can exhaust the integration's memory budget. Enabling **Stream (Large Files)** when configuring a handler changes how files are processed, delivering data row by row (CSV) or in chunks (RAW) so memory usage stays constant regardless of file size.
 
 ## When to stream
 
-| Scenario | What to pick |
+| Scenario | Approach |
 |---|---|
 | Files smaller than ~50 MB | Leave **Stream** off. Simpler handler code, and you get the whole file at once. |
 | CSV files larger than ~50 MB | Tick **Stream**. Define a row schema so each row arrives as a typed record. |


### PR DESCRIPTION
## Summary

Adds the developer guide for the file integration artifact (FTP/SFTP and local-file listeners), including:

- New pages under `en/docs/develop/integration-artifacts/file/`:
  - `high-availability.md` — coordination model, configuration, database schema, and operational caveats
  - `csv-fault-tolerance.md`, `streaming-large-files.md`, `file-dependency-triggers.md` — feature-specific guides
- Visual Designer + Ballerina Code tabs, walkthrough screenshots, and SQL schema for both MySQL and PostgreSQL
- Walkthrough updates and sidebar wiring (`local-file-watcher.md`, `streaming-csv-sftp.md`, `sidebars.ts`)
- Two operational warnings on the coordination page (see *Notes on linked issues* below)

## Notes on linked issues

This PR addresses the following coordination-layer gaps via documentation rather than runtime changes:

- wso2/product-integrator#1138 — duplicate `memberId` causing silent split-brain. The runtime trusts the configured Member ID; uniqueness is the deployer's responsibility. The page now warns about this and shows the Kubernetes downward-API pattern for guaranteeing uniqueness per pod.
- wso2/product-integrator#1140 — coordination database outage producing no log output. The active node pauses and standbys don't promote until the database is reachable again. The page now directs operators to monitor the coordination database directly as part of their infrastructure observability.

The Ballerina connector convention is for errors to flow as values (returned from handlers) rather than be emitted as runtime logs, and infrastructure observability lives outside the connector. Both issues fit that boundary cleanly: deployment hygiene and infra monitoring are the appropriate places to surface these conditions, so we're documenting the contract rather than adding state-tracking logging inside the listener.

## Test plan

- [ ] Render the page locally (`yarn start`) and confirm both warning admonitions display under *Enabling coordination* and *Database availability*
- [ ] Verify Visual Designer / Ballerina Code tabs render correctly
- [ ] Verify MySQL / PostgreSQL schema tabs render correctly
- [ ] Click through the *What's next* links