### PR TITLE
Add ICP API reference docs sourced from server implementation

### DIFF
--- a/en/docs/reference/api/auth-api.md
+++ b/en/docs/reference/api/auth-api.md
@@ -234,7 +234,7 @@ Lists all users with their group memberships. Requires `user_mgt:manage_users` o
 ```json
 {
   "users": [
-    { "userId": "usr-001", "username": "admin", "displayName": "Administrator", "groups": [...] }
+    { "userId": "usr-001", "username": "admin", "displayName": "Administrator", "groups": [] }
   ],
   "count": 1
 }
@@ -299,7 +299,7 @@ Returns the effective permissions for a user at a given scope. Users may fetch t
 {
   "userId": "usr-001",
   "scope": { "orgUuid": "org-uuid-001", "projectUuid": "proj-abc" },
-  "permissions": [...],
+  "permissions": [],
   "permissionNames": ["integration_mgt:view", "integration_mgt:manage"]
 }
 ```
@@ -457,10 +457,10 @@ Returns all available system permissions grouped by domain. Accessible to any au
     { "permissionId": "perm-001", "permissionName": "integration_mgt:view", "permissionDomain": "integration_mgt" }
   ],
   "groupedByDomain": {
-    "integration_mgt": [...],
-    "environment_mgt": [...],
-    "project_mgt": [...],
-    "user_mgt": [...]
+    "integration_mgt": [],
+    "environment_mgt": [],
+    "project_mgt": [],
+    "user_mgt": []
   }
 }
 ```

--- a/en/docs/reference/api/auth-api.md
+++ b/en/docs/reference/api/auth-api.md
@@ -133,9 +133,9 @@ Returns the OIDC authorization URL to redirect the user to for SSO login.
 
 ## Using the Token
 
-Include the access token returned by `/auth/login` or `/auth/refresh-token` in all GraphQL and Auth API requests:
+Include the access token returned by `/auth/login` or `/auth/refresh-token` in all protected GraphQL and Auth API requests (unauthenticated endpoints such as `/auth/login`, `/auth/refresh-token`, and OIDC bootstrap calls do not require this header):
 
-```
+```bash
 Authorization: Bearer <jwt-access-token>
 ```
 

--- a/en/docs/reference/api/auth-api.md
+++ b/en/docs/reference/api/auth-api.md
@@ -7,7 +7,7 @@ description: REST API for authentication, token management, and RBAC (users, gro
 
 The ICP server exposes a REST authentication service at:
 
-```
+```bash
 https://<icp-host>:9446/auth
 ```
 
@@ -298,11 +298,13 @@ Returns the effective permissions for a user at a given scope. Users may fetch t
 ```json
 {
   "userId": "usr-001",
-  "scope": { "orgUuid": 1, "projectUuid": "proj-abc" },
+  "scope": { "orgUuid": "org-uuid-001", "projectUuid": "proj-abc" },
   "permissions": [...],
   "permissionNames": ["integration_mgt:view", "integration_mgt:manage"]
 }
 ```
+
+`orgUuid` is a string UUID.
 
 ### `PUT /auth/orgs/{orgHandle}/users/{userId}/groups`
 
@@ -378,7 +380,7 @@ Assigns one or more roles to a group at a specified scope. Requires appropriate 
 ```json
 {
   "roleIds": ["role-001"],
-  "orgUuid": 1,
+  "orgUuid": "org-uuid-001",
   "projectUuid": "proj-abc",
   "envUuid": "env-001",
   "integrationUuid": "comp-xyz"

--- a/en/docs/reference/api/auth-api.md
+++ b/en/docs/reference/api/auth-api.md
@@ -1,0 +1,464 @@
+---
+title: Authentication API
+description: REST API for authentication, token management, and RBAC (users, groups, roles) in the Integration Control Plane.
+---
+
+# Authentication API
+
+The ICP server exposes a REST authentication service at:
+
+```
+https://<icp-host>:9446/auth
+```
+
+Use these endpoints to obtain a JWT access token before calling the [Management API](management.md).
+
+---
+
+## Obtain a Token
+
+### `POST /auth/login`
+
+Authenticates a user with username and password. Returns a short-lived JWT access token and a long-lived refresh token.
+
+**Request body:**
+
+```json
+{
+  "username": "admin",
+  "password": "admin"
+}
+```
+
+**Response `200 OK`:**
+
+```json
+{
+  "userId": "usr-001",
+  "token": "<jwt-access-token>",
+  "expiresIn": 3600,
+  "refreshToken": "<refresh-token>",
+  "refreshTokenExpiresIn": 86400,
+  "username": "admin",
+  "displayName": "Administrator",
+  "permissions": ["integration_mgt:view", "integration_mgt:manage"],
+  "isOidcUser": false,
+  "requirePasswordChange": false
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `token` | JWT access token — include as `Authorization: Bearer <token>` on all API calls |
+| `expiresIn` | Access token lifetime in seconds (default: `3600`) |
+| `refreshToken` | Opaque token used to obtain a new access token without re-logging in |
+| `refreshTokenExpiresIn` | Refresh token lifetime in seconds (default: `86400`) |
+| `requirePasswordChange` | If `true`, the user must call `/auth/force-change-password` before doing other operations |
+
+**Error responses:**
+
+| Status | Meaning |
+|--------|---------|
+| `401` | Invalid credentials |
+| `429` | Account locked out — check `Retry-After` header for seconds remaining |
+| `500` | Authentication backend unavailable |
+
+---
+
+### `POST /auth/refresh-token`
+
+Exchanges a refresh token for a new access token. Does **not** require an `Authorization` header.
+
+**Request body:**
+
+```json
+{
+  "refreshToken": "<refresh-token>"
+}
+```
+
+**Response `200 OK`:**
+
+```json
+{
+  "token": "<new-jwt-access-token>",
+  "expiresIn": 3600,
+  "refreshToken": "<new-or-same-refresh-token>",
+  "refreshTokenExpiresIn": 86400,
+  "username": "admin",
+  "displayName": "Administrator",
+  "permissions": ["integration_mgt:view", "integration_mgt:manage"]
+}
+```
+
+When refresh token rotation is enabled (default), the old refresh token is revoked and a new one is returned.
+
+---
+
+### `POST /auth/login/oidc`
+
+Exchanges an OIDC authorization code for an ICP access token. SSO must be configured and enabled.
+
+**Request body:**
+
+```json
+{
+  "code": "<oidc-authorization-code>"
+}
+```
+
+**Response `200 OK`:** Same structure as `/auth/login`, with `"isOidcUser": true`. The `requirePasswordChange` field is omitted for OIDC users.
+
+---
+
+### `GET /auth/oidc/authorize-url`
+
+Returns the OIDC authorization URL to redirect the user to for SSO login.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `state` | string | Optional CSRF state value to include in the redirect |
+
+**Response `200 OK`:**
+
+```json
+{
+  "authorizationUrl": "https://sso.example.com/authorize?client_id=...&state=..."
+}
+```
+
+---
+
+## Using the Token
+
+Include the access token returned by `/auth/login` or `/auth/refresh-token` in all GraphQL and Auth API requests:
+
+```
+Authorization: Bearer <jwt-access-token>
+```
+
+The token is signed with HMAC-SHA256 and validated against:
+
+- **Issuer**: `icp-frontend-jwt-issuer`
+- **Audience**: `icp-server`
+
+---
+
+## Token & Password Management
+
+All endpoints below require a valid `Authorization: Bearer <token>` header.
+
+### `GET /auth/capabilities`
+
+Returns the user management operations supported by the active user store (local vs LDAP).
+
+**Response `200 OK`:**
+
+```json
+{
+  "capabilities": ["authenticate", "password_change", "password_reset", "unlock_account", "create"]
+}
+```
+
+LDAP-backed deployments return only `["authenticate"]`.
+
+---
+
+### `POST /auth/change-password`
+
+Changes the authenticated user's password.
+
+**Request body:**
+
+```json
+{
+  "currentPassword": "old-password",
+  "newPassword": "new-password"
+}
+```
+
+**Response `200 OK`:** `{ "message": "Password changed successfully" }`
+
+---
+
+### `POST /auth/force-change-password`
+
+Sets a new password without supplying the current password. Only available when `requirePasswordChange` is `true` on the user account (set after an admin password reset).
+
+**Request body:**
+
+```json
+{
+  "newPassword": "new-password"
+}
+```
+
+**Response `200 OK`:** `{ "message": "Password changed successfully" }`
+
+---
+
+### `POST /auth/revoke-token`
+
+Revokes a specific refresh token (targeted logout) or all refresh tokens for the current user (logout from all devices).
+
+**Request body (revoke a specific token):**
+
+```json
+{
+  "refreshToken": "<refresh-token-to-revoke>"
+}
+```
+
+**Request body (revoke all — omit `refreshToken`):**
+
+```json
+{}
+```
+
+**Response `200 OK`:** `{ "message": "Refresh token revoked successfully" }` or `{ "message": "All refresh tokens revoked successfully. You have been logged out from all devices." }`
+
+---
+
+## User Management
+
+All endpoints require `Authorization: Bearer <token>`. Path parameter `{orgHandle}` is the organization's URL-safe identifier.
+
+### `GET /auth/orgs/{orgHandle}/users`
+
+Lists all users with their group memberships. Requires `user_mgt:manage_users` or `user_mgt:update_users` permission.
+
+**Response `200 OK`:**
+
+```json
+{
+  "users": [
+    { "userId": "usr-001", "username": "admin", "displayName": "Administrator", "groups": [...] }
+  ],
+  "count": 1
+}
+```
+
+### `GET /auth/orgs/{orgHandle}/users/{userId}`
+
+Returns details for the specified user. Users may only fetch their own details.
+
+### `POST /auth/orgs/{orgHandle}/users`
+
+Creates a new user. Requires `user_mgt:manage_users` permission.
+
+**Request body:**
+
+```json
+{
+  "username": "jdoe",
+  "password": "initial-password",
+  "displayName": "Jane Doe",
+  "groupIds": ["grp-001"]
+}
+```
+
+Username must match `^[a-zA-Z0-9_.]+$`.
+
+**Response `201 Created`:** Created user object.
+
+### `DELETE /auth/orgs/{orgHandle}/users/{userId}`
+
+Deletes a user. Cannot delete the system administrator or your own account. Requires `user_mgt:manage_users`.
+
+**Response `204 No Content`.**
+
+### `POST /auth/orgs/{orgHandle}/users/{userId}/reset-password`
+
+Admin-initiated password reset. Generates a new temporary password, sets `requirePasswordChange = true`, and revokes all existing sessions. Requires `user_mgt:manage_users`.
+
+**Response `200 OK`:** Returns the generated temporary password — shown once.
+
+### `POST /auth/orgs/{orgHandle}/users/{userId}/revoke-tokens`
+
+Revokes all active sessions for a user (admin action). Cannot be used on your own account. Requires `user_mgt:manage_users`.
+
+**Response `200 OK`:** `{ "message": "All sessions revoked successfully" }`
+
+### `POST /auth/orgs/{orgHandle}/users/{userId}/unlock-account`
+
+Unlocks an account locked by failed login attempts. Requires `user_mgt:manage_users`.
+
+**Response `200 OK`:** `{ "message": "Account unlocked successfully" }`
+
+### `GET /auth/orgs/{orgHandle}/users/{userId}/permissions`
+
+Returns the effective permissions for a user at a given scope. Users may fetch their own; admins may fetch any user.
+
+**Query parameters:** `projectId`, `integrationId`, `environmentId` (all optional, narrow the scope).
+
+**Response `200 OK`:**
+
+```json
+{
+  "userId": "usr-001",
+  "scope": { "orgUuid": 1, "projectUuid": "proj-abc" },
+  "permissions": [...],
+  "permissionNames": ["integration_mgt:view", "integration_mgt:manage"]
+}
+```
+
+### `PUT /auth/orgs/{orgHandle}/users/{userId}/groups`
+
+Replaces the user's group memberships with the provided list (adds missing, removes extra). Requires `user_mgt:manage_groups`, `user_mgt:update_users`, or `user_mgt:manage_users`.
+
+**Request body:**
+
+```json
+{ "groupIds": ["grp-001", "grp-002"] }
+```
+
+---
+
+## Group Management
+
+### `GET /auth/orgs/{orgHandle}/groups`
+
+Lists all groups with member and role counts.
+
+**Query parameters:** `projectId`, `integrationId` (optional scope filters).
+
+### `POST /auth/orgs/{orgHandle}/groups`
+
+Creates a new group. Requires `user_mgt:manage_groups`.
+
+**Request body:**
+
+```json
+{
+  "groupName": "Dev Team",
+  "description": "Development team members"
+}
+```
+
+**Response `201 Created`:** Created group object. Returns `409 Conflict` if the name already exists.
+
+### `GET /auth/orgs/{orgHandle}/groups/{groupId}`
+
+Returns details for a specific group.
+
+### `PUT /auth/orgs/{orgHandle}/groups/{groupId}`
+
+Updates a group's name or description. Requires `user_mgt:manage_groups`.
+
+### `DELETE /auth/orgs/{orgHandle}/groups/{groupId}`
+
+Deletes a group. Fails with `409 Conflict` if the group has role mappings; fails with `403 Forbidden` for the built-in Super Admins group. Requires `user_mgt:manage_groups`.
+
+### `POST /auth/orgs/{orgHandle}/groups/{groupId}/users`
+
+Adds users to a group. Requires `user_mgt:manage_groups`, `user_mgt:update_users`, or `user_mgt:manage_users`.
+
+**Request body:**
+
+```json
+{ "userIds": ["usr-001", "usr-002"] }
+```
+
+### `GET /auth/orgs/{orgHandle}/groups/{groupId}/users`
+
+Returns the list of users in a group.
+
+### `DELETE /auth/orgs/{orgHandle}/groups/{groupId}/users/{userId}`
+
+Removes a single user from a group.
+
+### `POST /auth/orgs/{orgHandle}/groups/{groupId}/roles`
+
+Assigns one or more roles to a group at a specified scope. Requires appropriate permissions at the target scope level.
+
+**Request body:**
+
+```json
+{
+  "roleIds": ["role-001"],
+  "orgUuid": 1,
+  "projectUuid": "proj-abc",
+  "envUuid": "env-001",
+  "integrationUuid": "comp-xyz"
+}
+```
+
+Omit `projectUuid`, `envUuid`, and `integrationUuid` for org-level assignments.
+
+### `GET /auth/orgs/{orgHandle}/groups/{groupId}/roles`
+
+Lists all role assignments for a group, enriched with role names and scope details.
+
+**Query parameters:** `projectId`, `integrationId` (optional scope filters).
+
+### `DELETE /auth/orgs/{orgHandle}/groups/{groupId}/roles/{mappingId}`
+
+Removes a role mapping from a group. The org-level Super Admin role cannot be removed from the Super Admins group. Requires appropriate permissions at the mapping's scope.
+
+---
+
+## Role Management
+
+### `GET /auth/orgs/{orgHandle}/roles`
+
+Lists all roles with group-assignment counts. Requires role management or integration/project management permissions.
+
+**Query parameters:** `projectId`, `integrationId` (optional scope filters).
+
+### `POST /auth/orgs/{orgHandle}/roles`
+
+Creates a new role with optional permission assignments. Requires `user_mgt:manage_roles`.
+
+**Request body:**
+
+```json
+{
+  "roleName": "Deployment Manager",
+  "description": "Can deploy integrations",
+  "permissionIds": ["perm-001", "perm-002"]
+}
+```
+
+**Response `201 Created`:** Created role object.
+
+### `GET /auth/orgs/{orgHandle}/roles/{roleId}`
+
+Returns role details including the full list of assigned permissions.
+
+### `PUT /auth/orgs/{orgHandle}/roles/{roleId}`
+
+Updates a role's name, description, and permission set. Providing `permissionIds` performs a full replace (adds missing, removes extras). Requires `user_mgt:manage_roles`.
+
+### `DELETE /auth/orgs/{orgHandle}/roles/{roleId}`
+
+Deletes a role. Fails with `409 Conflict` if the role is still assigned to any group. Requires `user_mgt:manage_roles`.
+
+### `GET /auth/orgs/{orgHandle}/roles/{roleId}/groups`
+
+Lists all groups that have this role assigned, enriched with scope and group metadata.
+
+---
+
+## Permissions
+
+### `GET /auth/permissions`
+
+Returns all available system permissions grouped by domain. Accessible to any authenticated user.
+
+**Response `200 OK`:**
+
+```json
+{
+  "permissions": [
+    { "permissionId": "perm-001", "permissionName": "integration_mgt:view", "permissionDomain": "integration_mgt" }
+  ],
+  "groupedByDomain": {
+    "integration_mgt": [...],
+    "environment_mgt": [...],
+    "project_mgt": [...],
+    "user_mgt": [...]
+  }
+}
+```

--- a/en/docs/reference/api/icp.md
+++ b/en/docs/reference/api/icp.md
@@ -11,7 +11,7 @@ This API is consumed by runtime agents, not by end users. It is separate from th
 
 ## Base URL
 
-```
+```bash
 https://<icp-host>:9445/icp
 ```
 
@@ -23,7 +23,7 @@ The default runtime listener port is `9445`.
 
 All requests must include a signed JWT in the `Authorization` header:
 
-```
+```bash
 Authorization: Bearer <runtime-jwt>
 ```
 
@@ -169,6 +169,7 @@ Each artifact entry includes at minimum a `name` field and a `state` field (`"en
 ```json
 {
   "acknowledged": true,
+  "fullHeartbeatRequired": false,
   "commands": [
     {
       "commandId": "cmd-001",
@@ -178,7 +179,8 @@ Each artifact entry includes at minimum a `name` field and a `state` field (`"en
       "issuedAt": "2025-05-01T10:01:00Z",
       "status": "PENDING"
     }
-  ]
+  ],
+  "errors": []
 }
 ```
 

--- a/en/docs/reference/api/icp.md
+++ b/en/docs/reference/api/icp.md
@@ -1,350 +1,256 @@
 ---
-title: ICP API
-description: REST API for the Integration Control Plane.
+title: ICP Runtime API
+description: REST API used by WSO2 Integrator runtimes to register and report state to the Integration Control Plane.
 ---
 
-# Integration Control Plane (ICP) API
+# ICP Runtime API
 
-The Integration Control Plane (ICP) provides a REST API for monitoring, observing, and managing running integrations deployed in WSO2 Integrator environments. The ICP dashboard uses this API internally, but it is also available for programmatic access, custom dashboards, and CI/CD pipeline integration.
+The Integration Control Plane (ICP) exposes a dedicated REST service for runtime agents (Micro Integrator and Ballerina Integrator) to register themselves and continuously report their state. The ICP uses the data from this service to drive reconciliation — pushing control commands back to runtimes to align their state with the desired configuration.
+
+This API is consumed by runtime agents, not by end users. It is separate from the [Management API](management.md) (GraphQL) and the [Authentication API](auth-api.md) (user-facing REST).
 
 ## Base URL
 
 ```
