### PR TITLE
docs: update connector example links to new sample base path

### DIFF
--- a/en/docs/connectors/catalog/ai-ml/azure.ai.search.index/example.md
+++ b/en/docs/connectors/catalog/ai-ml/azure.ai.search.index/example.md
@@ -101,9 +101,9 @@ Select **Save** to add the node to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/azure.ai.search.index_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/azure.ai.search.index_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/azure.ai.search.index_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/azure.ai.search.index_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/ai-ml/azure.ai.search/example.md
+++ b/en/docs/connectors/catalog/ai-ml/azure.ai.search/example.md
@@ -91,9 +91,9 @@ Select **Save**. The completed automation flow now shows the full **Start → Ge
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/azure.ai.search_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/azure.ai.search_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/azure.ai.search_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/azure.ai.search_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/ai-ml/milvus/example.md
+++ b/en/docs/connectors/catalog/ai-ml/milvus/example.md
@@ -95,6 +95,6 @@ The canvas switches to the Automation flow view, showing a **Start** node connec
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/milvus_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/milvus_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/milvus_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/milvus_connector_sample)

--- a/en/docs/connectors/catalog/ai-ml/mistral/example.md
+++ b/en/docs/connectors/catalog/ai-ml/mistral/example.md
@@ -88,6 +88,6 @@ Select **Save** to apply the configuration. The canvas updates to show the Chat 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/mistral_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mistral_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/mistral_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/mistral_connector_sample)

--- a/en/docs/connectors/catalog/ai-ml/openai.audio/example.md
+++ b/en/docs/connectors/catalog/ai-ml/openai.audio/example.md
@@ -88,9 +88,9 @@ Select **Save**.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/openai.audio_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/openai.audio_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/openai.audio_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/openai.audio_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/ai-ml/openai.finetunes/example.md
+++ b/en/docs/connectors/catalog/ai-ml/openai.finetunes/example.md
@@ -81,9 +81,9 @@ Select **Save** to apply the configuration.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/openai.finetunes_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/openai.finetunes_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/openai.finetunes_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/openai.finetunes_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/ai-ml/openai/example.md
+++ b/en/docs/connectors/catalog/ai-ml/openai/example.md
@@ -101,9 +101,9 @@ Select the `createChatCompletion` operation from the **openaiClient** connection
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/openai_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/openai_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/openai_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/openai_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/built-in/email/example.md
+++ b/en/docs/connectors/catalog/built-in/email/example.md
@@ -95,6 +95,6 @@ Select **Save** to add the step to the automation flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/email_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/email_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/email_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/email_connector_sample)

--- a/en/docs/connectors/catalog/built-in/grpc/example.md
+++ b/en/docs/connectors/catalog/built-in/grpc/example.md
@@ -93,6 +93,6 @@ Select **Save**. The `grpc : executeSimpleRPC` node appears on the canvas betwee
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/grpc_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/grpc_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/grpc_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/grpc_connector_sample)

--- a/en/docs/connectors/catalog/built-in/udp/example.md
+++ b/en/docs/connectors/catalog/built-in/udp/example.md
@@ -78,6 +78,6 @@ Select **Save** to add the step to the automation flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/udp_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/udp_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/udp_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/udp_connector_sample)

--- a/en/docs/connectors/catalog/built-in/websocket/example.md
+++ b/en/docs/connectors/catalog/built-in/websocket/example.md
@@ -88,6 +88,6 @@ In the WSO2 Integrator explorer, select **Add Artifact**, choose **Automation** 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/websocket_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/websocket_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/websocket_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/websocket_connector_sample)

--- a/en/docs/connectors/catalog/built-in/websub/example.md
+++ b/en/docs/connectors/catalog/built-in/websub/example.md
@@ -93,6 +93,6 @@ Select **Save** — the `publishUpdate` node appears on the flow canvas.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/websub_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/websub_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/websub_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/websub_connector_sample)

