### PR TITLE
[Migration tool] Document CLI option and fix a few wordings

### DIFF
--- a/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
@@ -123,7 +123,7 @@ When the AI enhancement completes, the status shows **AI Enhancement completed**
 
 You can migrate MuleSoft projects using the Ballerina CLI tool. Follow these steps:
 
-### Prerequisite
+### CLI prerequisite
 - Ensure Ballerina is installed, and the `bal` command is available in your environment.
 
 ### Steps

--- a/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
@@ -12,7 +12,7 @@ import TabAwareToc from '@site/src/components/TabAwareToc';
 
 ## Overview
 
-The MuleSoft migration tool converts MuleSoft Anypoint flows (XML configurations) to Ballerina code. It handles HTTP listeners, request connectors, DataWeave transformations, routers, and error handling patterns.
+The MuleSoft migration tool converts MuleSoft Anypoint flows (XML configurations) to Ballerina code. It handles HTTP listeners, request connectors, DataWeave transformations, routers, error handling patterns and more.
 
 ## Run the MuleSoft migration tool
 
@@ -114,11 +114,9 @@ While the agent is running:
 - Click **Pause** to pause the AI enhancement. Click **Resume** to continue.
 - Click **Done** to exit the wizard, or **Open Project** to open the project without waiting for the agent to finish.
 
-   ![Ehancing with ai-agent](/img/develop/tools/migration-tools/mule-ai-enhancement.png)
+   ![Enhancing with ai-agent](/img/develop/tools/migration-tools/mule-ai-enhancement.png)
 
 When the AI enhancement completes, the status shows **AI Enhancement completed**. Click **Open Project** to open the migrated project or **Done** to exit.
-
-<!-- TODO: Add screenshot: mule-ai-enhancement.png -->
 
 </TabItem>
 <TabItem value="code" label="CLI">

