### PR TITLE
Include guidelines for keystore and truststore configs

### DIFF
--- a/en/docs/connectors/catalog/built-in/grpc/trigger-reference.md
+++ b/en/docs/connectors/catalog/built-in/grpc/trigger-reference.md
@@ -61,12 +61,16 @@ import ballerina/grpc;
 listener grpc:Listener grpcListener = new (9090,
     secureSocket = {
         key: {
-            certFile: "./resources/public.crt",
-            keyFile: "./resources/private.key"
+            certFile: "/path/to/server.crt",
+            keyFile: "/path/to/server.key"
         }
     }
 );
 ```
+
+:::tip Generating certificates
+For instructions on generating certificates using `keytool`, see [Keystores and Truststores](../../../../deploy-operate/secure/keystore-truststore.md).
+:::
 
 **Listener with mutual TLS:**
 
@@ -76,12 +80,12 @@ import ballerina/grpc;
 listener grpc:Listener grpcListener = new (9090,
     secureSocket = {
         key: {
-            certFile: "./resources/public.crt",
-            keyFile: "./resources/private.key"
+            certFile: "/path/to/server.crt",
+            keyFile: "/path/to/server.key"
         },
         mutualSsl: {
             verifyClient: grpc:REQUIRE,
-            cert: "./resources/public.crt"
+            cert: "/path/to/ca.crt"
         }
     }
 );

--- a/en/docs/connectors/catalog/built-in/tcp/trigger-reference.md
+++ b/en/docs/connectors/catalog/built-in/tcp/trigger-reference.md
@@ -57,11 +57,15 @@ import ballerina/tcp;
 
 listener tcp:Listener tcpListener = new (3000, secureSocket = {
     key: {
-        certFile: "./certs/server.crt",
-        keyFile: "./certs/server.key"
+        certFile: "/path/to/server.crt",
+        keyFile: "/path/to/server.key"
     }
 });
 ```
+
+:::tip Generating certificates
+For instructions on generating certificates using `keytool`, see [Keystores and Truststores](../../../../deploy-operate/secure/keystore-truststore.md).
+:::
 
 
 ---

--- a/en/docs/connectors/catalog/messaging/kafka/setup-guide.md
+++ b/en/docs/connectors/catalog/messaging/kafka/setup-guide.md
@@ -69,6 +69,6 @@ Managed Kafka services (Confluent Cloud, Amazon MSK, Azure Event Hubs) provide t
 
 For encrypted connections:
 
-1. Generate or obtain SSL certificates for your Kafka cluster (CA certificate, server certificate, and key).
+1. Generate a CA certificate, server certificate, and key — or obtain them from your PKI. See [Keystores and Truststores](../../../../deploy-operate/secure/keystore-truststore.md) for step-by-step instructions using `keytool`.
 2. Configure the broker's `server.properties` with the keystore and truststore paths.
-3. Note the **truststore/certificate file path** and **keystore credentials** for use in the connector configuration.
+3. Note the **truststore/certificate file path** and **keystore credentials** — you will use these when configuring the Ballerina connector.

--- a/en/docs/deploy-operate/deploy-and-operate.md
+++ b/en/docs/deploy-operate/deploy-and-operate.md
@@ -59,10 +59,11 @@ Monitor, trace, and debug in production:
 
 Harden your integrations for production:
 
-- **[Runtime Security](secure/runtime-security.md)** — JVM security, keystores, non-root execution
+- **[Keystores and Truststores](secure/keystore-truststore.md)** — Create and configure keystores, truststores, and TLS certificates
+- **[Runtime Security](secure/runtime-security.md)** — JVM security, non-root execution, network policies
 - **[Authentication](secure/authentication.md)** — OAuth 2.0, JWT, mTLS
 - **[API security and rate limiting](secure/api-security-rate-limiting.md)** — Protect your endpoints