--- a/en/docs/connectors/catalog/cloud-infrastructure/aws.marketplace.mpe/example.md
+++ b/en/docs/connectors/catalog/cloud-infrastructure/aws.marketplace.mpe/example.md
@@ -95,6 +95,6 @@ Select **Save** to add the `mpe : getEntitlements` step to the flow canvas. The 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.marketplace.mpe_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.marketplace.mpe_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.marketplace.mpe_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.marketplace.mpe_connector_sample)

--- a/en/docs/connectors/catalog/cloud-infrastructure/aws.marketplace.mpm/example.md
+++ b/en/docs/connectors/catalog/cloud-infrastructure/aws.marketplace.mpm/example.md
@@ -95,6 +95,6 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.marketplace.mpm_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.marketplace.mpm_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.marketplace.mpm_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.marketplace.mpm_connector_sample)

--- a/en/docs/connectors/catalog/cloud-infrastructure/elastic.elasticcloud/example.md
+++ b/en/docs/connectors/catalog/cloud-infrastructure/elastic.elasticcloud/example.md
@@ -78,9 +78,9 @@ The **List Deployments** operation form opens. This operation requires no mandat
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/elastic.elasticcloud_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/elastic.elasticcloud_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/elastic.elasticcloud_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/elastic.elasticcloud_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/communication/aws.sns/example.md
+++ b/en/docs/connectors/catalog/communication/aws.sns/example.md
@@ -101,6 +101,6 @@ Select **Save**. The publish node is added to the flow canvas, connected to `sns
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.sns_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.sns_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.sns_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.sns_connector_sample)

--- a/en/docs/connectors/catalog/communication/discord/example.md
+++ b/en/docs/connectors/catalog/communication/discord/example.md
@@ -86,9 +86,9 @@ Select **+ Add Artifact** and select **Automation** under the Automation categor
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/discord_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/discord_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/discord_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/discord_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/communication/googleapis.gmail/example.md
+++ b/en/docs/connectors/catalog/communication/googleapis.gmail/example.md
@@ -102,9 +102,9 @@ The sidebar now shows `main` (Automation) under **Entry Points**, and the flow e
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/googleapis.gmail_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/googleapis.gmail_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/googleapis.gmail_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/googleapis.gmail_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/communication/intercom/example.md
+++ b/en/docs/connectors/catalog/communication/intercom/example.md
@@ -84,9 +84,9 @@ Select **+ Add Artifact** on the canvas, then select **Automation** from the art
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/intercom_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/intercom_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/intercom_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/intercom_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/communication/slack/example.md
+++ b/en/docs/connectors/catalog/communication/slack/example.md
@@ -88,9 +88,9 @@ Select **Save** to add the step to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/slack_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/slack_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/slack_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/slack_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/communication/zoom.meetings/example.md
+++ b/en/docs/connectors/catalog/communication/zoom.meetings/example.md
@@ -102,9 +102,9 @@ Select **Save Connection** to persist the connection. The **meetingsClient** nod
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/zoom_meetings_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/zoom_meetings_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/zoom_meetings_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/zoom_meetings_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/communication/zoom.scheduler/example.md
+++ b/en/docs/connectors/catalog/communication/zoom.scheduler/example.md
@@ -83,9 +83,9 @@ Select **List schedules** from the operations panel. The configuration form open
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/zoom.scheduler_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/zoom.scheduler_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/zoom.scheduler_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/zoom.scheduler_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.automation.actions/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.automation.actions/example.md
@@ -88,9 +88,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.automation.actions_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.automation.actions_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.automation.actions_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.automation.actions_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.associations.schema/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.associations.schema/example.md
@@ -85,9 +85,9 @@ Select **Save**.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.associations.schema_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.associations.schema_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.associations.schema_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.associations.schema_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.associations/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.associations/example.md
@@ -86,9 +86,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.associations_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.associations_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.associations_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.associations_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.carts/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.carts/example.md
@@ -90,9 +90,9 @@ In the left panel of WSO2 Integrator, select **Configurations** (listed at the b
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.carts_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.carts_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.carts_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.carts_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.discounts/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.discounts/example.md
@@ -88,9 +88,9 @@ Select **Save** to create the connection.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.discounts_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.discounts_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.discounts_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.discounts_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.orders/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.orders/example.md
@@ -77,9 +77,9 @@ Select **List** to open the operation configuration form. The operation has no r
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.orders_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.orders_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.orders_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.orders_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.quotes/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.quotes/example.md
@@ -84,9 +84,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.quotes_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.quotes_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.quotes_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.quotes_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.taxes/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.commerce.taxes/example.md
@@ -86,9 +86,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.taxes_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.taxes_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.commerce.taxes_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.commerce.taxes_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagement.meeting/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagement.meeting/example.md
@@ -89,9 +89,9 @@ The flow canvas opens showing a **Start** node, a placeholder step slot, and an 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.engagement.meeting_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagement.meeting_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.engagement.meeting_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagement.meeting_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagement.notes/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagement.notes/example.md
@@ -83,9 +83,9 @@ Select **Save**.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.engagement.notes_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagement.notes_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.engagement.notes_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagement.notes_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.calls/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.calls/example.md
@@ -85,6 +85,6 @@ Use `hubspot.crm.engagements.calls` as the exact connection name. On the low-cod
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.calls_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.calls_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.calls_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.calls_connector_sample)

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.communications/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.communications/example.md
@@ -89,9 +89,9 @@ Select **Save** to add the step to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.communications_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.communications_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.communications_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.communications_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.email/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.email/example.md
@@ -82,9 +82,9 @@ Select **Save** to add the operation to the flow. The completed automation flow 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.email_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.email_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.email_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.email_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.tasks/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.engagements.tasks/example.md
@@ -91,9 +91,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.tasks_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.tasks_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.engagements.tasks_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.engagements.tasks_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.extensions.timelines/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.extensions.timelines/example.md
@@ -85,9 +85,9 @@ Select **Save** to add the operation node to the canvas.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.extensions.timelines_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.extensions.timelines_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.extensions.timelines_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.extensions.timelines_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.extensions.videoconferencing/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.extensions.videoconferencing/example.md
@@ -93,9 +93,9 @@ Select **Save** to apply the configuration.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.extensions.videoconferencing_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.extensions.videoconferencing_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.extensions.videoconferencing_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.extensions.videoconferencing_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.lists/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.lists/example.md
@@ -88,9 +88,9 @@ Select **Save** to add the step to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.lists_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.lists_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.lists_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.lists_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.companies/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.companies/example.md
@@ -87,9 +87,9 @@ Select **Save** to add the operation to the canvas.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.companies_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.companies_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.companies_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.companies_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.contacts/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.contacts/example.md
@@ -91,9 +91,9 @@ The flow canvas now shows: **Start → (empty slot) → Error Handler**.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.contacts_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.contacts_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.contacts_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.contacts_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.deals/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.deals/example.md
@@ -86,9 +86,9 @@ Select **Save Connection** to persist the connection. The `dealsClient` connecti
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.deals_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.deals_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.deals_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.deals_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.feedback/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.feedback/example.md
@@ -83,9 +83,9 @@ Configure the operation with the following value:
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.feedback_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.feedback_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.feedback_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.feedback_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.leads/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.leads/example.md
@@ -91,9 +91,9 @@ Select **Save**.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.leads_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.leads_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.leads_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.leads_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.lineitems/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.lineitems/example.md
@@ -85,9 +85,9 @@ Select **Save** to apply the configuration.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.lineitems_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.lineitems_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.lineitems_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.lineitems_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.products/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.products/example.md
@@ -95,9 +95,9 @@ The `products : get` node appears on the canvas with result variable `result`.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.products_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.products_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.products_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.products_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.schemas/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.schemas/example.md
@@ -92,9 +92,9 @@ Expand the `schemasClient` connection node on the canvas to view available opera
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.schemas_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.schemas_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.schemas_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.schemas_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.tickets/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.obj.tickets/example.md
@@ -84,9 +84,9 @@ Select **Save**. The canvas updates to show the `tickets : post` node with `resu
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.tickets_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.tickets_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.obj.tickets_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.obj.tickets_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.owners/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.owners/example.md
@@ -85,9 +85,9 @@ Select **Save Connection** to persist the connection. The `ownersClient` connect
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.owners_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.owners_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.owners_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.owners_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.pipelines/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.pipelines/example.md
@@ -92,9 +92,9 @@ The `main` entry point appears under **Entry Points** and the flow canvas opens 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.pipelines_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.pipelines_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.pipelines_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.pipelines_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/crm-sales/hubspot.crm.properties/example.md
+++ b/en/docs/connectors/catalog/crm-sales/hubspot.crm.properties/example.md
@@ -84,9 +84,9 @@ Select **Save**.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.crm.properties_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.properties_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.crm.properties_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.crm.properties_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/database/aws.redshift/example.md
+++ b/en/docs/connectors/catalog/database/aws.redshift/example.md
@@ -96,9 +96,9 @@ Select **Save** to add the step to the automation flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.redshift_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.redshift_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.redshift_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.redshift_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/database/aws.redshiftdata/example.md
+++ b/en/docs/connectors/catalog/database/aws.redshiftdata/example.md
@@ -95,9 +95,9 @@ Select **Save**. The canvas updates to show a new **`Redshift data : execute`** 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.redshiftdata_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.redshiftdata_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.redshiftdata_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.redshiftdata_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/database/java.jdbc/example.md
+++ b/en/docs/connectors/catalog/database/java.jdbc/example.md
@@ -96,6 +96,6 @@ The Automation flow opens in the canvas editor with a **Start** node and an **Er
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/java.jdbc_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/java.jdbc_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/java.jdbc_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/java.jdbc_connector_sample)