-https://<icp-host>:<port>/api/v1
+https://<icp-host>:9445/icp
 ```
 
-The default ICP port is `9164`. The base path is configurable in the deployment settings.
+The default runtime listener port is `9445`.
+
+---
 
 ## Authentication
 
-All ICP API requests require authentication. The API supports Basic Authentication and OAuth 2.0 bearer tokens.
+All requests must include a signed JWT in the `Authorization` header:
 
-### Basic Authentication
-
-```bash
-curl -k -u admin:admin https://localhost:9164/api/v1/integrations
+```
+Authorization: Bearer <runtime-jwt>
 ```
 
-### Bearer Token
+The token is validated using **kid-based lookup**:
 
-Obtain a token from the token endpoint, then include it in the `Authorization` header:
+1. The JWT header must contain a `kid` claim identifying the org secret key.
+2. The ICP looks up the HMAC secret associated with that `kid`.
+3. The JWT is validated against that secret with:
+   - **Issuer**: `icp-runtime-jwt-issuer`
+   - **Audience**: `icp-server`
+   - **Required scope claim**: `runtime_agent`
+   - **Clock skew tolerance**: 10 seconds
 
-```bash
-# Obtain token
-curl -k -X POST https://localhost:9164/api/v1/auth/token \
-  -H "Content-Type: application/json" \
-  -d '{"username": "admin", "password": "admin"}'
+Tokens are provisioned when a runtime key is created in the ICP (via the Management API). A key can be unbound (not yet associated with a project/component) or bound.
 
-# Use token
-curl -k https://localhost:9164/api/v1/integrations \
-  -H "Authorization: Bearer <access_token>"
-```
+---
 
-**Response:**
+## Endpoints
+
+### `POST /icp/heartbeat`
+
+Submits a full heartbeat from a runtime. This is the primary registration and state-reporting mechanism. On the first heartbeat from an unbound key, the ICP auto-provisions the project and component and binds the key to them.
+
+After processing the heartbeat, the ICP runs reconciliation and returns any pending control commands for the runtime to execute.
+
+**Request body:**
 
 ```json
 {
-  "accessToken": "eyJhbGciOi...",
-  "tokenType": "Bearer",
-  "expiresIn": 3600
-}
-```
-
-## Integration Discovery Endpoints
-
-### List All Integrations
-
-Returns all deployed integrations and their status.
-
-```
-GET /api/v1/integrations
-```
-
-**Response:**
-
-```json
-{
-  "count": 3,
-  "list": [
-    {
-      "name": "OrderService",
-      "type": "service",
-      "status": "active",
-      "version": "1.0.0",
-      "deployedAt": "2025-10-15T08:30:00Z",
-      "listeners": ["http:9090"]
-    },
-    {
-      "name": "InventorySync",
-      "type": "automation",
-      "status": "active",
-      "version": "2.1.0",
-      "deployedAt": "2025-10-14T12:00:00Z",
-      "listeners": []
-    }
-  ]
-}
-```
-
-### Get Integration Details
-
-Returns detailed information about a specific integration.
-
-```
-GET /api/v1/integrations/{name}
-```
-
-**Parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `name` | path | The integration name |
-
-**Response:**
-
-```json
-{
-  "name": "OrderService",
-  "type": "service",
-  "status": "active",
+  "heartbeatVersion": "v1.0",
+  "runtimeId": "runtime-abc123",
+  "runtimeType": "wso2-mi",
+  "status": "RUNNING",
+  "environment": "dev-env",
+  "project": "MyProject",
+  "component": "OrderService",
   "version": "1.0.0",
-  "package": "wso2/order_service",
-  "deployedAt": "2025-10-15T08:30:00Z",
-  "listeners": [
-    {
-      "protocol": "http",
-      "port": 9090,
-      "host": "0.0.0.0"
-    }
-  ],
-  "resources": [
-    {
-      "method": "GET",
-      "path": "/orders",
-      "returnType": "Order[]|error"
-    },
-    {
-      "method": "POST",
-      "path": "/orders",
-      "returnType": "Order|error"
-    }
-  ]
+  "runtimeHostname": "mi-host.example.com",
+  "runtimePort": "9164",
+  "nodeInfo": {
+    "platformName": "wso2-mi",
+    "platformVersion": "4.3.0",
+    "osName": "Linux",
+    "osVersion": "5.15.0",
+    "osArch": "amd64",
+    "javaVersion": "17.0.9",
+    "javaVendor": "Eclipse Adoptium",
+    "totalMemory": 2147483648,
+    "freeMemory": 1073741824,
+    "maxMemory": 2147483648,
+    "usedMemory": 1073741824
+  },
+  "artifacts": {
+    "listeners": [],
+    "services": [],
+    "apis": [{ "name": "OrderAPI", "state": "enabled" }],
+    "proxyServices": [],
+    "sequences": [],
+    "tasks": [],
+    "templates": [],
+    "messageStores": [],
+    "messageProcessors": [],
+    "localEntries": [],
+    "dataServices": [],
+    "carbonApps": [],
+    "dataSources": [],
+    "connectors": [],
+    "registryResources": [],
+    "endpoints": [],
+    "inboundEndpoints": []
+  },
+  "runtimeHash": "sha256-abc123...",
+  "timestamp": "2025-05-01T10:00:00Z"
 }
 ```
 
-## Artifact Discovery Endpoints
+**Request fields:**
 
-### List Services
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `heartbeatVersion` | string | No | Heartbeat format version. Default: `"v1.0"` |
+| `runtimeId` | string | Yes | Unique identifier for this runtime instance |
+| `runtimeType` | string | Yes | Runtime type identifier (e.g., `"wso2-mi"`) |
+| `status` | string | Yes | Current runtime status (`"RUNNING"`, `"STOPPED"`, etc.) |
+| `environment` | string | Yes | Environment handler or UUID the runtime belongs to |
+| `project` | string | Yes | Project name or UUID |
+| `component` | string | Yes | Component/integration name or UUID |
+| `version` | string | No | Runtime version |
+| `runtimeHostname` | string | No | Hostname of the MI management API |
+| `runtimePort` | string | No | Port of the MI management API |
+| `nodeInfo` | object | Yes | Host system information (see below) |
+| `artifacts` | object | Yes | All deployed artifacts grouped by type (see below) |
+| `runtimeHash` | string | Yes | Hash of the full runtime state, used for delta comparison |
+| `timestamp` | string | Yes | ISO 8601 UTC timestamp of the heartbeat |
+| `logLevels` | object | No | Current log levels as a `{ "loggerName": "LEVEL" }` map (Ballerina runtimes) |
 