--- a/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
@@ -16,9 +16,12 @@ The MuleSoft migration tool converts MuleSoft Anypoint flows (XML configurations
 ## Run the MuleSoft migration tool
 
 <Tabs>
-<TabItem value="ui" label="Visual Designer" default>
+<TabItem value="ui" label="Wizard" default>
 
 The migration wizard guides you through a 5-step process to convert your MuleSoft project(s) into a WSO2 Integrator project.
+
+### Prerequisite
+- Ensure WSO2 Integrator is installed and available on your system.
 
 ### Step 1: Configure source
 
@@ -116,18 +119,57 @@ When the AI enhancement completes, the status shows **AI Enhancement completed**
 <!-- TODO: Add screenshot: mule-ai-enhancement.png -->
 
 </TabItem>
-<TabItem value="code" label="Ballerina Code">
+<TabItem value="code" label="CLI">
 
-```bash
-# Migrate a MuleSoft project
-bal migrate mule -i /path/to/mule-project/ -o migrated/
+You can migrate MuleSoft projects using the Ballerina CLI tool. Follow these steps:
 
-# Specify the MuleSoft version
-bal migrate mule -i /path/to/mule-project/ --version 4 -o migrated/
+### Prerequisite
+- Ensure Ballerina is installed, and the `bal` command is available in your environment.
 
-# Generate report only
-bal migrate mule -i /path/to/mule-project/ --report-only
-```
+### Steps
+1. **Install the migration tool:**
+   Install the migration tool by running:
+   ```bash
+   bal tool pull migrate-mule
+   ```
+2. **Run the migration command:**
+   Use the following command syntax to migrate your projects:
+   ```bash
+   bal migrate-mule <source-project-directory-or-file> [-o|--out <output-directory>] [-f|--force-version <3|4>] [-k|--keep-structure] [-v|--verbose] [-d|--dry-run] [-m|--multi-root]
+   ```
+
+#### Key parameters
+- `<source-project-directory-or-file>`: Path to the MuleSoft project directory or a standalone Mule XML file.
+- `-o, --out <output-directory>`: (Optional) Output directory for the generated Ballerina package.
+- `-f, --force-version <3|4>`: (Optional) Force Mule version if auto-detection fails.
+- `-k, --keep-structure`: (Optional) Preserve original Mule project structure.
+- `-v, --verbose`: (Optional) Enable verbose output.
+- `-d, --dry-run`: (Optional) Analyze and generate a migration report without creating Ballerina code.
+- `-m, --multi-root`: (Optional) Treat each child directory as a separate Mule project and convert all.
+
+### Examples
+
+Here are some example commands you can use:
+
+- Migrate a MuleSoft project to a specific output directory:
+  ```bash
+  bal migrate-mule /path/to/mule-project -o /path/to/output-dir
+  ```
+
+- Migrate all MuleSoft projects in a directory (multi-root mode):
+  ```bash
+  bal migrate-mule /path/to/projects-directory -o /path/to/output-dir -m
+  ```
+
+- Analyze all MuleSoft projects without generating code (dry-run):
+  ```bash
+  bal migrate-mule /path/to/projects-directory -o /path/to/output-dir -m -d
+  ```
+
+For more CLI options and usage, see the [official migration tool documentation](https://central.ballerina.io/wso2/tool_migrate_mule/latest).
+
+---
+**Note:** The migration AI enhancement feature is currently only available in the wizard (UI) workflow. It is not available when using the CLI tool.
 
 </TabItem>
 </Tabs>

--- a/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
@@ -6,6 +6,7 @@ description: Migrate MuleSoft integrations to WSO2 Integrator with automated cod
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import TabAwareToc from '@site/src/components/TabAwareToc';
 
 # Migrate from MuleSoft
 
@@ -15,6 +16,7 @@ The MuleSoft migration tool converts MuleSoft Anypoint flows (XML configurations
 
 ## Run the MuleSoft migration tool
 
+<TabAwareToc />
 <Tabs>
 <TabItem value="ui" label="Wizard" default>
 

--- a/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
@@ -6,6 +6,7 @@ description: Migrate TIBCO BusinessWorks integrations to WSO2 Integrator with au
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import TabAwareToc from '@site/src/components/TabAwareToc';
 
 # Migrate from TIBCO BusinessWorks
 
@@ -15,6 +16,7 @@ The TIBCO migration tool converts TIBCO BusinessWorks process definitions to Bal
 
 ## Run the TIBCO migration tool
 
+<TabAwareToc />
 <Tabs>
 <TabItem value="ui" label="Wizard" default>
 

--- a/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
@@ -16,9 +16,12 @@ The TIBCO migration tool converts TIBCO BusinessWorks process definitions to Bal
 ## Run the TIBCO migration tool
 
 <Tabs>
-<TabItem value="ui" label="Visual Designer" default>
+<TabItem value="ui" label="Wizard" default>
 
 The migration wizard guides you through a 5-step process to convert your TIBCO BusinessWorks project(s) into a WSO2 Integrator project.
+
+### Prerequisite
+- Ensure WSO2 Integrator is installed and available on your system.
 
 ### Step 1: Configure source
 
@@ -109,23 +112,63 @@ While the agent is running:
 
    ![Ehancing with ai-agent](/img/develop/tools/migration-tools/tibco-ai-enhancement.png)
 
-When the AI enhancement completes, the status shows **AI Enhancement completed**. Click **Open Workspace** to open the migrated workspace or **Done** to exit.
+When the AI enhancement completes, the status shows **AI Enhancement completed**. Click **Open Project** to open the migrated project or **Done** to exit.
 
 <!-- TODO: Add screenshot: tibco-ai-enhancement.png -->
 
 </TabItem>
-<TabItem value="code" label="Ballerina Code">
+<TabItem value="code" label="CLI">
 
-```bash
-# Migrate a TIBCO BusinessWorks project
-bal migrate tibco -i /path/to/tibco-project/ -o migrated/
+You can migrate TIBCO BusinessWorks projects using the Ballerina CLI tool. Follow these steps:
 
-# Specify the TIBCO BusinessWorks version
-bal migrate tibco -i /path/to/tibco-project/ --version 6 -o migrated/
+### Prerequisite
+- Ensure Ballerina is installed, and the `bal` command is available in your environment.
 
-# Generate report only
-bal migrate tibco -i /path/to/tibco-project/ --report-only
-```
+### Steps
+1. **Install the migration tool:**
+    Install the migration tool by running:
+    ```bash
+    bal tool pull migrate-tibco
+    ```
+2. **Run the migration command:**
+    Use the following command syntax to migrate your projects:
+    ```bash
+    bal migrate-tibco <source-project-directory-or-file> [-o|--out <output-directory>] [-k|--keep-structure] [-v|--verbose] [-d|--dry-run] [-m|--multi-root] [-g|--org-name <organization-name>] [-p|--project-name <project-name>]
+    ```
+
+#### Key parameters
+- `<source-project-directory-or-file>`: Path to the TIBCO BusinessWorks project directory or a standalone process file.
+- `-o, --out <output-directory>`: (Optional) Output directory for the generated Ballerina package.
+- `-k, --keep-structure`: (Optional) Preserve original process structure.
+- `-v, --verbose`: (Optional) Enable verbose output.
+- `-d, --dry-run`: (Optional) Analyze and generate a migration report without creating Ballerina code.
+- `-m, --multi-root`: (Optional) Treat each child directory as a separate TIBCO project and convert all.
+- `-g, --org-name <organization-name>`: (Optional) Organization name for the generated Ballerina package.
+- `-p, --project-name <project-name>`: (Optional) Project name for the generated Ballerina package.
+
+### Examples
+
+Here are some example commands you can use:
+
+- Migrate a TIBCO BusinessWorks project to a specific output directory:
+    ```bash
+    bal migrate-tibco /path/to/tibco-project -o /path/to/output-dir
+    ```
+
+- Migrate all TIBCO BusinessWorks projects in a directory (multi-root mode):
+    ```bash
+    bal migrate-tibco /path/to/projects-directory -o /path/to/output-dir -m
+    ```
+
+- Analyze all TIBCO BusinessWorks projects without generating code (dry-run):
+    ```bash
+    bal migrate-tibco /path/to/projects-directory -o /path/to/output-dir -m -d
+    ```
+
+For more CLI options and usage, see the [official migration tool documentation](https://central.ballerina.io/wso2/tool_migrate_tibco/latest).
+
+---
+**Note:** The migration AI enhancement feature is currently only available in the wizard (UI) workflow. It is not available when using the CLI tool.
 
 </TabItem>
 </Tabs>

--- a/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
@@ -12,7 +12,7 @@ import TabAwareToc from '@site/src/components/TabAwareToc';
 
 ## Overview
 
-The TIBCO migration tool converts TIBCO BusinessWorks process definitions to Ballerina code. It handles process flows, activities, transitions, shared resources, and error handling configurations.
+The TIBCO migration tool converts TIBCO BusinessWorks process definitions to Ballerina code. It handles process flows, activities, transitions, shared resources, error handling configurations and more.
 
 ## Run the TIBCO migration tool
 
@@ -56,7 +56,6 @@ When the dry run completes, the wizard displays a summary of the migration cover
 Click **View Full Report** to open the full HTML report. The report includes:
 
 - **Migration Coverage Overview** — Overall coverage percentage with a breakdown of total, migratable, and non-migratable code lines.
-- **Breakdown Components** — Separate coverage for Mule Elements and DataWeave expressions.
 - **Manual Work Estimation** — Estimated effort (best, average, and worst case) for completing non-migratable items.
 - **Currently Unsupported Elements** — List of elements that could not be automatically migrated.
 - **Element Blocks that Require Manual Conversion** — Specific code blocks that need manual implementation.
@@ -112,11 +111,9 @@ While the agent is running:
 - Click **Pause** to pause the AI enhancement. Click **Resume** to continue.
 - Click **Done** to exit the wizard, or **Open Workspace** to open the workspace without waiting for the agent to finish.
 
-   ![Ehancing with ai-agent](/img/develop/tools/migration-tools/tibco-ai-enhancement.png)
+   ![Enhancing with ai-agent](/img/develop/tools/migration-tools/tibco-ai-enhancement.png)
 
 When the AI enhancement completes, the status shows **AI Enhancement completed**. Click **Open Project** to open the migrated project or **Done** to exit.
-
-<!-- TODO: Add screenshot: tibco-ai-enhancement.png -->
 
 </TabItem>
 <TabItem value="code" label="CLI">

--- a/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
@@ -86,7 +86,7 @@ After the migration completes successfully, the **AI Enhancement (Recommended)**
 - **Enhance with AI** — AI automatically resolves unmapped elements, fixes build errors, and improves migration quality.
 - **Skip for Now – Enhance Later** — Keep the project as-is. You can trigger AI enhancement later from the WSO2 Integrator Copilot.
 
-Click **Start AI Enhancement** to proceed to Step 5, or if you chose to skip, click **Open Workspace** to open the migrated workspace or **Done** to exit.
+Click **Start AI Enhancement** to proceed to Step 5, or if you chose to skip, click **Open Project** to open the migrated project or **Done** to exit.
 
    ![Rule-based migration step](/img/develop/tools/migration-tools/rule-based-migration.png)
 
@@ -109,7 +109,7 @@ After signing in, the AI agent runs automatically and streams its progress. The 
 While the agent is running:
 
 - Click **Pause** to pause the AI enhancement. Click **Resume** to continue.
-- Click **Done** to exit the wizard, or **Open Workspace** to open the workspace without waiting for the agent to finish.
+- Click **Done** to exit the wizard, or **Open Project** to open the project without waiting for the agent to finish.
 
    ![Enhancing with ai-agent](/img/develop/tools/migration-tools/tibco-ai-enhancement.png)
 
@@ -120,7 +120,7 @@ When the AI enhancement completes, the status shows **AI Enhancement completed**
 
 You can migrate TIBCO BusinessWorks projects using the Ballerina CLI tool. Follow these steps:
 
-### Prerequisite
+### CLI prerequisite
 - Ensure Ballerina is installed, and the `bal` command is available in your environment.
 
 ### Steps

--- a/en/src/components/TabAwareToc/index.tsx
+++ b/en/src/components/TabAwareToc/index.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+
+/**
+ * Hides TOC entries for headings that live inside inactive tab panels,
+ * and restores them when their tab becomes active.
+ *
+ * Drop <TabAwareToc /> anywhere in an MDX page that uses <Tabs>.
+ */
+export default function TabAwareToc(): null {
+    useEffect(() => {
+        function updateToc() {
+            const tabPanels = document.querySelectorAll<HTMLElement>('[role="tabpanel"]');
+
+            tabPanels.forEach((panel) => {
+                const isHidden = panel.hidden;
+                const headings = panel.querySelectorAll<HTMLElement>('h1, h2, h3, h4, h5, h6');
+
+                headings.forEach((heading) => {
+                    const id = heading.id;
+                    if (!id) return;
+
+                    const tocLink = document.querySelector<HTMLAnchorElement>(
+                        `.table-of-contents a[href="#${id}"]`
+                    );
+                    if (!tocLink) return;
+
+                    const tocItem = tocLink.closest<HTMLElement>('li');
+                    if (tocItem) {
+                        tocItem.style.display = isHidden ? 'none' : '';
+                    }
+                });
+            });
+        }
+
+        updateToc();
+
+        const handleTabClick = () => setTimeout(updateToc, 50);
+
+        const tabLists = document.querySelectorAll('[role="tablist"]');
+        tabLists.forEach((tabList) => tabList.addEventListener('click', handleTabClick));
+
+        return () => {
+            tabLists.forEach((tabList) => tabList.removeEventListener('click', handleTabClick));
+        };
+    }, []);
+
+    return null;
+}

--- a/en/src/components/TabAwareToc/index.tsx
+++ b/en/src/components/TabAwareToc/index.tsx
@@ -34,13 +34,19 @@ export default function TabAwareToc(): null {
 
         updateToc();
 
-        const handleTabClick = () => setTimeout(updateToc, 50);
+        const scheduleUpdate = () => setTimeout(updateToc, 50);
 
         const tabLists = document.querySelectorAll('[role="tablist"]');
-        tabLists.forEach((tabList) => tabList.addEventListener('click', handleTabClick));
+        tabLists.forEach((tabList) => {
+            tabList.addEventListener('click', scheduleUpdate);
+            tabList.addEventListener('keydown', scheduleUpdate);
+        });
 
         return () => {
-            tabLists.forEach((tabList) => tabList.removeEventListener('click', handleTabClick));
+            tabLists.forEach((tabList) => {
+                tabList.removeEventListener('click', scheduleUpdate);
+                tabList.removeEventListener('keydown', scheduleUpdate);
+            });
         };
     }, []);
 


### PR DESCRIPTION
## Purpose
$subject.

## Preview
<img width="899" height="910" alt="Screenshot 2026-05-06 at 00 46 15" src="https://github.com/user-attachments/assets/1f55137f-4125-4734-a94d-6d1ad58a14c9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked MuleSoft and TIBCO migration guides into tabbed pages with separate Wizard (UI) and CLI workflows, updated step-by-step flows, images, messaging, and "Open Project" wording; clarified that AI enhancement is available only in the Wizard.
* **New Features**
  * Added a TOC that dynamically shows headings for the active tab; introduced a CLI tab with install/usage examples.
* **Bug Fixes**
  * Fixed a screenshot caption typo and updated related copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->