--- a/en/docs/connectors/catalog/database/mongodb/example.md
+++ b/en/docs/connectors/catalog/database/mongodb/example.md
@@ -98,9 +98,9 @@ Click **Save Connection** to persist the connection. The `mongodbClient` node ap
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/mongodb_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/mongodb_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/database/mysql/example.md
+++ b/en/docs/connectors/catalog/database/mysql/example.md
@@ -93,6 +93,6 @@ Fill in the operation fields, then click **Save** to add the step to the automat
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/mysql_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mysql_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/mysql_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/mysql_connector_sample)

--- a/en/docs/connectors/catalog/database/oracledb/example.md
+++ b/en/docs/connectors/catalog/database/oracledb/example.md
@@ -98,6 +98,6 @@ Click **Save**.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/oracledb_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/oracledb_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/oracledb_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/oracledb_connector_sample)

--- a/en/docs/connectors/catalog/database/redis/example.md
+++ b/en/docs/connectors/catalog/database/redis/example.md
@@ -98,7 +98,7 @@ After saving the `set` operation, the Automation canvas displays the complete in
 
 ## Try it yourself
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/redis-connector-sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/redis-connector-sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/database/snowflake/example.md
+++ b/en/docs/connectors/catalog/database/snowflake/example.md
@@ -89,7 +89,7 @@ Click **Query** to open the Query operation configuration form and fill in the f
 
 ![Completed flow on the canvas showing Start → snowflake:query → Error Handler → End](/img/connectors/catalog/database/snowflake/snowflake_screenshot_06_completed_flow.png)
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/snowflake_connector_demo)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/snowflake_db_connector)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/database/snowflake/example.md
+++ b/en/docs/connectors/catalog/database/snowflake/example.md
@@ -89,7 +89,7 @@ Click **Query** to open the Query operation configuration form and fill in the f
 
 ![Completed flow on the canvas showing Start → snowflake:query → Error Handler → End](/img/connectors/catalog/database/snowflake/snowflake_screenshot_06_completed_flow.png)
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/snowflake_connector_demo)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/snowflake_connector_demo)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/developer-tools/wso2.apim.catalog/example.md
+++ b/en/docs/connectors/catalog/developer-tools/wso2.apim.catalog/example.md
@@ -82,9 +82,9 @@ Expand the **catalogClient** node in the node panel to reveal all available oper
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/wso2.apim.catalog_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/wso2.apim.catalog_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/wso2.apim.catalog_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/wso2.apim.catalog_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/ecommerce/sap.commerce.webservices/example.md
+++ b/en/docs/connectors/catalog/ecommerce/sap.commerce.webservices/example.md
@@ -98,9 +98,9 @@ In the left panel of WSO2 Integrator, select **Configurations** (listed at the b
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.commerce.webservices_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.commerce.webservices_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.commerce.webservices_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.commerce.webservices_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/ecommerce/shopify.admin/example.md
+++ b/en/docs/connectors/catalog/ecommerce/shopify.admin/example.md
@@ -93,6 +93,6 @@ Select **Save Connection** to persist the connection configuration. The shopify.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/shopify.admin_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/shopify.admin_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/shopify.admin_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/shopify.admin_connector_sample)