-Returns all deployed Ballerina services.
+**`nodeInfo` fields:**
 
-```
-GET /api/v1/services
-```
+| Field | Type | Description |
+|-------|------|-------------|
+| `platformName` | string | Platform identifier (default: `"wso2-mi"`) |
+| `platformVersion` | string | Platform/product version |
+| `platformHome` | string | Installation directory |
+| `ballerinaHome` | string | Ballerina home directory (BI runtimes) |
+| `osName` | string | Operating system name |
+| `osVersion` | string | OS version |
+| `osArch` | string | CPU architecture |
+| `javaVersion` | string | JVM version |
+| `javaVendor` | string | JVM vendor |
+| `carbonHome` | string | Carbon home directory (MI runtimes) |
+| `totalMemory` | integer | Total JVM heap memory in bytes |
+| `freeMemory` | integer | Free JVM heap memory in bytes |
+| `maxMemory` | integer | Maximum JVM heap memory in bytes |
+| `usedMemory` | integer | Used JVM heap memory in bytes |
 
-**Response:**
+**`artifacts` fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `listeners` | array | Active HTTP/HTTPS listeners (BI) |
+| `services` | array | Deployed Ballerina services (BI) |
+| `main` | object | Main Ballerina package info: `packageOrg`, `packageName`, `packageVersion` (BI) |
+| `apis` | array | REST APIs (MI) |
+| `proxyServices` | array | Proxy services (MI) |
+| `sequences` | array | Sequences (MI) |
+| `tasks` | array | Scheduled tasks (MI) |
+| `templates` | array | Templates (MI) |
+| `messageStores` | array | Message stores (MI) |
+| `messageProcessors` | array | Message processors (MI) |
+| `localEntries` | array | Local entries (MI) |
+| `dataServices` | array | Data services (MI) |
+| `carbonApps` | array | Carbon applications (MI) |
+| `dataSources` | array | Data sources (MI) |
+| `connectors` | array | Connectors (MI) |
+| `registryResources` | array | Registry resources (MI) |
+| `endpoints` | array | Named endpoints (MI) |
+| `inboundEndpoints` | array | Inbound endpoints (MI) |
+
+Each artifact entry includes at minimum a `name` field and a `state` field (`"enabled"` or `"disabled"`).
+
+**Response `200 OK`:**
 
 ```json
 {
-  "count": 2,
-  "list": [
+  "acknowledged": true,
+  "commands": [
     {
-      "name": "OrderService",
-      "basePath": "/orders",
-      "listeners": ["http:9090"],
-      "resourceCount": 4
-    }
-  ]
-}
-```
-
-### List Listeners
-
-Returns all active listeners across all integrations.
-
-```
-GET /api/v1/listeners
-```
-
-**Response:**
-
-```json
-{
-  "count": 2,
-  "list": [
-    {
-      "protocol": "http",
-      "port": 9090,
-      "host": "0.0.0.0",
-      "attachedServices": ["OrderService", "HealthCheck"]
-    }
-  ]
-}
-```
-
-### List Connectors
-
-Returns all external connectors (clients) in use by deployed integrations.
-
-```
-GET /api/v1/connectors
-```
-
-**Response:**
-
-```json
-{
-  "count": 3,
-  "list": [
-    {
-      "name": "mysqlClient",
-      "type": "ballerinax/mysql:Client",
-      "integration": "OrderService",
-      "status": "connected"
-    },
-    {
-      "name": "httpClient",
-      "type": "ballerina/http:Client",
-      "integration": "OrderService",
-      "targetUrl": "https://inventory.example.com"
-    }
-  ]
-}
-```
-
-## Monitoring Endpoints
-
-### Health Check
-
-Returns the health status of the ICP server and connected runtimes.
-
-```
-GET /api/v1/health
-```
-
-**Response:**
-
-```json
-{
-  "status": "healthy",
-  "uptime": "72h15m30s",
-  "connectedRuntimes": 3,
-  "timestamp": "2025-10-15T10:30:00Z"
-}
-```
-
-### Get Metrics
-
-Returns runtime metrics for a specific integration or the entire deployment.
-
-```
-GET /api/v1/metrics
-GET /api/v1/metrics/{integrationName}
-```
-
-**Query Parameters:**
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `period` | string | `"1h"` | Time window for metrics (`5m`, `1h`, `24h`, `7d`) |
-| `type` | string | `"all"` | Metric type filter (`requests`, `errors`, `latency`, `all`) |
-
-**Response:**
-
-```json
-{
-  "integrationName": "OrderService",
-  "period": "1h",
-  "metrics": {
-    "totalRequests": 15230,
-    "errorCount": 12,
-    "errorRate": 0.079,
-    "avgLatencyMs": 45.2,
-    "p95LatencyMs": 120.5,
-    "p99LatencyMs": 250.0,
-    "activeConnections": 8
-  }
-}
-```
-
-### Get Logs
-
-Retrieves log entries for an integration.
-
-```
-GET /api/v1/logs/{integrationName}
-```
-
-**Query Parameters:**
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `level` | string | `"INFO"` | Minimum log level (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
-| `limit` | int | `100` | Maximum number of log entries |
-| `since` | string | — | ISO 8601 timestamp to fetch logs from |
-
-**Response:**
-
-```json
-{
-  "integrationName": "OrderService",
-  "entries": [
-    {
-      "timestamp": "2025-10-15T10:29:55Z",
-      "level": "ERROR",
-      "message": "Failed to connect to database",
-      "module": "wso2/order_service:db",
-      "error": "Connection refused"
+      "commandId": "cmd-001",
+      "runtimeId": "runtime-abc123",
+      "targetArtifact": { "name": "OrderAPI" },
+      "action": "STOP",
+      "issuedAt": "2025-05-01T10:01:00Z",
+      "status": "PENDING"
     }
   ]
 }
 ```
 
-## Runtime Management Endpoints
+| Field | Type | Description |
+|-------|------|-------------|
+| `acknowledged` | boolean | `true` if the heartbeat was accepted and processed |
+| `fullHeartbeatRequired` | boolean | If `true`, the runtime must send a full heartbeat on the next cycle |
+| `commands` | array | Control commands to execute (may be empty) |
+| `errors` | array | Error messages if processing partially failed |
 
-### Activate/Deactivate an Integration
+**`commands` entry fields:**
 
-```
-PUT /api/v1/integrations/{name}/status
-```
+| Field | Type | Description |
+|-------|------|-------------|
+| `commandId` | string | Unique command identifier |
+| `runtimeId` | string | Target runtime |
+| `targetArtifact.name` | string | Name of the artifact to act on |
+| `action` | string | `START`, `STOP`, or `SET_LOGGER_LEVEL` |
+| `issuedAt` | string | ISO 8601 UTC timestamp |
+| `status` | string | `PENDING`, `SENT`, `ACKNOWLEDGED`, `FAILED`, or `COMPLETED` |
+| `payload` | string | JSON-encoded additional data for the action (e.g., log level settings) |
 
-**Request Body:**
+**Error responses:**
+
+| Status | Reason |
+|--------|--------|
+| `400 Bad Request` | Invalid heartbeat payload, unknown `kid`, or invalid project/component name |
+| `401 Unauthorized` | Missing or invalid JWT, or insufficient scope (requires `runtime_agent`) |
+| `409 Conflict` | Environment or runtime type mismatch between the JWT key binding and the heartbeat |
+
+---
+
+### `POST /icp/deltaHeartbeat`
+
+Submits a lightweight delta heartbeat containing only the runtime ID and a hash of its current state. If the hash matches the ICP's last known state, no full resync is needed, reducing overhead for stable runtimes.
+
+If the key is unbound (not yet associated with a project/component), the ICP cannot resolve the context from a delta heartbeat alone and instructs the runtime to send a full heartbeat.
+
+**Request body:**
 
 ```json
 {
-  "status": "inactive"
+  "heartbeatVersion": "v1.0",
+  "runtimeId": "runtime-abc123",
+  "runtimeHash": "sha256-abc123...",
+  "timestamp": "2025-05-01T10:05:00Z"
 }
 ```
 
-**Response:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `heartbeatVersion` | string | No | Heartbeat format version. Default: `"v1.0"` |
+| `runtimeId` | string | Yes | Unique identifier for this runtime instance |
+| `runtimeHash` | string | Yes | Hash of the full runtime state |
+| `timestamp` | string | Yes | ISO 8601 UTC timestamp |
+
+**Response `200 OK`:**
+
+Same structure as the full heartbeat response. If `fullHeartbeatRequired` is `true`, the runtime must send a `POST /icp/heartbeat` on the next cycle.
 
 ```json
 {
-  "name": "OrderService",
-  "previousStatus": "active",
-  "currentStatus": "inactive",
-  "updatedAt": "2025-10-15T10:35:00Z"
+  "acknowledged": true,
+  "fullHeartbeatRequired": false,
+  "commands": []
 }
 ```
 
-## Error Responses
+**Error responses:**
 
-All error responses follow a consistent format:
-
-```json
-{
-  "error": {
-    "code": "INTEGRATION_NOT_FOUND",
-    "message": "Integration 'UnknownService' not found",
-    "status": 404
-  }
-}
-```
-
-| Status Code | Description |
-|-------------|-------------|
-| `400` | Bad request -- invalid parameters |
-| `401` | Unauthorized -- missing or invalid credentials |
-| `403` | Forbidden -- insufficient permissions |
-| `404` | Not found -- the specified resource does not exist |
-| `500` | Internal server error |
+| Status | Reason |
+|--------|--------|
+| `400 Bad Request` | Unknown `kid` |
+| `401 Unauthorized` | Missing or invalid JWT |
+| `409 Conflict` | Runtime type mismatch |

--- a/en/docs/reference/api/icp.md
+++ b/en/docs/reference/api/icp.md
@@ -245,7 +245,8 @@ Same structure as the full heartbeat response. If `fullHeartbeatRequired` is `tr
 {
   "acknowledged": true,
   "fullHeartbeatRequired": false,
-  "commands": []
+  "commands": [],
+  "errors": []
 }
 ```
 

--- a/en/docs/reference/api/management.md
+++ b/en/docs/reference/api/management.md
@@ -44,15 +44,13 @@ The token is signed with HMAC-SHA256 and validated against:
 Returns a list of registered runtimes. All parameters are optional filters.
 
 ```graphql
-query {
-  runtimes(
-    status: String
-    runtimeType: String
-    environmentId: String
-    projectId: String
-    componentId: String
-  ): [Runtime!]!
-}
+runtimes(
+  status: String
+  runtimeType: String
+  environmentId: String
+  projectId: String
+  componentId: String
+): [Runtime!]!
 ```
 
 **Example:**
@@ -77,9 +75,7 @@ query {
 Returns a single runtime by ID.
 
 ```graphql
-query {
-  runtime(runtimeId: String!): Runtime
-}
+runtime(runtimeId: String!): Runtime
 ```
 
 #### `componentDeployment`
@@ -87,15 +83,13 @@ query {
 Returns deployment information for a component in a specific environment.
 
 ```graphql
-query {
-  componentDeployment(
-    orgHandler: String!
-    orgUuid: String!
-    componentId: String!
-    versionId: String!
-    environmentId: String!
-  ): ComponentDeployment
-}
+componentDeployment(
+  orgHandler: String!
+  orgUuid: String!
+  componentId: String!
+  versionId: String!
+  environmentId: String!
+): ComponentDeployment
 ```
 
 ---
@@ -107,9 +101,7 @@ query {
 Returns all environments accessible to the authenticated user.
 
 ```graphql
-query {
-  environments(orgUuid: String, type: String, projectId: String): [Environment!]!
-}
+environments(orgUuid: String, type: String, projectId: String): [Environment!]!
 ```
 
 The `type` parameter accepts `"prod"` or `"non-prod"` to filter by production status.
@@ -134,9 +126,7 @@ query {
 Returns a single environment by its handler (slug).
 
 ```graphql
-query {
-  environmentByHandler(environmentHandler: String!): Environment
-}
+environmentByHandler(environmentHandler: String!): Environment
 ```
 
 #### `environmentHandlerAvailability`
@@ -144,9 +134,7 @@ query {
 Checks if a handler string is available for a new environment.
 
 ```graphql
-query {
-  environmentHandlerAvailability(environmentHandlerCandidate: String!): EnvironmentHandlerAvailability!
-}
+environmentHandlerAvailability(environmentHandlerCandidate: String!): EnvironmentHandlerAvailability!
 ```
 
 ---
@@ -158,9 +146,7 @@ query {
 Returns all projects accessible to the authenticated user.
 
 ```graphql
-query {
-  projects(orgId: Int): [Project!]!
-}
+projects(orgId: Int): [Project!]!
 ```
 
 #### `project`
@@ -168,9 +154,7 @@ query {
 Returns a single project by ID.
 
 ```graphql
-query {
-  project(orgId: Int, projectId: String!): Project
-}
+project(orgId: Int, projectId: String!): Project
 ```
 
 #### `projectByHandler`
@@ -178,9 +162,7 @@ query {
 Returns a project by its handler within an organization.
 
 ```graphql
-query {
-  projectByHandler(orgId: Int!, projectHandler: String!): Project
-}
+projectByHandler(orgId: Int!, projectHandler: String!): Project
 ```
 
 #### `projectCreationEligibility`
@@ -188,9 +170,7 @@ query {
 Checks whether the authenticated user is permitted to create a project.
 
 ```graphql
-query {
-  projectCreationEligibility(orgId: Int!, orgHandler: String!): ProjectCreationEligibility!
-}
+projectCreationEligibility(orgId: Int!, orgHandler: String!): ProjectCreationEligibility!
 ```
 
 #### `projectHandlerAvailability`
@@ -198,9 +178,7 @@ query {
 Checks if a handler string is available for a new project within an organization.
 
 ```graphql
-query {
-  projectHandlerAvailability(orgId: Int!, projectHandlerCandidate: String!): ProjectHandlerAvailability!
-}
+projectHandlerAvailability(orgId: Int!, projectHandlerCandidate: String!): ProjectHandlerAvailability!
 ```
 
 ---
@@ -212,13 +190,11 @@ query {
 Returns all components accessible to the user within an organization, with optional project filter and sort/pagination options.
 
 ```graphql
-query {
-  components(
-    orgHandler: String!
-    projectId: String
-    options: ComponentOptionsInput
-  ): [Component!]!
-}
+components(
+  orgHandler: String!
+  projectId: String
+  options: ComponentOptionsInput
+): [Component!]!
 ```
 
 #### `component`
@@ -226,13 +202,11 @@ query {
 Returns a single component by ID, or by project ID and handler.
 
 ```graphql
-query {
-  component(
-    componentId: String
-    projectId: String
-    componentHandler: String
-  ): Component
-}
+component(
+  componentId: String
+  projectId: String
+  componentHandler: String
+): Component
 ```
 
 #### `componentArtifactTypes`
@@ -240,9 +214,7 @@ query {
 Returns the artifact types available for a component, optionally filtered by environment.
 
 ```graphql
-query {
-  componentArtifactTypes(componentId: String!, environmentId: String): ArtifactTypes!
-}
+componentArtifactTypes(componentId: String!, environmentId: String): ArtifactTypes!
 ```
 
 ---
@@ -254,33 +226,25 @@ All artifact queries below share the same signature pattern and require both `en
 #### `servicesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  servicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Service!]!
-}
+servicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Service!]!
 ```
 
 #### `listenersByEnvironmentAndComponent`
 
 ```graphql
-query {
-  listenersByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Listener!]!
-}
+listenersByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Listener!]!
 ```
 
 #### `automationsByEnvironmentAndComponent`
 
 ```graphql
-query {
-  automationsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Automation!]!
-}
+automationsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Automation!]!
 ```
 
 #### `restApisByEnvironmentAndComponent`
 
 ```graphql
-query {
-  restApisByEnvironmentAndComponent(environmentId: String!, componentId: String!): [RestApi!]!
-}
+restApisByEnvironmentAndComponent(environmentId: String!, componentId: String!): [RestApi!]!
 ```
 
 **Example:**
@@ -303,97 +267,73 @@ query {
 #### `proxyServicesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  proxyServicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [ProxyService!]!
-}
+proxyServicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [ProxyService!]!
 ```
 
 #### `endpointsByEnvironmentAndComponent`
 
 ```graphql
-query {
-  endpointsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MIEndpoint!]!
-}
+endpointsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MIEndpoint!]!
 ```
 
 #### `inboundEndpointsByEnvironmentAndComponent`
 
 ```graphql
-query {
-  inboundEndpointsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [InboundEndpoint!]!
-}
+inboundEndpointsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [InboundEndpoint!]!
 ```
 
 #### `sequencesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  sequencesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Sequence!]!
-}
+sequencesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Sequence!]!
 ```
 
 #### `tasksByEnvironmentAndComponent`
 
 ```graphql
-query {
-  tasksByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Task!]!
-}
+tasksByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Task!]!
 ```
 
 #### `templatesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  templatesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Template!]!