-- **[Secrets and encryption](secure/secrets-encryption.md)** — Keystores, environment variables, vault integration
+- **[Secrets and encryption](secure/secrets-encryption.md)** — Environment variables, vault integration
 - **[Compliance](secure/compliance-considerations.md)** — Compliance considerations
 
 ## Capacity planning

--- a/en/docs/deploy-operate/secure/keystore-truststore.md
+++ b/en/docs/deploy-operate/secure/keystore-truststore.md
@@ -1,10 +1,10 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 title: Keystores and Truststores
 description: Create, configure, and manage keystores and truststores for TLS, mutual TLS, and secure connections in Ballerina integrations.
 ---
 
-# Keystores and truststores
+# Keystores and Truststores
 
 Keystores and truststores are foundational to securing communication in production deployments. This guide explains what each is, how to create them, and how to configure them in WSO2 Integrator.
 

--- a/en/docs/deploy-operate/secure/keystore-truststore.md
+++ b/en/docs/deploy-operate/secure/keystore-truststore.md
@@ -1,0 +1,308 @@
+---
+sidebar_position: 2
+title: Keystores and Truststores
+description: Create, configure, and manage keystores and truststores for TLS, mutual TLS, and secure connections in Ballerina integrations.
+---
+
+# Keystores and truststores
+
+Keystores and truststores are foundational to securing communication in production deployments. This guide explains what each is, how to create them, and how to configure them in WSO2 Integrator.
+
+| Concept | What it stores | Primary use |
+|---------|---------------|-------------|
+| **Keystore** | Private key + the service's own certificate | Proves the identity of your service to clients |
+| **Truststore** | Trusted CA or peer certificates (public certs only) | Decides which remote parties your service trusts |
+
+---
+
+## Prerequisites
+
+The examples below use the **Java `keytool`** utility, which is bundled with every JDK. Verify it is available:
+
+```bash
+keytool -version
+```
+
+For production deployments you will also need access to a **Certificate Authority (CA)** or a **PKCS12 certificate bundle** (`.p12`) already issued by your CA.
+
+---
+
+## Create a keystore
+
+A keystore stores your service's private key and its certificate. Use the following steps to create a new keystore.
+
+### Step 1 — Generate a new key pair and self-signed certificate
+
+Use a self-signed certificate during development and testing only. **Always replace it with a CA-signed certificate in production.**
+
+```bash
+keytool -genkeypair \
+  -alias integration \
+  -keyalg RSA \
+  -keysize 2048 \
+  -sigalg SHA256withRSA \
+  -validity 365 \
+  -keystore keystore.p12 \
+  -storetype PKCS12 \
+  -storepass <keystore-password> \
+  -keypass <keystore-password> \
+  -dname "CN=integration.example.com, OU=Engineering, O=Example Inc, L=Colombo, ST=Western, C=LK"
+```
+
+| Flag | Description |
+|------|-------------|
+| `-alias` | Logical name for this key entry inside the keystore |
+| `-keyalg RSA -keysize 2048` | RSA 2048-bit key (use 4096 for higher security requirements) |
+| `-sigalg SHA256withRSA` | Signature algorithm; SHA256withRSA is the minimum recommended |
+| `-validity 365` | Certificate validity in days |
+| `-storetype PKCS12` | The keystore type |
+| `-storepass` | Password to protect the keystore file |
+| `-dname` | Distinguished name embedded in the certificate |
+
+### Step 2 — Generate a Certificate Signing Request (CSR)
+
+This step is required for production environments. Skip it if you are using a self-signed certificate.
+
+```bash
+keytool -certreq \
+  -alias integration \
+  -keystore keystore.p12 \
+  -storetype PKCS12 \
+  -storepass <keystore-password> \
+  -file integration.csr
+```
+
+Submit `integration.csr` to your CA. The CA returns a signed certificate file (e.g., `integration.crt`) together with any intermediate CA certificates.
+
+### Step 3 — Import the CA-signed certificate into the keystore
+
+Skip this step if you are using a self-signed certificate. Otherwise, import the CA certificate chain (root and any intermediates) so that `keytool` can verify the chain of trust.
+
+```bash
+# Import the root CA certificate
+keytool -importcert \
+  -alias rootCA \
+  -file rootCA.crt \
+  -keystore keystore.p12 \
+  -storetype PKCS12 \
+  -storepass <keystore-password> \
+  -noprompt
+
+# Import an intermediate CA certificate (if present)
+keytool -importcert \
+  -alias intermediateCA \
+  -file intermediateCA.crt \
+  -keystore keystore.p12 \
+  -storetype PKCS12 \
+  -storepass <keystore-password> \
+  -noprompt
+```
+
+Then import the signed service certificate under the same alias used when generating the key pair:
+
+```bash
+keytool -importcert \
+  -alias integration \
+  -file integration.crt \
+  -keystore keystore.p12 \
+  -storetype PKCS12 \
+  -storepass <keystore-password>
+```
+
+### Verify the keystore
+
+```bash
+keytool -list -keystore keystore.p12 -storetype PKCS12 -storepass <keystore-password> -v
+```
+
+The output lists all entries. Confirm the `integration` entry shows type **PrivateKeyEntry** and that the certificate chain is complete.
+
+---
+
+## Create a truststore
+
+A truststore holds the public certificates of CAs (or specific peers) that your service should trust. How you populate it depends on whether you are using CA-signed or self-signed certificates.
+
+### CA-signed certificates
+
+Import the root CA certificate (and any intermediates) from your CA into the truststore. You do not need to import individual service certificates — any certificate signed by a trusted CA is automatically trusted.
+
+```bash
+keytool -importcert \
+  -alias rootCA \
+  -file rootCA.crt \
+  -keystore truststore.p12 \
+  -storetype PKCS12 \
+  -storepass <truststore-password> \
+  -noprompt
+```
+
+Repeat the command for each intermediate CA certificate if your chain includes them. Use a distinct `-alias` for each entry.
+
+### Self-signed certificates
+
+With self-signed certificates, there is no CA, so you must import each peer's certificate individually.
+
+First, export the certificate from the peer's keystore:
+
+```bash
+keytool -exportcert \
+  -alias integration \
+  -keystore keystore.p12 \
+  -storetype PKCS12 \
+  -storepass <keystore-password> \
+  -file integration.crt \
+  -rfc
+```
+
+Then import the exported certificate into your truststore:
+
+```bash
+keytool -importcert \
+  -alias integration \
+  -file integration.crt \
+  -keystore truststore.p12 \
+  -storetype PKCS12 \
+  -storepass <truststore-password> \
+  -noprompt
+```
+
+Repeat this for every peer that uses a self-signed certificate, using a unique `-alias` each time.
+
+### Verify the truststore
+
+```bash
+keytool -list -keystore truststore.p12 -storetype PKCS12 -storepass <truststore-password>
+```
+
+---
+
+## Configure Ballerina services
+
+The examples below show how to use the keystore and truststore files in Ballerina services.
+
+### HTTP client with TLS
+
+One-way TLS authenticates the **server** to the client. The client only needs a truststore containing the CA that signed the server's certificate.
+
+```ballerina
+import ballerina/http;
+
+configurable string truststorePath = ?;
+configurable string truststorePassword = ?;
+
+http:Client secureClient = check new ("https://api.example.com", {
+    secureSocket: {
+        cert: {
+            path: truststorePath,
+            password: truststorePassword
+        }
+    }
+});
+```
+
+### Mutual TLS (mTLS) for HTTP
+
+Mutual TLS requires both sides to authenticate. The server presents its certificate (from its keystore) and validates the client certificate against its truststore, and the client does the same in reverse.
+
+#### HTTP listener — server side
+
+```ballerina
+import ballerina/http;
+
+configurable string keystorePath = ?;
+configurable string keystorePassword = ?;
+configurable string truststorePath = ?;
+configurable string truststorePassword = ?;
+
+listener http:Listener secureListener = new (9443, {
+    secureSocket: {
+        key: {
+            path: keystorePath,
+            password: keystorePassword
+        },
+        mutualSsl: {
+            verifyClient: http:REQUIRE,
+            cert: {
+                path: truststorePath,
+                password: truststorePassword
+            }
+        }
+    }
+});
+```
+
+#### HTTP client — client side
+
+```ballerina
+import ballerina/http;
+
+configurable string keystorePath = ?;
+configurable string keystorePassword = ?;
+configurable string truststorePath = ?;
+configurable string truststorePassword = ?;
+
+http:Client mtlsClient = check new ("https://api.example.com", {
+    secureSocket: {
+        key: {
+            path: keystorePath,
+            password: keystorePassword
+        },
+        cert: {
+            path: truststorePath,
+            password: truststorePassword
+        }
+    }
+});
+```
+
+#### gRPC with mutual TLS
+
+gRPC uses the same `secureSocket` structure. The example below shows a secured gRPC listener with mutual TLS enabled.
+
+```ballerina
+import ballerina/grpc;
+
+configurable string keystorePath = ?;
+configurable string keystorePassword = ?;
+configurable string truststorePath = ?;
+configurable string truststorePassword = ?;
+
+listener grpc:Listener secureGrpcListener = new (9090, {
+    secureSocket: {
+        key: {
+            path: keystorePath,
+            password: keystorePassword
+        },
+        mutualSsl: {
+            verifyClient: grpc:REQUIRE,
+            cert: {
+                path: truststorePath,
+                password: truststorePassword
+            }
+        }
+    }
+});
+```
+
+### Externalizing passwords
+
+All keystore and truststore paths and passwords are declared as `configurable` variables in the examples above. Supply their values through `Config.toml` or environment variables — never hardcode them in source code.
+
+**Config.toml:**
+
+```toml
+keystorePath = "/opt/integration/security/keystore.p12"
+keystorePassword = "<keystore-password>"
+truststorePath = "/opt/integration/security/truststore.p12"
+truststorePassword = "<truststore-password>"
+```
+
+## References
+
+- [Ballerina HTTP Module — SSL/TLS](https://lib.ballerina.io/ballerina/http/latest)
+- [Ballerina gRPC Module — Secured Communication](https://lib.ballerina.io/ballerina/grpc/latest)
+- [Ballerina Crypto Module](https://central.ballerina.io/ballerina/crypto/latest)
+- [Keystores and certificates](runtime-security#keystores-and-certificates)
+- [Secrets and encryption](secrets-encryption.md)
+- [Java keytool documentation](https://docs.oracle.com/en/java/javase/17/docs/specs/man/keytool.html)

--- a/en/docs/deploy-operate/secure/keystore-truststore.md
+++ b/en/docs/deploy-operate/secure/keystore-truststore.md
@@ -303,6 +303,5 @@ truststorePassword = "<truststore-password>"
 - [Ballerina HTTP Module — SSL/TLS](https://lib.ballerina.io/ballerina/http/latest)
 - [Ballerina gRPC Module — Secured Communication](https://lib.ballerina.io/ballerina/grpc/latest)
 - [Ballerina Crypto Module](https://central.ballerina.io/ballerina/crypto/latest)
-- [Keystores and certificates](runtime-security#keystores-and-certificates)
 - [Secrets and encryption](secrets-encryption.md)
 - [Java keytool documentation](https://docs.oracle.com/en/java/javase/17/docs/specs/man/keytool.html)

--- a/en/docs/deploy-operate/secure/runtime-security.md
+++ b/en/docs/deploy-operate/secure/runtime-security.md
@@ -40,7 +40,7 @@ java -version
 # Ensure JDK 17.0.x or later with latest patch
 ```
 
-## Keystores and certificates
+## Keystores and truststores
 
 Creating keystores, truststores is covered in detail in [Keystores and Truststores](keystore-truststore.md). That page covers:
 

--- a/en/docs/deploy-operate/secure/runtime-security.md
+++ b/en/docs/deploy-operate/secure/runtime-security.md
@@ -42,99 +42,11 @@ java -version
 
 ## Keystores and certificates
 
-### Creating a keystore
+Creating keystores, truststores is covered in detail in [Keystores and Truststores](keystore-truststore.md). That page covers:
 
-Generate a keystore for TLS:
-
-```bash
-keytool -genkeypair \
-  -alias integration-server \
-  -keyalg RSA \
-  -keysize 2048 \
-  -validity 365 \
-  -keystore keystore.p12 \
-  -storetype PKCS12 \
-  -storepass changeit \
-  -dname "CN=integration.example.com,O=MyOrg,L=City,ST=State,C=US"
-```
-
-### Configuring TLS in Ballerina
-
-```ballerina
-import ballerina/http;
-
-listener http:Listener secureEP = new (9443, {
-    secureSocket: {
-        key: {
-            path: "/opt/integrations/keystore.p12",
-            password: "changeit"
-        }
-    }
-});
-
-service /api on secureEP {
-    resource function get health() returns string {
-        return "OK";
-    }
-}
-```
-
-### Mutual TLS (mTLS)
-
-Enable client certificate verification:
-
-```ballerina
-listener http:Listener mtlsEP = new (9443, {
-    secureSocket: {
-        key: {
-            path: "/opt/integrations/keystore.p12",
-            password: "changeit"
-        },
-        mutualSsl: {
-            cert: {
-                path: "/opt/integrations/truststore.p12",
-                password: "changeit"
-            },
-            verifyClient: http:REQUIRE
-        }
-    }
-});
-```
-
-### Truststore configuration
-
-Configure trusted CA certificates for outbound connections:
-
-```ballerina
-final http:Client secureClient = check new ("https://api.example.com", {
-    secureSocket: {
-        cert: {
-            path: "/opt/integrations/truststore.p12",
-            password: "changeit"
-        }
-    }
-});
-```
-
-### Certificate rotation
-
-Automate certificate rotation using a script or cert-manager (Kubernetes):
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: integration-cert
-spec:
-  secretName: integration-tls
-  issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
-  commonName: integration.example.com
-  dnsNames:
-    - integration.example.com
-  renewBefore: 720h  # Renew 30 days before expiry
-```
+- Generating keystores and truststores using `keytool`
+- Configuring TLS and mutual TLS for HTTP and gRPC services
+- Keeping certificate paths and passwords out of source code using `Config.toml` and environment variables
 
 ## Non-Root execution
 
@@ -272,6 +184,7 @@ spec:
 
 ## What's next
 
+- [Keystores and Truststores](keystore-truststore.md) -- Create and configure TLS certificates, keystores, and truststores
 - [Secrets & Encryption](secrets-encryption.md) -- Manage secrets and encryption
 - [Authentication](authentication.md) -- Configure authentication for services
 - [API Security](api-security-rate-limiting.md) -- Secure your API endpoints

--- a/en/sidebars.ts
+++ b/en/sidebars.ts
@@ -2043,6 +2043,7 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Secure',
           items: [
+            'deploy-operate/secure/keystore-truststore',
             'deploy-operate/secure/runtime-security',
             'deploy-operate/secure/authentication',
             'deploy-operate/secure/api-security-rate-limiting',


### PR DESCRIPTION
## Purpose
> $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Keystores and Truststores guide with keytool-driven examples and Ballerina TLS/mTLS configuration samples.
  * Updated gRPC and TCP listener docs to use absolute path placeholders for TLS credentials and added keystore/truststore tips.
  * Clarified Kafka SSL/TLS setup with explicit truststore/keystore guidance for the connector.
  * Reorganized security docs: moved keystore content to the new guide and added it to the Secure sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->