--- a/en/docs/connectors/catalog/erp-business/guidewire.insnow/example.md
+++ b/en/docs/connectors/catalog/erp-business/guidewire.insnow/example.md
@@ -87,9 +87,9 @@ Select **Save Connection** to persist the configuration. The `insnowClient` conn
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/guidewire.insnow_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/guidewire.insnow_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/guidewire.insnow_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/guidewire.insnow_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/ibm.ctg/example.md
+++ b/en/docs/connectors/catalog/erp-business/ibm.ctg/example.md
@@ -93,6 +93,6 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/ibm.ctg_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/ibm.ctg_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/ibm.ctg_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/ibm.ctg_connector_sample)

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sales_inquiry_srv/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sales_inquiry_srv/example.md
@@ -88,9 +88,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sales_inquiry_srv_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sales_inquiry_srv_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sales_inquiry_srv_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sales_inquiry_srv_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sales_order_simulation_srv/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sales_order_simulation_srv/example.md
@@ -85,9 +85,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sales_order_simulation_srv_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sales_order_simulation_srv_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sales_order_simulation_srv_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sales_order_simulation_srv_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sales_quotation_srv/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sales_quotation_srv/example.md
@@ -92,9 +92,9 @@ Select **Save** to create the connection. The `apiSalesQuotationSrvClient` entry
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sales_quotation_srv_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sales_quotation_srv_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sales_quotation_srv_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sales_quotation_srv_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.api_salesdistrict_srv/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.api_salesdistrict_srv/example.md
@@ -84,9 +84,9 @@ Select **List A Sales Districts** to add it to the flow. The operation requires 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.api_salesdistrict_srv_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_salesdistrict_srv_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.api_salesdistrict_srv_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_salesdistrict_srv_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.api_salesorganization_srv/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.api_salesorganization_srv/example.md
@@ -95,9 +95,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.api_salesorganization_srv_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_salesorganization_srv_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.api_salesorganization_srv_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_salesorganization_srv_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sd_incoterms_srv/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sd_incoterms_srv/example.md
@@ -100,9 +100,9 @@ In the left panel of WSO2 Integrator, select **Configurations** (listed at the b
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sd_incoterms_srv_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sd_incoterms_srv_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sd_incoterms_srv_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sd_incoterms_srv_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sd_sa_soldtopartydetn/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.api_sd_sa_soldtopartydetn/example.md
@@ -85,9 +85,9 @@ Select **Save** to apply the configuration.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sd_sa_soldtopartydetn_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sd_sa_soldtopartydetn_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.api_sd_sa_soldtopartydetn_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.api_sd_sa_soldtopartydetn_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.ce_salesorder_0001/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.ce_salesorder_0001/example.md
@@ -87,6 +87,6 @@ Leave the optional query parameters (filter, orderby, select, skip, top) empty. 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.sales.order.analytics_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.sales.order.analytics_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.sales.order.analytics_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.sales.order.analytics_connector_sample)