-}
+templatesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Template!]!
 ```
 
 #### `messageStoresByEnvironmentAndComponent`
 
 ```graphql
-query {
-  messageStoresByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MessageStore!]!
-}
+messageStoresByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MessageStore!]!
 ```
 
 #### `messageProcessorsByEnvironmentAndComponent`
 
 ```graphql
-query {
-  messageProcessorsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MessageProcessor!]!
-}
+messageProcessorsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MessageProcessor!]!
 ```
 
 #### `localEntriesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  localEntriesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [LocalEntry!]!
-}
+localEntriesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [LocalEntry!]!
 ```
 
 #### `dataServicesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  dataServicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [DataService!]!
-}
+dataServicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [DataService!]!
 ```
 
 #### `dataSourcesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  dataSourcesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [DataSource!]!
-}
+dataSourcesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [DataSource!]!
 ```
 
 #### `carbonAppsByEnvironmentAndComponent`
 
 ```graphql
-query {
-  carbonAppsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [CarbonApp!]!
-}
+carbonAppsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [CarbonApp!]!
 ```
 
 #### `carbonAppFaultStackTrace`
@@ -401,25 +341,19 @@ query {
 Returns the fault stack trace for a Carbon App on a specific runtime.
 
 ```graphql
-query {
-  carbonAppFaultStackTrace(runtimeId: String!, appName: String!): CarbonAppFaultStackTrace
-}
+carbonAppFaultStackTrace(runtimeId: String!, appName: String!): CarbonAppFaultStackTrace
 ```
 
 #### `connectorsByEnvironmentAndComponent`
 
 ```graphql
-query {
-  connectorsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Connector!]!
-}
+connectorsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Connector!]!
 ```
 
 #### `registryResourcesByEnvironmentAndComponent`
 
 ```graphql
-query {
-  registryResourcesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [RegistryResource!]!
-}
+registryResourcesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [RegistryResource!]!
 ```
 
 ---
@@ -433,17 +367,15 @@ These queries fetch live details from the MI Management API for a single artifac
 Returns the source definition of an artifact (e.g., sequence XML, API definition).
 
 ```graphql
-query {
-  artifactSourceByComponent(
-    componentId: String!
-    artifactType: String!
-    artifactName: String!
-    environmentId: String
-    runtimeId: String
-    packageName: String
-    templateType: String
-  ): String!
-}
+artifactSourceByComponent(
+  componentId: String!
+  artifactType: String!
+  artifactName: String!
+  environmentId: String
+  runtimeId: String
+  packageName: String
+  templateType: String
+): String!
 ```
 
 #### `artifactWsdlByComponent`
@@ -451,16 +383,14 @@ query {
 Returns the WSDL content for a proxy service artifact.
 
 ```graphql
-query {
-  artifactWsdlByComponent(
-    componentId: String!
-    artifactType: String!
-    artifactName: String!
-    environmentId: String
-    runtimeId: String
-    packageName: String
-  ): String!
-}
+artifactWsdlByComponent(
+  componentId: String!
+  artifactType: String!
+  artifactName: String!
+  environmentId: String
+  runtimeId: String
+  packageName: String
+): String!
 ```
 
 #### `localEntryValueByComponent`
@@ -468,14 +398,12 @@ query {
 Returns the value of a named local entry.
 
 ```graphql
-query {
-  localEntryValueByComponent(
-    componentId: String!
-    entryName: String!
-    environmentId: String
-    runtimeId: String
-  ): String!
-}
+localEntryValueByComponent(
+  componentId: String!
+  entryName: String!
+  environmentId: String
+  runtimeId: String
+): String!
 ```
 
 #### `artifactParametersByComponent`
@@ -483,16 +411,14 @@ query {
 Returns parameters for an inbound endpoint, message processor, or data source artifact.
 
 ```graphql
-query {
-  artifactParametersByComponent(
-    componentId: String!
-    artifactType: String!
-    artifactName: String!
-    environmentId: String
-    runtimeId: String
-    packageName: String
-  ): [Parameter!]!
-}
+artifactParametersByComponent(
+  componentId: String!
+  artifactType: String!
+  artifactName: String!
+  environmentId: String
+  runtimeId: String
+  packageName: String
+): [Parameter!]!
 ```
 
 #### `dataSourceOverviewByComponent`
@@ -500,14 +426,12 @@ query {
 Returns overview fields (name, type, description, driverClass, userName, url) for a data source.
 
 ```graphql
-query {
-  dataSourceOverviewByComponent(
-    componentId: String!
-    dataSourceName: String!
-    environmentId: String
-    runtimeId: String
-  ): [Parameter!]!
-}
+dataSourceOverviewByComponent(
+  componentId: String!
+  dataSourceName: String!
+  environmentId: String
+  runtimeId: String
+): [Parameter!]!
 ```
 
 #### `messageStoreOverviewByComponent`
@@ -515,14 +439,12 @@ query {
 Returns overview fields (name, type, container, size) for a message store.
 
 ```graphql
-query {
-  messageStoreOverviewByComponent(
-    componentId: String!
-    storeName: String!
-    environmentId: String
-    runtimeId: String
-  ): [Parameter!]!
-}
+messageStoreOverviewByComponent(
+  componentId: String!
+  storeName: String!
+  environmentId: String
+  runtimeId: String
+): [Parameter!]!
 ```
 
 #### `messageProcessorOverviewByComponent`
@@ -530,14 +452,12 @@ query {
 Returns overview fields (name, type, messageStore, status) for a message processor.
 
 ```graphql
-query {
-  messageProcessorOverviewByComponent(
-    componentId: String!
-    processorName: String!
-    environmentId: String
-    runtimeId: String
-  ): [Parameter!]!
-}
+messageProcessorOverviewByComponent(
+  componentId: String!
+  processorName: String!
+  environmentId: String
+  runtimeId: String
+): [Parameter!]!
 ```
 
 #### `dataServiceOverviewByComponent`
@@ -545,14 +465,12 @@ query {
 Returns structured overview (dataSources, queries, resources, operations) for a data service.
 
 ```graphql
-query {
-  dataServiceOverviewByComponent(
-    componentId: String!
-    dataServiceName: String!
-    environmentId: String
-    runtimeId: String
-  ): MgmtDataServiceInfo!
-}
+dataServiceOverviewByComponent(
+  componentId: String!
+  dataServiceName: String!
+  environmentId: String
+  runtimeId: String
+): MgmtDataServiceInfo!
 ```
 
 ---
@@ -564,9 +482,7 @@ query {
 Returns loggers for a specific runtime. For MI runtimes, fetches live from the MI Management API. For BI runtimes, reads from the database with reconcile state overlaid.
 
 ```graphql
-query {
-  loggersByRuntime(runtimeId: String!): [Logger!]!
-}
+loggersByRuntime(runtimeId: String!): [Logger!]!
 ```
 
 #### `loggersByEnvironmentAndComponent`
@@ -574,9 +490,7 @@ query {
 Returns loggers grouped by component name across all runtimes in an environment.
 
 ```graphql
-query {
-  loggersByEnvironmentAndComponent(environmentId: String!, componentId: String!): [LoggerGroup!]!
-}
+loggersByEnvironmentAndComponent(environmentId: String!, componentId: String!): [LoggerGroup!]!
 ```
 
 **Example:**
@@ -602,9 +516,7 @@ query {
 Returns the list of available log files on an MI runtime. The runtime must be in `RUNNING` status.
 
 ```graphql
