### PR TITLE
[Data Mapper] Correct map fields wordings in the description

### DIFF
--- a/en/docs/develop/integration-artifacts/supporting/data-mapper/data-mapper.md
+++ b/en/docs/develop/integration-artifacts/supporting/data-mapper/data-mapper.md
@@ -5,7 +5,7 @@ description: Transform data between record types visually using the WSO2 Integra
 
 # Data mapper
 
-The data mapper transforms data between different record types using a visual canvas. Map fields one-to-one, write inline expressions, iterate over arrays, aggregate values, and reuse common mappings as submappings, all without leaving the integration flow.
+The data mapper transforms data between different record types using a visual canvas. Map fields, write inline expressions, iterate over arrays, aggregate values, and reuse common mappings as submappings, all without leaving the integration flow.
 
 :::info Prerequisites
 - WSO2 Integrator installed ([Install guide](../../../../get-started/install.md))


### PR DESCRIPTION
Removed "one-to-one" because the data mapper supports all mapping combinations, not limited to one-to-one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Data mapper documentation to clarify support for aggregate values during array iteration, inline expressions, and reusable submappings within the integration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->