--- a/en/docs/connectors/catalog/erp-business/sap.s4hana.salesarea_0001/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap.s4hana.salesarea_0001/example.md
@@ -88,9 +88,9 @@ Select **Save** to apply the configuration.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap.s4hana.salesarea_0001_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.salesarea_0001_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap.s4hana.salesarea_0001_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap.s4hana.salesarea_0001_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/erp-business/sap/example.md
+++ b/en/docs/connectors/catalog/erp-business/sap/example.md
@@ -92,9 +92,9 @@ Select **Save** to add the operation to the automation flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/sap_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/sap_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/sap_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/finance-accounting/paypal.invoices/example.md
+++ b/en/docs/connectors/catalog/finance-accounting/paypal.invoices/example.md
@@ -84,9 +84,9 @@ In the left panel, select **Configurations**. Set a value for each configurable 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/paypal.invoices_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.invoices_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/paypal.invoices_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.invoices_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/finance-accounting/paypal.orders/example.md
+++ b/en/docs/connectors/catalog/finance-accounting/paypal.orders/example.md
@@ -84,9 +84,9 @@ Select **Save** to apply the configuration.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/paypal.orders_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.orders_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/paypal.orders_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.orders_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/finance-accounting/paypal.payments/example.md
+++ b/en/docs/connectors/catalog/finance-accounting/paypal.payments/example.md
@@ -91,9 +91,9 @@ In the left panel, select **Configurations** and set a value for each configurab
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/paypal.payments_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.payments_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/paypal.payments_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.payments_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/finance-accounting/paypal.subscriptions/example.md
+++ b/en/docs/connectors/catalog/finance-accounting/paypal.subscriptions/example.md
@@ -92,9 +92,9 @@ The Automation entry point `main` is created and appears under **Entry Points** 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/paypal.subscriptions_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.subscriptions_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/paypal.subscriptions_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/paypal.subscriptions_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/finance-accounting/stripe/example.md
+++ b/en/docs/connectors/catalog/finance-accounting/stripe/example.md
@@ -88,9 +88,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/stripe_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/stripe_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/stripe_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/stripe_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/hrms/peoplehr/example.md
+++ b/en/docs/connectors/catalog/hrms/peoplehr/example.md
@@ -84,6 +84,6 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/peoplehr_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/peoplehr_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/peoplehr_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/peoplehr_connector_sample)

