### PR TITLE
Fix code block line spacing in documentation theme

### DIFF
--- a/en/src/css/custom.css
+++ b/en/src/css/custom.css
@@ -422,6 +422,8 @@ code {
   border-radius: var(--ifm-code-border-radius);
   border: 1px solid #CBD5E1;
   background-color: #F1F5F9 !important;
+  padding: 1rem;
+  line-height: 1.5;
 }
 
 [data-theme='dark'] .prism-code {
@@ -434,6 +436,14 @@ code {
   border: none;
   padding: 0;
   color: inherit;
+  font-size: var(--ifm-code-font-size);
+  line-height: inherit;
+}
+
+/* Ensure code lines have proper spacing */
+.prism-code .token-line {
+  line-height: 1.5;
+  padding: 0.125rem 0;
 }
 
 /* Blockquotes — subtle left border */


### PR DESCRIPTION
## Purpose
Related issue: #188 

Code blocks in the documentation site rendered with cramped spacing, making code/raw-text samples harder to read. The custom theme CSS was unintentionally removing padding.

## Approach
Added three CSS rules to `./en/src/css/custom.css`:
1. `.prism-code` padding and line-height adjustment  
2. `.prism-code code` inherits correct spacing  
3. `.token-line` adds vertical spacing per line

## Before / After
### Before
<img width="889" height="187" alt="image" src="https://github.com/user-attachments/assets/ec8b790c-2c2f-4461-8d8b-b6afedf5a547" />

### After
<img width="874" height="205" alt="image" src="https://github.com/user-attachments/assets/1f83ca14-28cf-4585-b4fe-567047dc9270" />

---

### Before
<img width="857" height="646" alt="image" src="https://github.com/user-attachments/assets/bc4b8344-4d86-45ce-9737-68f89bdcdbba" />

### After
<img width="842" height="664" alt="image" src="https://github.com/user-attachments/assets/2f01ff75-4ac5-45e1-9d0e-03989102258d" />


## Test environment
- Chrome, Safari 
- macOS 26.4.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced code block styling with improved padding, line-height, and spacing for better readability and visual consistency across code displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->