-query {
-  logFilesByRuntime(runtimeId: String!, searchKey: String): LogFilesResponse!
-}
+logFilesByRuntime(runtimeId: String!, searchKey: String): LogFilesResponse!
 ```
 
 #### `logFileContent`
@@ -612,9 +524,7 @@ query {
 Returns the content of a specific log file. The `fileName` must be a plain filename with no path separators or traversal sequences.
 
 ```graphql
-query {
-  logFileContent(runtimeId: String!, fileName: String!): String!
-}
+logFileContent(runtimeId: String!, fileName: String!): String!
 ```
 
 ---
@@ -628,9 +538,7 @@ These queries operate on the MI registry and require the runtime to be in `RUNNI
 Lists the contents of a registry directory path.
 
 ```graphql
-query {
-  registryDirectory(runtimeId: String!, path: String!, expand: Boolean): RegistryDirectoryResponse!
-}
+registryDirectory(runtimeId: String!, path: String!, expand: Boolean): RegistryDirectoryResponse!
 ```
 
 #### `registryFileContent`
@@ -638,9 +546,7 @@ query {
 Returns the content of a registry file at the given path.
 
 ```graphql
-query {
-  registryFileContent(runtimeId: String!, path: String!): String!
-}
+registryFileContent(runtimeId: String!, path: String!): String!
 ```
 
 #### `registryResourceMetadata`
@@ -648,9 +554,7 @@ query {
 Returns metadata (name and mediaType) for a registry resource.
 
 ```graphql
-query {
-  registryResourceMetadata(runtimeId: String!, path: String!): RegistryResourceMetadata!
-}
+registryResourceMetadata(runtimeId: String!, path: String!): RegistryResourceMetadata!
 ```
 
 #### `registryResourceProperties`
@@ -658,9 +562,7 @@ query {
 Returns the properties of a registry resource.
 
 ```graphql
-query {
-  registryResourceProperties(runtimeId: String!, path: String!): RegistryPropertiesResponse!
-}
+registryResourceProperties(runtimeId: String!, path: String!): RegistryPropertiesResponse!
 ```
 
 ---
@@ -672,9 +574,7 @@ query {
 Returns org-level secrets. Optionally filter by environment.
 
 ```graphql
-query {
-  orgSecrets(environmentId: String): [OrgSecretListEntry!]!
-}
+orgSecrets(environmentId: String): [OrgSecretListEntry!]!
 ```
 
 #### `componentSecrets`
@@ -682,9 +582,7 @@ query {
 Returns secrets bound to a specific component in an environment.
 
 ```graphql
-query {
-  componentSecrets(componentId: String!, environmentId: String!): [BoundSecretEntry!]!
-}
+componentSecrets(componentId: String!, environmentId: String!): [BoundSecretEntry!]!
 ```
 
 ---
@@ -696,9 +594,7 @@ query {
 Returns the list of users configured on an MI runtime.
 
 ```graphql
-query {
-  getMIUsers(componentId: String!, runtimeId: String!): MIUsersResponse!
-}
+getMIUsers(componentId: String!, runtimeId: String!): MIUsersResponse!
 ```
 
 **Example:**
@@ -742,9 +638,7 @@ query {
 Deletes a runtime by ID. If `revokeSecret` is `true` and the runtime's secret is no longer used by any other runtime, the secret is also revoked.
 
 ```graphql
-mutation {
-  deleteRuntime(runtimeId: String!, revokeSecret: Boolean): DeleteRuntimeResult!
-}
+deleteRuntime(runtimeId: String!, revokeSecret: Boolean): DeleteRuntimeResult!
 ```
 
 **Example:**
@@ -768,9 +662,7 @@ mutation {
 Creates a new environment. Requires environment management permission; production environments require full management permission.
 
 ```graphql
-mutation {
-  createEnvironment(environment: EnvironmentInput!): Environment
-}
+createEnvironment(environment: EnvironmentInput!): Environment
 ```
 
 **Input:**
@@ -789,9 +681,7 @@ input EnvironmentInput {
 Deletes an environment by ID.
 
 ```graphql
-mutation {
-  deleteEnvironment(environmentId: String!): Boolean!
-}
+deleteEnvironment(environmentId: String!): Boolean!
 ```
 
 #### `updateEnvironment`
@@ -799,14 +689,12 @@ mutation {
 Updates the name, handler, or description of an environment.
 
 ```graphql
-mutation {
-  updateEnvironment(
-    environmentId: String!
-    name: String
-    handler: String
-    description: String
-  ): Environment
-}
+updateEnvironment(
+  environmentId: String!
+  name: String
+  handler: String
+  description: String
+): Environment
 ```
 
 #### `updateEnvironmentProductionStatus`
@@ -814,9 +702,7 @@ mutation {
 Promotes or demotes an environment to/from production status. Always requires full management permission.
 
 ```graphql
-mutation {
-  updateEnvironmentProductionStatus(environmentId: String!, isProduction: Boolean!): Environment
-}
+updateEnvironmentProductionStatus(environmentId: String!, isProduction: Boolean!): Environment
 ```
 
 ---
@@ -828,9 +714,7 @@ mutation {
 Creates a new project.
 
 ```graphql
-mutation {
-  createProject(project: ProjectInput!): Project
-}
+createProject(project: ProjectInput!): Project
 ```
 
 #### `deleteProject`
@@ -838,9 +722,7 @@ mutation {
 Deletes a project. Fails if the project still contains components.
 
 ```graphql
-mutation {
-  deleteProject(orgId: Int!, projectId: String!): DeleteResponse!
-}
+deleteProject(orgId: Int!, projectId: String!): DeleteResponse!
 ```
 
 #### `updateProject`
@@ -848,9 +730,7 @@ mutation {
 Updates project name, version, or description.
 
 ```graphql
-mutation {
-  updateProject(project: ProjectUpdateInput!): Project
-}
+updateProject(project: ProjectUpdateInput!): Project
 ```
 
 **Input:**
@@ -874,9 +754,7 @@ input ProjectUpdateInput {
 Creates a new component within a project. The name must be 3–64 characters.
 
 ```graphql
-mutation {
-  createComponent(component: ComponentInput!): Component
-}
+createComponent(component: ComponentInput!): Component
 ```
 
 **Input:**
@@ -904,9 +782,7 @@ input ComponentInput {
 Deletes a component. Returns a detailed response. Fails if the component has registered runtimes.
 
 ```graphql
-mutation {
-  deleteComponentV2(orgHandler: String!, componentId: String!, projectId: String!): DeleteComponentV2Response!
-}
+deleteComponentV2(orgHandler: String!, componentId: String!, projectId: String!): DeleteComponentV2Response!
 ```
 
 #### `updateComponent`
@@ -914,9 +790,7 @@ mutation {
 Updates component fields such as name, display name, or description.
 
 ```graphql
-mutation {
-  updateComponent(component: ComponentUpdateInput!): Component!
-}
+updateComponent(component: ComponentUpdateInput!): Component!
 ```
 
 ---
@@ -928,9 +802,7 @@ mutation {
 Enables or disables a named artifact across all MI runtimes of a component. Changes are propagated via the reconcile engine.
 
 ```graphql
-mutation {
-  updateArtifactStatus(input: ArtifactStatusChangeInput!): ArtifactStatusChangeResponse!
-}
+updateArtifactStatus(input: ArtifactStatusChangeInput!): ArtifactStatusChangeResponse!
 ```
 
 **Input:**
@@ -967,9 +839,7 @@ mutation {
 Enables or disables tracing on a specific artifact in an environment.
 
 ```graphql
-mutation {
-  updateArtifactTracingStatus(input: ArtifactTracingChangeInput!): ArtifactTracingChangeResponse!
-}
+updateArtifactTracingStatus(input: ArtifactTracingChangeInput!): ArtifactTracingChangeResponse!
 ```
 
 **Input:**
@@ -989,9 +859,7 @@ input ArtifactTracingChangeInput {
 Enables or disables statistics collection on an artifact. Supported artifact types: `proxy-service`, `endpoint`, `api`, `sequence`, `inbound-endpoint`.
 
 ```graphql
-mutation {
-  updateArtifactStatisticsStatus(input: ArtifactStatisticsChangeInput!): ArtifactStatisticsChangeResponse!
-}
+updateArtifactStatisticsStatus(input: ArtifactStatisticsChangeInput!): ArtifactStatisticsChangeResponse!
 ```
 
 **Input:**
@@ -1011,9 +879,7 @@ input ArtifactStatisticsChangeInput {
 Triggers a scheduled task on all MI runtimes of a component. Commands are queued for offline runtimes and delivered on next heartbeat.
 
 ```graphql
-mutation {
-  triggerArtifact(input: ArtifactTriggerInput!): ArtifactTriggerResponse!
-}
+triggerArtifact(input: ArtifactTriggerInput!): ArtifactTriggerResponse!
 ```
 
 **Input:**
@@ -1034,9 +900,7 @@ input ArtifactTriggerInput {
 Starts or stops a named listener on a set of runtimes.
 
 ```graphql
-mutation {
-  updateListenerState(input: ListenerControlInput!): ListenerControlResponse!
-}
+updateListenerState(input: ListenerControlInput!): ListenerControlResponse!
 ```
 
 **Input:**
@@ -1073,9 +937,7 @@ mutation {
 Updates the log level for MI loggers (applied immediately via the MI Management API) or BI component loggers (applied via the reconcile engine).
 
 ```graphql
-mutation {
-  updateLogLevel(input: UpdateLogLevelInput!): UpdateLogLevelResponse!
-}
+updateLogLevel(input: UpdateLogLevelInput!): UpdateLogLevelResponse!
 ```
 
 **Input:**
@@ -1131,9 +993,7 @@ mutation {
 Creates an org-level secret for an environment. If `componentId` is provided, the secret is bound to that component.
 
 ```graphql
-mutation {
-  createOrgSecret(environmentId: String!, componentId: String): String!
-}
+createOrgSecret(environmentId: String!, componentId: String): String!
 ```
 
 Returns the secret value as a plain string (shown only once).
@@ -1143,9 +1003,7 @@ Returns the secret value as a plain string (shown only once).
 Revokes an org-level secret by its key ID.
 
 ```graphql
-mutation {
-  revokeOrgSecret(keyId: String!): Boolean!
-}
+revokeOrgSecret(keyId: String!): Boolean!
 ```
 
 ---
@@ -1157,16 +1015,14 @@ mutation {
 Creates a new user on an MI runtime.
 
 ```graphql
-mutation {
-  addMIUser(
-    componentId: String!
-    runtimeId: String!
-    username: String!
-    password: String!
-    isAdmin: Boolean
-    domain: String
-  ): MIUserOperationResponse!
-}
+addMIUser(
+  componentId: String!
+  runtimeId: String!
+  username: String!
+  password: String!
+  isAdmin: Boolean
+  domain: String
+): MIUserOperationResponse!
 ```
 
 #### `deleteMIUser`
@@ -1174,14 +1030,12 @@ mutation {
 Deletes a user from an MI runtime.
 
 ```graphql
-mutation {
-  deleteMIUser(
-    componentId: String!
-    runtimeId: String!
-    username: String!
-    domain: String
-  ): MIUserOperationResponse!
-}
+deleteMIUser(
+  componentId: String!
+  runtimeId: String!
+  username: String!
+  domain: String
+): MIUserOperationResponse!
 ```
 
 ---

--- a/en/docs/reference/api/management.md
+++ b/en/docs/reference/api/management.md
@@ -9,7 +9,7 @@ The Management API is a GraphQL endpoint exposed by the Integration Control Plan
 
 ## Endpoint
 
-```
+```bash
 POST https://<icp-host>:9446/graphql
 ```
 
@@ -26,7 +26,7 @@ Before calling the GraphQL API, obtain a JWT access token from the ICP authentic
 
 Once you have a token, include it in every request:
 
-```
+```bash
 Authorization: Bearer <jwt-access-token>
 ```
 

--- a/en/docs/reference/api/management.md
+++ b/en/docs/reference/api/management.md
@@ -1,389 +1,1287 @@
 ---
 title: Management API
-description: REST API for managing WSO2 Integrator deployments.
+description: GraphQL API for managing WSO2 Integrator deployments via the Integration Control Plane (ICP).
 ---
 
 # Management API
 
-The Management API provides RESTful endpoints for deploying, configuring, and controlling WSO2 Integrator instances and their integrations. Use this API to automate deployment workflows, manage runtime configuration, and integrate with CI/CD pipelines.
+The Management API is a GraphQL endpoint exposed by the Integration Control Plane (ICP) server. It provides queries and mutations to manage runtimes, environments, projects, components, artifacts, loggers, secrets, and MI users.
 
-## Base URL
+## Endpoint
 
 ```
-https://<management-host>:<port>/management/v1
+POST https://<icp-host>:9446/graphql
 ```
 
-The default management port is `9165`. The base path is configurable in the deployment settings.
+The default port is `9446`. All operations use the same endpoint via HTTP `POST`.
 
 ## Authentication
 
-All Management API requests require authentication using Basic Authentication or an OAuth 2.0 bearer token.
+Before calling the GraphQL API, obtain a JWT access token from the ICP authentication service. See the [Authentication API](auth-api.md) for the full reference covering:
 
-### Basic Authentication
+- Login (local credentials and OIDC/SSO)
+- Token refresh and revocation
+- Password management
+- User, group, role, and permission management
 
-```bash
-curl -k -u admin:admin https://localhost:9165/management/v1/deployments
-```
-
-### Bearer Token
-
-```bash
-curl -k -X POST https://localhost:9165/management/v1/auth/token \
-  -H "Content-Type: application/json" \
-  -d '{"username": "admin", "password": "admin"}'
-```
-
-Include the token in subsequent requests:
-
-```bash
-curl -k https://localhost:9165/management/v1/deployments \
-  -H "Authorization: Bearer <access_token>"
-```
-
-## Deployment Endpoints
-
-### List Deployments
-
-Returns all deployed integration packages.
+Once you have a token, include it in every request:
 
 ```
-GET /management/v1/deployments
+Authorization: Bearer <jwt-access-token>
 ```
 
-**Query Parameters:**
+The token is signed with HMAC-SHA256 and validated against:
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `status` | string | `"all"` | Filter by deployment status (`active`, `inactive`, `failed`, `all`) |
-| `limit` | int | `50` | Maximum number of results |
-| `offset` | int | `0` | Pagination offset |
+- **Issuer**: `icp-frontend-jwt-issuer`
+- **Audience**: `icp-server`
 
-**Response:**
+## Queries
 
-```json
-{
-  "count": 2,
-  "total": 2,
-  "list": [
-    {
-      "id": "dep-001",
-      "name": "order-service",
-      "version": "1.2.0",
-      "status": "active",
-      "replicas": 3,
-      "createdAt": "2025-10-10T08:00:00Z",
-      "updatedAt": "2025-10-15T09:00:00Z"
-    },
-    {
-      "id": "dep-002",
-      "name": "inventory-sync",
-      "version": "2.0.1",
-      "status": "active",
-      "replicas": 1,
-      "createdAt": "2025-10-12T14:00:00Z",
-      "updatedAt": "2025-10-12T14:00:00Z"
-    }
-  ]
+### Runtimes
+
+#### `runtimes`
+
+Returns a list of registered runtimes. All parameters are optional filters.
+
+```graphql
+query {
+  runtimes(
+    status: String
+    runtimeType: String
+    environmentId: String
+    projectId: String
+    componentId: String
+  ): [Runtime!]!
 }
 ```
 
-### Get Deployment Details
+**Example:**
 
-Returns detailed information about a specific deployment.
-
+```graphql
+query {
+  runtimes(environmentId: "env-001", componentId: "comp-abc") {
+    runtimeId
+    runtimeName
+    runtimeType
+    status
+    version
+    lastHeartbeat
+    component { id name }
+    environment { id name }
+  }
+}
 ```
-GET /management/v1/deployments/{deploymentId}
+
+#### `runtime`
+
+Returns a single runtime by ID.
+
+```graphql
+query {
+  runtime(runtimeId: String!): Runtime
+}
 ```
 
-**Response:**
+#### `componentDeployment`
+
+Returns deployment information for a component in a specific environment.
+
+```graphql
+query {
+  componentDeployment(
+    orgHandler: String!
+    orgUuid: String!
+    componentId: String!
+    versionId: String!
+    environmentId: String!
+  ): ComponentDeployment
+}
+```
+
+---
+
+### Environments
+
+#### `environments`
+
+Returns all environments accessible to the authenticated user.
+
+```graphql
+query {
+  environments(orgUuid: String, type: String, projectId: String): [Environment!]!
+}
+```
+
+The `type` parameter accepts `"prod"` or `"non-prod"` to filter by production status.
+
+**Example:**
+
+```graphql
+query {
+  environments(type: "non-prod") {
+    id
+    name
+    handler
+    description
+    isProduction
+    critical
+  }
+}
+```
+
+#### `environmentByHandler`
+
+Returns a single environment by its handler (slug).
+
+```graphql
+query {
+  environmentByHandler(environmentHandler: String!): Environment
+}
+```
+
+#### `environmentHandlerAvailability`
+
+Checks if a handler string is available for a new environment.
+
+```graphql
+query {
+  environmentHandlerAvailability(environmentHandlerCandidate: String!): EnvironmentHandlerAvailability!
+}
+```
+
+---
+
+### Projects
+
+#### `projects`
+
+Returns all projects accessible to the authenticated user.
+
+```graphql
+query {
+  projects(orgId: Int): [Project!]!
+}
+```
+
+#### `project`
+
+Returns a single project by ID.
+
+```graphql
+query {
+  project(orgId: Int, projectId: String!): Project
+}
+```
+
+#### `projectByHandler`
+
+Returns a project by its handler within an organization.
+
+```graphql
+query {
+  projectByHandler(orgId: Int!, projectHandler: String!): Project
+}
+```
+
+#### `projectCreationEligibility`
+
+Checks whether the authenticated user is permitted to create a project.
+
+```graphql
+query {
+  projectCreationEligibility(orgId: Int!, orgHandler: String!): ProjectCreationEligibility!
+}
+```
+
+#### `projectHandlerAvailability`
+
+Checks if a handler string is available for a new project within an organization.
+
+```graphql
+query {
+  projectHandlerAvailability(orgId: Int!, projectHandlerCandidate: String!): ProjectHandlerAvailability!
+}
+```
+
+---
+
+### Components
+
+#### `components`
+
+Returns all components accessible to the user within an organization, with optional project filter and sort/pagination options.
+
+```graphql
+query {
+  components(
+    orgHandler: String!
+    projectId: String
+    options: ComponentOptionsInput
+  ): [Component!]!
+}
+```
+
+#### `component`
+
+Returns a single component by ID, or by project ID and handler.
+
+```graphql
+query {
+  component(
+    componentId: String
+    projectId: String
+    componentHandler: String
+  ): Component
+}
+```
+
+#### `componentArtifactTypes`
+
+Returns the artifact types available for a component, optionally filtered by environment.
+
+```graphql
+query {
+  componentArtifactTypes(componentId: String!, environmentId: String): ArtifactTypes!
+}
+```
+
+---
+
+### Artifacts by Environment and Component
+
+All artifact queries below share the same signature pattern and require both `environmentId` and `componentId`. State fields (e.g., `state`, `tracing`, `statistics`) are overlaid from the reconcile engine.
+
+#### `servicesByEnvironmentAndComponent`
+
+```graphql
+query {
+  servicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Service!]!
+}
+```
+
+#### `listenersByEnvironmentAndComponent`
+
+```graphql
+query {
+  listenersByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Listener!]!
+}
+```
+
+#### `automationsByEnvironmentAndComponent`
+
+```graphql
+query {
+  automationsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Automation!]!
+}
+```
+
+#### `restApisByEnvironmentAndComponent`
+
+```graphql
+query {
+  restApisByEnvironmentAndComponent(environmentId: String!, componentId: String!): [RestApi!]!
+}
+```
+
+**Example:**
+
+```graphql
+query {
+  restApisByEnvironmentAndComponent(environmentId: "env-001", componentId: "comp-abc") {
+    name
+    url
+    context
+    version
+    state
+    tracing
+    statistics
+    resources { path methods }
+  }
+}
+```
+
+#### `proxyServicesByEnvironmentAndComponent`
+
+```graphql
+query {
+  proxyServicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [ProxyService!]!
+}
+```
+
+#### `endpointsByEnvironmentAndComponent`
+
+```graphql
+query {
+  endpointsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MIEndpoint!]!
+}
+```
+
+#### `inboundEndpointsByEnvironmentAndComponent`
+
+```graphql
+query {
+  inboundEndpointsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [InboundEndpoint!]!
+}
+```
+
+#### `sequencesByEnvironmentAndComponent`
+
+```graphql
+query {
+  sequencesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Sequence!]!
+}
+```
+
+#### `tasksByEnvironmentAndComponent`
+
+```graphql
+query {
+  tasksByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Task!]!
+}
+```
+
+#### `templatesByEnvironmentAndComponent`
+
+```graphql
+query {
+  templatesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Template!]!
+}
+```
+
+#### `messageStoresByEnvironmentAndComponent`
+
+```graphql
+query {
+  messageStoresByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MessageStore!]!
+}
+```
+
+#### `messageProcessorsByEnvironmentAndComponent`
+
+```graphql
+query {
+  messageProcessorsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [MessageProcessor!]!
+}
+```
+
+#### `localEntriesByEnvironmentAndComponent`
+
+```graphql
+query {
+  localEntriesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [LocalEntry!]!
+}
+```
+
+#### `dataServicesByEnvironmentAndComponent`
+
+```graphql
+query {
+  dataServicesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [DataService!]!
+}
+```
+
+#### `dataSourcesByEnvironmentAndComponent`
+
+```graphql
+query {
+  dataSourcesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [DataSource!]!
+}
+```
+
+#### `carbonAppsByEnvironmentAndComponent`
+
+```graphql
+query {
+  carbonAppsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [CarbonApp!]!
+}
+```
+
+#### `carbonAppFaultStackTrace`
+
+Returns the fault stack trace for a Carbon App on a specific runtime.
+
+```graphql
+query {
+  carbonAppFaultStackTrace(runtimeId: String!, appName: String!): CarbonAppFaultStackTrace
+}
+```
+
+#### `connectorsByEnvironmentAndComponent`
+
+```graphql
+query {
+  connectorsByEnvironmentAndComponent(environmentId: String!, componentId: String!): [Connector!]!
+}
+```
+
+#### `registryResourcesByEnvironmentAndComponent`
+
+```graphql
+query {
+  registryResourcesByEnvironmentAndComponent(environmentId: String!, componentId: String!): [RegistryResource!]!
+}
+```
+
+---
+
+### Artifact Detail Queries
+
+These queries fetch live details from the MI Management API for a single artifact. They accept an optional `environmentId`, `runtimeId`, and `packageName` to target a specific runtime.
+
+#### `artifactSourceByComponent`
+
+Returns the source definition of an artifact (e.g., sequence XML, API definition).
+
+```graphql
+query {
+  artifactSourceByComponent(
+    componentId: String!
+    artifactType: String!
+    artifactName: String!
+    environmentId: String
+    runtimeId: String
+    packageName: String
+    templateType: String
+  ): String!
+}
+```
+
+#### `artifactWsdlByComponent`
+
+Returns the WSDL content for a proxy service artifact.
+
+```graphql
+query {
+  artifactWsdlByComponent(
+    componentId: String!
+    artifactType: String!
+    artifactName: String!
+    environmentId: String
+    runtimeId: String
+    packageName: String
+  ): String!
+}
+```
+
+#### `localEntryValueByComponent`
+
+Returns the value of a named local entry.
+
+```graphql
+query {
+  localEntryValueByComponent(
+    componentId: String!
+    entryName: String!
+    environmentId: String
+    runtimeId: String
+  ): String!
+}
+```
+
+#### `artifactParametersByComponent`
+
+Returns parameters for an inbound endpoint, message processor, or data source artifact.
+
+```graphql
+query {
+  artifactParametersByComponent(
+    componentId: String!
+    artifactType: String!
+    artifactName: String!
+    environmentId: String
+    runtimeId: String
+    packageName: String
+  ): [Parameter!]!
+}
+```
+
+#### `dataSourceOverviewByComponent`
+
+Returns overview fields (name, type, description, driverClass, userName, url) for a data source.
+
+```graphql
+query {
+  dataSourceOverviewByComponent(
+    componentId: String!
+    dataSourceName: String!
+    environmentId: String
+    runtimeId: String
+  ): [Parameter!]!
+}
+```
+
+#### `messageStoreOverviewByComponent`
+
+Returns overview fields (name, type, container, size) for a message store.
+
+```graphql
+query {
+  messageStoreOverviewByComponent(
+    componentId: String!
+    storeName: String!
+    environmentId: String
+    runtimeId: String
+  ): [Parameter!]!
+}
+```
+
+#### `messageProcessorOverviewByComponent`
+
+Returns overview fields (name, type, messageStore, status) for a message processor.
+
+```graphql
+query {
+  messageProcessorOverviewByComponent(
+    componentId: String!
+    processorName: String!
+    environmentId: String
+    runtimeId: String
+  ): [Parameter!]!
+}
+```
+
+#### `dataServiceOverviewByComponent`
+
+Returns structured overview (dataSources, queries, resources, operations) for a data service.
+
+```graphql
+query {
+  dataServiceOverviewByComponent(
+    componentId: String!
+    dataServiceName: String!
+    environmentId: String
+    runtimeId: String
+  ): MgmtDataServiceInfo!
+}
+```
+
+---
+
+### Loggers
+
+#### `loggersByRuntime`
+
+Returns loggers for a specific runtime. For MI runtimes, fetches live from the MI Management API. For BI runtimes, reads from the database with reconcile state overlaid.
+
+```graphql
+query {
+  loggersByRuntime(runtimeId: String!): [Logger!]!
+}
+```
+
+#### `loggersByEnvironmentAndComponent`
+
+Returns loggers grouped by component name across all runtimes in an environment.
+
+```graphql
+query {
+  loggersByEnvironmentAndComponent(environmentId: String!, componentId: String!): [LoggerGroup!]!
+}
+```
+
+**Example:**
+
+```graphql
+query {
+  loggersByEnvironmentAndComponent(environmentId: "env-001", componentId: "comp-abc") {
+    loggerName
+    componentName
+    logLevel
+    logLevelInSync
+    runtimeIds
+  }
+}
+```
+
+---
+
+### Log Files
+
+#### `logFilesByRuntime`
+
+Returns the list of available log files on an MI runtime. The runtime must be in `RUNNING` status.
+
+```graphql
+query {
+  logFilesByRuntime(runtimeId: String!, searchKey: String): LogFilesResponse!
+}
+```
+
+#### `logFileContent`
+
+Returns the content of a specific log file. The `fileName` must be a plain filename with no path separators or traversal sequences.
+
+```graphql
+query {
+  logFileContent(runtimeId: String!, fileName: String!): String!
+}
+```
+
+---
+
+### Registry Browser
+
+These queries operate on the MI registry and require the runtime to be in `RUNNING` status.
+
+#### `registryDirectory`
+
+Lists the contents of a registry directory path.
+
+```graphql
+query {
+  registryDirectory(runtimeId: String!, path: String!, expand: Boolean): RegistryDirectoryResponse!
+}
+```
+
+#### `registryFileContent`
+
+Returns the content of a registry file at the given path.
+
+```graphql
+query {
+  registryFileContent(runtimeId: String!, path: String!): String!
+}
+```
+
+#### `registryResourceMetadata`
+
+Returns metadata (name and mediaType) for a registry resource.
+
+```graphql
+query {
+  registryResourceMetadata(runtimeId: String!, path: String!): RegistryResourceMetadata!
+}
+```
+
+#### `registryResourceProperties`
+
+Returns the properties of a registry resource.
+
+```graphql
+query {
+  registryResourceProperties(runtimeId: String!, path: String!): RegistryPropertiesResponse!
+}
+```
+
+---
+
+### Secrets
+
+#### `orgSecrets`
+
+Returns org-level secrets. Optionally filter by environment.
+
+```graphql
+query {
+  orgSecrets(environmentId: String): [OrgSecretListEntry!]!
+}
+```
+
+#### `componentSecrets`
+
+Returns secrets bound to a specific component in an environment.
+
+```graphql
+query {
+  componentSecrets(componentId: String!, environmentId: String!): [BoundSecretEntry!]!
+}
+```
+
+---
+
+### MI Runtime User Management
+
+#### `getMIUsers`
+
+Returns the list of users configured on an MI runtime.
+
+```graphql
+query {
+  getMIUsers(componentId: String!, runtimeId: String!): MIUsersResponse!
+}
+```
+
+**Example:**
+
+```graphql
+query {
+  getMIUsers(componentId: "comp-abc", runtimeId: "runtime-001") {
+    users {
+      username
+      domain
+      isAdmin
+    }
+  }
+}
+```
+
+---
+
+### System
+
+#### `systemInfo`
+
+Returns the ICP server version.
+
+```graphql
+query {
+  systemInfo {
+    version
+  }
+}
+```
+
+---
+
+## Mutations
+
+### Runtime Mutations
+
+#### `deleteRuntime`
+
+Deletes a runtime by ID. If `revokeSecret` is `true` and the runtime's secret is no longer used by any other runtime, the secret is also revoked.
+
+```graphql
+mutation {
+  deleteRuntime(runtimeId: String!, revokeSecret: Boolean): DeleteRuntimeResult!
+}
+```
+
+**Example:**
+
+```graphql
+mutation {
+  deleteRuntime(runtimeId: "runtime-001", revokeSecret: true) {
+    deleted
+    orphanedKeyId
+    secretRevoked
+  }
+}
+```
+
+---
+
+### Environment Mutations
+
+#### `createEnvironment`
+
+Creates a new environment. Requires environment management permission; production environments require full management permission.
+
+```graphql
+mutation {
+  createEnvironment(environment: EnvironmentInput!): Environment
+}
+```
+
+**Input:**
+
+```graphql
+input EnvironmentInput {
+  name: String!
+  environmentHandler: String!
+  description: String
+  isProduction: Boolean
+}
+```
+
+#### `deleteEnvironment`
+
+Deletes an environment by ID.
+
+```graphql
+mutation {
+  deleteEnvironment(environmentId: String!): Boolean!
+}
+```
+
+#### `updateEnvironment`
+
+Updates the name, handler, or description of an environment.
+
+```graphql
+mutation {
+  updateEnvironment(
+    environmentId: String!
+    name: String
+    handler: String
+    description: String
+  ): Environment
+}
+```
+
+#### `updateEnvironmentProductionStatus`
+
+Promotes or demotes an environment to/from production status. Always requires full management permission.
+
+```graphql
+mutation {
+  updateEnvironmentProductionStatus(environmentId: String!, isProduction: Boolean!): Environment
+}
+```
+
+---
+
+### Project Mutations
+
+#### `createProject`
+
+Creates a new project.
+
+```graphql
+mutation {
+  createProject(project: ProjectInput!): Project
+}
+```
+
+#### `deleteProject`
+
+Deletes a project. Fails if the project still contains components.
+
+```graphql
+mutation {
+  deleteProject(orgId: Int!, projectId: String!): DeleteResponse!
+}
+```
+
+#### `updateProject`
+
+Updates project name, version, or description.
+
+```graphql
+mutation {
+  updateProject(project: ProjectUpdateInput!): Project
+}
+```
+
+**Input:**
+
+```graphql
+input ProjectUpdateInput {
+  id: String!
+  orgId: Int
+  name: String
+  version: String
+  description: String
+}
+```
+
+---
+
+### Component Mutations
+
+#### `createComponent`
+
+Creates a new component within a project. The name must be 3–64 characters.
+
+```graphql
+mutation {
+  createComponent(component: ComponentInput!): Component
+}
+```
+
+**Input:**
+
+```graphql
+input ComponentInput {
+  projectId: String!
+  name: String!
+  displayName: String
+  description: String
+  orgId: Int
+  orgHandler: String
+  componentType: RuntimeType
+  technology: String
+  repository: String
+  branch: String
+  directoryPath: String
+  secretRef: String
+  isPublicRepo: Boolean
+}
+```
+
+#### `deleteComponentV2`
+
+Deletes a component. Returns a detailed response. Fails if the component has registered runtimes.
+
+```graphql
+mutation {
+  deleteComponentV2(orgHandler: String!, componentId: String!, projectId: String!): DeleteComponentV2Response!
+}
+```
+
+#### `updateComponent`
+
+Updates component fields such as name, display name, or description.
+
+```graphql
+mutation {
+  updateComponent(component: ComponentUpdateInput!): Component!
+}
+```
+
+---
+
+### Artifact Control Mutations
+
+#### `updateArtifactStatus`
+
+Enables or disables a named artifact across all MI runtimes of a component. Changes are propagated via the reconcile engine.
+
+```graphql
+mutation {
+  updateArtifactStatus(input: ArtifactStatusChangeInput!): ArtifactStatusChangeResponse!
+}
+```
+
+**Input:**
+
+```graphql
+input ArtifactStatusChangeInput {
+  componentId: String!
+  artifactType: String!
+  artifactName: String!
+  status: String!   # "active" or "inactive"
+}
+```
+
+**Example:**
+
+```graphql
+mutation {
+  updateArtifactStatus(input: {
+    componentId: "comp-abc"
+    artifactType: "api"
+    artifactName: "OrderAPI"
+    status: "inactive"
+  }) {
+    status
+    message
+    successCount
+    failedCount
+  }
+}
+```
+
+#### `updateArtifactTracingStatus`
+
+Enables or disables tracing on a specific artifact in an environment.
+
+```graphql
+mutation {
+  updateArtifactTracingStatus(input: ArtifactTracingChangeInput!): ArtifactTracingChangeResponse!
+}
+```
+
+**Input:**
+
+```graphql
+input ArtifactTracingChangeInput {
+  componentId: String!
+  environmentId: String!
+  artifactType: String!
+  artifactName: String!
+  trace: String!   # "enable" or "disable"
+}
+```
+
+#### `updateArtifactStatisticsStatus`
+
+Enables or disables statistics collection on an artifact. Supported artifact types: `proxy-service`, `endpoint`, `api`, `sequence`, `inbound-endpoint`.
+
+```graphql
+mutation {
+  updateArtifactStatisticsStatus(input: ArtifactStatisticsChangeInput!): ArtifactStatisticsChangeResponse!
+}
+```
+
+**Input:**
+
+```graphql
+input ArtifactStatisticsChangeInput {
+  componentId: String!
+  environmentId: String!
+  artifactType: String!
+  artifactName: String!
+  statistics: String!   # "enable" or "disable"
+}
+```
+
+#### `triggerArtifact`
+
+Triggers a scheduled task on all MI runtimes of a component. Commands are queued for offline runtimes and delivered on next heartbeat.
+
+```graphql
+mutation {
+  triggerArtifact(input: ArtifactTriggerInput!): ArtifactTriggerResponse!
+}
+```
+
+**Input:**
+
+```graphql
+input ArtifactTriggerInput {
+  componentId: String!
+  taskName: String!
+}
+```
+
+---
+
+### Listener Control Mutations
+
+#### `updateListenerState`
+
+Starts or stops a named listener on a set of runtimes.
+
+```graphql
+mutation {
+  updateListenerState(input: ListenerControlInput!): ListenerControlResponse!
+}
+```
+
+**Input:**
+
+```graphql
+input ListenerControlInput {
+  runtimeIds: [String!]!
+  listenerName: String!
+  action: ControlAction!   # START or STOP
+}
+```
+
+**Example:**
+
+```graphql
+mutation {
+  updateListenerState(input: {
+    runtimeIds: ["runtime-001", "runtime-002"]
+    listenerName: "httpListener"
+    action: STOP
+  }) {
+    success
+    message
+  }
+}
+```
+
+---
+
+### Logger Control Mutations
+
+#### `updateLogLevel`
+
+Updates the log level for MI loggers (applied immediately via the MI Management API) or BI component loggers (applied via the reconcile engine).
+
+```graphql
+mutation {
+  updateLogLevel(input: UpdateLogLevelInput!): UpdateLogLevelResponse!
+}
+```
+
+**Input:**
+
+```graphql
+input UpdateLogLevelInput {
+  runtimeIds: [String!]!
+  componentType: RuntimeType    # MI or BI; inferred from first runtime if omitted
+  componentName: String         # required for BI
+  loggerName: String            # required for MI
+  loggerClass: String           # optional: provide to add a new MI logger
+  logLevel: LogLevel!
+}
+```
+
+**Example — update an MI logger:**
+
+```graphql
+mutation {
+  updateLogLevel(input: {
+    runtimeIds: ["runtime-001"]
+    loggerName: "org.apache.synapse"
+    logLevel: DEBUG
+  }) {
+    success
+    message
+  }
+}
+```
+
+**Example — add a new MI logger with a class:**
+
+```graphql
+mutation {
+  updateLogLevel(input: {
+    runtimeIds: ["runtime-001"]
+    loggerName: "com.example.MyLogger"
+    loggerClass: "com.example.MyLogger"
+    logLevel: INFO
+  }) {
+    success
+    message
+  }
+}
+```
+
+---
+
+### Secret Mutations
+
+#### `createOrgSecret`
+
+Creates an org-level secret for an environment. If `componentId` is provided, the secret is bound to that component.
+
+```graphql
+mutation {
+  createOrgSecret(environmentId: String!, componentId: String): String!
+}
+```
+
+Returns the secret value as a plain string (shown only once).
+
+#### `revokeOrgSecret`
+
+Revokes an org-level secret by its key ID.
+
+```graphql
+mutation {
+  revokeOrgSecret(keyId: String!): Boolean!
+}
+```
+
+---
+
+### MI Runtime User Management Mutations
+
+#### `addMIUser`
+
+Creates a new user on an MI runtime.
+
+```graphql
+mutation {
+  addMIUser(
+    componentId: String!
+    runtimeId: String!
+    username: String!
+    password: String!
+    isAdmin: Boolean
+    domain: String
+  ): MIUserOperationResponse!
+}
+```
+
+#### `deleteMIUser`
+
+Deletes a user from an MI runtime.
+
+```graphql
+mutation {
+  deleteMIUser(
+    componentId: String!
+    runtimeId: String!
+    username: String!
+    domain: String
+  ): MIUserOperationResponse!
+}
+```
+
+---
+
+## Key Types
+
+### `Runtime`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `runtimeId` | `String!` | Unique runtime identifier |
+| `runtimeName` | `String` | Human-readable name |
+| `runtimeType` | `String!` | `"MI"` or `"BI"` |
+| `status` | `String!` | Current status (e.g., `RUNNING`, `OFFLINE`) |
+| `version` | `String` | Runtime version |
+| `component` | `Component!` | The component this runtime belongs to |
+| `environment` | `Environment!` | The environment this runtime is deployed in |
+| `platformName` | `String` | Host platform name |
+| `registrationTime` | `String` | ISO 8601 timestamp when the runtime registered |
+| `lastHeartbeat` | `String` | ISO 8601 timestamp of last heartbeat |
+
+### `Environment`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String!` | Unique environment ID |
+| `name` | `String!` | Display name |
+| `handler` | `String!` | URL-safe identifier (slug) |
+| `description` | `String` | Optional description |
+| `isProduction` | `Boolean!` | Whether this is a production environment |
+| `critical` | `Boolean` | Same as `isProduction`; controls permission level required |
+
+### `Component`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String!` | Unique component ID |
+| `name` | `String!` | Component name |
+| `displayName` | `String` | Human-readable display name |
+| `componentType` | `RuntimeType!` | `MI` or `BI` |
+| `projectId` | `String!` | Parent project ID |
+
+### `LogLevel` (enum)
+
+`OFF` | `FATAL` | `ERROR` | `WARN` | `INFO` | `DEBUG` | `TRACE`
+
+### `ControlAction` (enum)
+
+`START` | `STOP`
+
+### `RuntimeType` (enum)
+
+`MI` | `BI`
+
+### `ArtifactState` (enum)
+
+Possible values: `active`, `inactive` (rendered as strings in the schema).
+
+---
+
+## Permissions
+
+Operations are protected by role-based access control (RBAC). The key permission levels are:
+
+| Permission | Covers |
+|------------|--------|
+| `integration_mgt:view` | Reading artifact and runtime data |
+| `integration_mgt:edit` | Modifying artifacts, log levels, MI users |
+| `integration_mgt:manage` | Full control including deletes and secret management |
+| `environment_mgt:manage` | Creating and deleting production environments |
+| `environment_mgt:manage_nonprod` | Managing non-production environments |
+| `project_mgt:manage` | Creating and deleting projects |
+| `project_mgt:edit` | Updating project metadata |
+
+Insufficient permissions return a GraphQL error with the message `Access denied: ...`.
+
+## Error Handling
+
+GraphQL errors are returned in the standard format:
 
 ```json
 {
-  "id": "dep-001",
-  "name": "order-service",
-  "version": "1.2.0",
-  "status": "active",
-  "package": {
-    "org": "wso2",
-    "name": "order_service",
-    "version": "1.2.0"
-  },
-  "replicas": 3,
-  "resources": {
-    "cpu": "500m",
-    "memory": "512Mi"
-  },
-  "endpoints": [
+  "errors": [
     {
-      "protocol": "http",
-      "host": "order-service.default.svc.cluster.local",
-      "port": 9090,
-      "basePath": "/orders"
+      "message": "Access denied: insufficient permissions to delete runtime",
+      "locations": [{ "line": 2, "column": 3 }],
+      "path": ["deleteRuntime"]
     }
   ],
-  "configuration": {
-    "configFiles": ["Config.toml"],
-    "secrets": ["db-credentials"]
-  },
-  "createdAt": "2025-10-10T08:00:00Z",
-  "updatedAt": "2025-10-15T09:00:00Z"
+  "data": null
 }
 ```
 
-### Deploy an Integration
+Common error messages:
 
-Deploys a new integration package or updates an existing deployment.
-
-```
-POST /management/v1/deployments
-```
-
-**Request Body:**
-
-```json
-{
-  "name": "order-service",
-  "package": {
-    "org": "wso2",
-    "name": "order_service",
-    "version": "1.3.0",
-    "repository": "central"
-  },
-  "replicas": 3,
-  "resources": {
-    "minCpu": "200m",
-    "maxCpu": "1000m",
-    "minMemory": "256Mi",
-    "maxMemory": "512Mi"
-  },
-  "configFiles": {
-    "Config.toml": "port = 9090\nhostname = \"api.example.com\""
-  },
-  "envVars": {
-    "BAL_CONFIG_VAR_DB_PASSWORD": "secret"
-  }
-}
-```
-
-**Response (201 Created):**
-
-```json
-{
-  "id": "dep-003",
-  "name": "order-service",
-  "version": "1.3.0",
-  "status": "deploying",
-  "createdAt": "2025-10-15T11:00:00Z"
-}
-```
-
-### Update a Deployment
-
-Updates an existing deployment (e.g., change replicas, update configuration).
-
-```
-PUT /management/v1/deployments/{deploymentId}
-```
-
-**Request Body:**
-
-```json
-{
-  "replicas": 5,
-  "resources": {
-    "maxMemory": "1Gi"
-  }
-}
-```
-
-### Delete a Deployment
-
-Removes a deployed integration.
-
-```
-DELETE /management/v1/deployments/{deploymentId}
-```
-
-**Query Parameters:**
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `force` | boolean | `false` | Force removal even if the integration is active |
-
-**Response (204 No Content):** Empty body on success.
-
-## Configuration Endpoints
-
-### Get Deployment Configuration
-
-Retrieves the current runtime configuration for a deployment.
-
-```
-GET /management/v1/deployments/{deploymentId}/config
-```
-
-**Response:**
-
-```json
-{
-  "deploymentId": "dep-001",
-  "configFiles": {
-    "Config.toml": "port = 9090\nhostname = \"api.example.com\""
-  },
-  "envVars": [
-    "BAL_CONFIG_VAR_PORT",
-    "BAL_CONFIG_VAR_HOSTNAME"
-  ],
-  "secrets": [
-    "db-credentials"
-  ]
-}
-```
-
-### Update Deployment Configuration
-
-Updates the runtime configuration of a deployed integration. Changes may trigger a rolling restart.
-
-```
-PUT /management/v1/deployments/{deploymentId}/config
-```
-
-**Request Body:**
-
-```json
-{
-  "configFiles": {
-    "Config.toml": "port = 9091\nhostname = \"api-v2.example.com\""
-  },
-  "envVars": {
-    "BAL_CONFIG_VAR_LOG_LEVEL": "DEBUG"
-  },
-  "restartPolicy": "rolling"
-}
-```
-
-## Scaling Endpoints
-
-### Get Scaling Status
-
-```
-GET /management/v1/deployments/{deploymentId}/scale
-```
-
-**Response:**
-
-```json
-{
-  "deploymentId": "dep-001",
-  "currentReplicas": 3,
-  "desiredReplicas": 3,
-  "minReplicas": 1,
-  "maxReplicas": 10,
-  "autoscaling": {
-    "enabled": true,
-    "targetCpuUtilization": 60
-  }
-}
-```
-
-### Scale a Deployment
-
-```
-PUT /management/v1/deployments/{deploymentId}/scale
-```
-
-**Request Body:**
-
-```json
-{
-  "replicas": 5
-}
-```
-
-## Lifecycle Endpoints
-
-### Restart a Deployment
-
-Performs a rolling restart of the deployment.
-
-```
-POST /management/v1/deployments/{deploymentId}/restart
-```
-
-**Request Body (optional):**
-
-```json
-{
-  "strategy": "rolling"
-}
-```
-
-### Suspend a Deployment
-
-Scales the deployment to zero replicas without deleting it.
-
-```
-POST /management/v1/deployments/{deploymentId}/suspend
-```
-
-### Resume a Deployment
-
-Restores the deployment to its configured replica count.
-
-```
-POST /management/v1/deployments/{deploymentId}/resume
-```
-
-## Environment Endpoints
-
-### List Environments
-
-Returns all configured deployment environments.
-
-```
-GET /management/v1/environments
-```
-
-**Response:**
-
-```json
-{
-  "count": 3,
-  "list": [
-    {"name": "development", "status": "active", "runtimes": 2},
-    {"name": "staging", "status": "active", "runtimes": 3},
-    {"name": "production", "status": "active", "runtimes": 5}
-  ]
-}
-```
-
-### Get Environment Details
-
-```
-GET /management/v1/environments/{envName}
-```
-
-## Error Responses
-
-All errors follow a consistent format:
-
-```json
-{
-  "error": {
-    "code": "DEPLOYMENT_NOT_FOUND",
-    "message": "Deployment 'dep-999' not found",
-    "status": 404
-  }
-}
-```
-
-| Status Code | Description |
-|-------------|-------------|
-| `400` | Bad request -- invalid request body or parameters |
-| `401` | Unauthorized -- missing or invalid credentials |
-| `403` | Forbidden -- insufficient permissions for the operation |
-| `404` | Not found -- the specified deployment or resource does not exist |
-| `409` | Conflict -- a deployment with the same name already exists |
-| `422` | Unprocessable entity -- validation failed (e.g., invalid package version) |
-| `500` | Internal server error |
-| `503` | Service unavailable -- the management server is starting up or shutting down |
+| Message pattern | Cause |
+|-----------------|-------|
+| `Access denied: ...` | Insufficient RBAC permission |
+| `Runtime not found` | Invalid or deleted `runtimeId` |
+| `Integration not found` | Invalid `componentId` |
+| `Runtime is not online` | Operation requires `RUNNING` status |
+| `Authorization header missing in request` | Missing or malformed `Authorization` header |
+| `At least one runtime ID must be provided` | Empty `runtimeIds` list in mutation input |

--- a/en/sidebars.ts
+++ b/en/sidebars.ts
@@ -2048,6 +2048,7 @@ const sidebars: SidebarsConfig = {
           label: 'APIs',
           items: [
             'reference/api/management',
+            'reference/api/auth-api',
             'reference/api/icp',
             'reference/api/ballerina-documentation',
           ],


### PR DESCRIPTION
## Summary

- Rewrote `management.md` with accurate GraphQL API documentation derived from `graphql_api.bal` and `schema_graphql.graphql`, replacing the previous placeholder REST API content
- Added `auth-api.md` as a standalone Authentication API reference covering login, token refresh/revocation, password management, and full RBAC (users, groups, roles) sourced from `auth_service.bal`; `management.md` now has a concise cross-reference to it
- Rewrote `icp.md` as the **ICP Runtime API** reference covering the heartbeat and delta heartbeat endpoints sourced from `runtime_service.bal`
- Added `auth-api` entry and updated `icp` label in `sidebars.ts` left nav

## Test plan

- [ ] Verify `management.md` renders correctly and GraphQL examples are accurate
- [ ] Verify `auth-api.md` renders as a standalone page with correct heading hierarchy
- [ ] Verify `icp.md` renders with title "ICP Runtime API"
- [ ] Verify left nav shows all three API pages under the **APIs** category
- [ ] Check cross-links between `management.md` ↔ `auth-api.md` ↔ `icp.md` resolve correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added a comprehensive Authentication API reference covering token issuance/refresh, OIDC login, authorization headers, token/password management, RBAC endpoints (users/groups/roles/permissions), request/response schemas and error definitions.
* Replaced ICP docs with an ICP Runtime API reference detailing runtime registration, heartbeat and delta-heartbeat workflows, payloads, control commands and error semantics.
* Replaced REST Management API docs with a GraphQL-based reference including queries, mutations, types and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->