--- a/en/docs/connectors/catalog/marketing-social/hubspot.marketing.campaigns/example.md
+++ b/en/docs/connectors/catalog/marketing-social/hubspot.marketing.campaigns/example.md
@@ -88,9 +88,9 @@ Select **Save** to add the step to the canvas.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.marketing.campaigns_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.campaigns_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.marketing.campaigns_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.campaigns_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/marketing-social/hubspot.marketing.emails/example.md
+++ b/en/docs/connectors/catalog/marketing-social/hubspot.marketing.emails/example.md
@@ -83,9 +83,9 @@ Select the **+** node in the flow to open the node panel, then expand **emailsCl
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.marketing.emails_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.emails_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.marketing.emails_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.emails_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/marketing-social/hubspot.marketing.events/example.md
+++ b/en/docs/connectors/catalog/marketing-social/hubspot.marketing.events/example.md
@@ -99,9 +99,9 @@ The automation flow is created with a **Start** node and an **Error Handler** no
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.marketing.events_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.events_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.marketing.events_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.events_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/marketing-social/hubspot.marketing.forms/example.md
+++ b/en/docs/connectors/catalog/marketing-social/hubspot.marketing.forms/example.md
@@ -93,9 +93,9 @@ Select **Save** to add the step to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.marketing.forms_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.forms_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.marketing.forms_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.forms_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/marketing-social/hubspot.marketing.subscriptions/example.md
+++ b/en/docs/connectors/catalog/marketing-social/hubspot.marketing.subscriptions/example.md
@@ -92,9 +92,9 @@ You should now see the completed flow with the operation placed between **Start*
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/hubspot.marketing.subscriptions_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.subscriptions_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/hubspot.marketing.subscriptions_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/hubspot.marketing.subscriptions_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/marketing-social/mailchimp.marketing/example.md
+++ b/en/docs/connectors/catalog/marketing-social/mailchimp.marketing/example.md
@@ -99,9 +99,9 @@ Select **Save** to add the operation to the automation flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/mailchimp.marketing_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mailchimp.marketing_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/mailchimp.marketing_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/mailchimp.marketing_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/marketing-social/salesforce.marketingcloud/example.md
+++ b/en/docs/connectors/catalog/marketing-social/salesforce.marketingcloud/example.md
@@ -98,9 +98,9 @@ The `main` automation is created and the flow canvas opens, showing a **Start** 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/salesforce.marketingcloud_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/salesforce.marketingcloud_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/salesforce.marketingcloud_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/salesforce.marketingcloud_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/marketing-social/twitter/example.md
+++ b/en/docs/connectors/catalog/marketing-social/twitter/example.md
@@ -104,9 +104,9 @@ The canvas switches to the Automation flow view showing **Start → (empty place
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/twitter_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/twitter_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/twitter_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/twitter_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/messaging/aws.sqs/example.md
+++ b/en/docs/connectors/catalog/messaging/aws.sqs/example.md
@@ -84,9 +84,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.sqs_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.sqs_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.sqs_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.sqs_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/messaging/confluent.cregistry/example.md
+++ b/en/docs/connectors/catalog/messaging/confluent.cregistry/example.md
@@ -91,6 +91,6 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/confluent.cregistry_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/confluent.cregistry_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/confluent.cregistry_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/confluent.cregistry_connector_sample)

--- a/en/docs/connectors/catalog/messaging/gcloud.pubsub/example.md
+++ b/en/docs/connectors/catalog/messaging/gcloud.pubsub/example.md
@@ -99,6 +99,6 @@ Select **Save** to create the connection. The canvas updates and the **pubsubPub
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/gcloud.pubsub_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/gcloud.pubsub_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/gcloud.pubsub_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/gcloud.pubsub_connector_sample)

--- a/en/docs/connectors/catalog/messaging/java.jms/example.md
+++ b/en/docs/connectors/catalog/messaging/java.jms/example.md
@@ -99,9 +99,9 @@ Select **Save** to add the step to the canvas.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/java.jms_message_producer_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/java.jms_message_producer_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/java.jms_message_producer_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/java.jms_message_producer_connector_sample)
 
 
 ## Jms MessageConsumer Example
@@ -197,6 +197,6 @@ Select **Save**. The canvas shows a new `jms : receive` node with the label `res
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/java.jms_message_consumer_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/java.jms_message_consumer_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/java.jms_message_consumer_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/java.jms_message_consumer_connector_sample)

--- a/en/docs/connectors/catalog/messaging/nats/example.md
+++ b/en/docs/connectors/catalog/messaging/nats/example.md
@@ -92,6 +92,6 @@ Select **Save**. The `nats : publishMessage` node is added to the Automation flo
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/nats_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/nats_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/nats_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/nats_connector_sample)

--- a/en/docs/connectors/catalog/productivity-collaboration/asana/example.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/asana/example.md
@@ -88,9 +88,9 @@ The completed canvas flow shows the Automation entry point → asana : get (Get 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/asana_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/asana_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/asana_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/asana_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/productivity-collaboration/docusign.dsadmin/example.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/docusign.dsadmin/example.md
@@ -92,9 +92,9 @@ Select **Save Connection** to persist the connection. The `dsadminClient` node a
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/docusign.dsadmin_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/docusign.dsadmin_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/docusign.dsadmin_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/docusign.dsadmin_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/productivity-collaboration/googleapis.calendar/example.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/googleapis.calendar/example.md
@@ -92,6 +92,6 @@ Select **Save**. The `calendar : createEvent` node is added to the Automation fl
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/googleapis.calendar_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/googleapis.calendar_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/googleapis.calendar_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/googleapis.calendar_connector_sample)

--- a/en/docs/connectors/catalog/productivity-collaboration/googleapis.sheets/example.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/googleapis.sheets/example.md
@@ -94,6 +94,6 @@ Select **Save** to add the step to the automation flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/googleapis.sheets_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/googleapis.sheets_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/googleapis.sheets_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/googleapis.sheets_connector_sample)

--- a/en/docs/connectors/catalog/productivity-collaboration/jira/example.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/jira/example.md
@@ -102,9 +102,9 @@ Select **Save**. The canvas updates to show the completed automation flow with *
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/jira_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/jira_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/jira_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/jira_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/productivity-collaboration/smartsheet/example.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/smartsheet/example.md
@@ -101,9 +101,9 @@ Select **Save** to add the node to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/smartsheet_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/smartsheet_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/smartsheet_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/smartsheet_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/productivity-collaboration/trello/example.md
+++ b/en/docs/connectors/catalog/productivity-collaboration/trello/example.md
@@ -94,9 +94,9 @@ Select **Save** to add the operation to the canvas flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/trello_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/trello_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/trello_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/trello_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/security-identity/aws.secretmanager/example.md
+++ b/en/docs/connectors/catalog/security-identity/aws.secretmanager/example.md
@@ -96,6 +96,6 @@ The canvas now shows the completed flow: **Start → secretmanager : getSecretVa
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.secretmanager_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.secretmanager_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.secretmanager_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.secretmanager_connector_sample)

--- a/en/docs/connectors/catalog/security-identity/scim/example.md
+++ b/en/docs/connectors/catalog/security-identity/scim/example.md
@@ -93,9 +93,9 @@ Select **Save Connection** to persist the SCIM connection. The connector entry a
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/scim_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/scim_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/scim_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/scim_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/storage-file/alfresco/example.md
+++ b/en/docs/connectors/catalog/storage-file/alfresco/example.md
@@ -89,9 +89,9 @@ Select **Save** to persist the connection configuration. The Alfresco connector 
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/alfresco_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/alfresco_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/alfresco_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/alfresco_connector_sample)
 
 ## More code examples
 

--- a/en/docs/connectors/catalog/storage-file/aws.s3/example.md
+++ b/en/docs/connectors/catalog/storage-file/aws.s3/example.md
@@ -96,6 +96,6 @@ In the left panel of WSO2 Integrator, select **Configurations** (listed at the b
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/aws.s3_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.s3_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/aws.s3_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/aws.s3_connector_sample)

--- a/en/docs/connectors/catalog/storage-file/microsoft.onedrive/example.md
+++ b/en/docs/connectors/catalog/storage-file/microsoft.onedrive/example.md
@@ -82,9 +82,9 @@ Select **Save** to add the operation to the flow.
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/connectors/microsoft_onedrive_connector_sample)
+[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/microsoft_onedrive_connector_sample)
 
-[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/connectors/microsoft_onedrive_connector_sample)
+[View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/microsoft_onedrive_connector_sample)
 
 ## More code examples
 


### PR DESCRIPTION
## Purpose
> Align connector example links with the new integration samples path. Resolves N/A (no linked issues).

## Goals
> Ensure Devant and GitHub links in connector example pages point to the correct sample directories.

## Approach
> Updated Devant and GitHub links in all connector example pages to use the new `integrator-default-profile/connectors` base path, preserving existing sample directory names.

## Documentation
> Updated pages:
> - en/docs/connectors/catalog/**/example.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated connector documentation links to point to the correct sample locations for deploying and viewing source code across AI/ML, built-in, cloud infrastructure, communication, CRM, database, and other connector categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->