### PR TITLE
Update azure logic apps migration docs

### DIFF
--- a/en/docs/develop/tools/migration-tools/migrate-from-azure-logic-apps.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-azure-logic-apps.md
@@ -4,24 +4,68 @@ title: Migrate from Azure Logic Apps
 description: Migrate Azure Logic Apps workflows to WSO2 Integrator with automated code generation.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import TabAwareToc from '@site/src/components/TabAwareToc';
+
 # Migrate from Azure Logic Apps
 
 ## Overview
 
-The Azure Logic Apps migration tool converts Logic Apps workflow definitions (ARM templates and workflow JSON) to Ballerina code. It handles triggers, actions, connectors, control flow, and error handling patterns.
+The Azure Logic Apps migration tool converts Logic Apps workflow definitions (ARM templates and workflow JSON) to Ballerina code. It handles triggers, actions, connectors, control flow, error handling patterns and more.
 
 ## Run the Azure Logic Apps migration tool
 
-```bash
-# Migrate an Azure Logic Apps project
-bal migrate azure -i /path/to/logic-apps-project/ -o migrated/
+<TabAwareToc />
+<Tabs>
+<TabItem value="ui" label="Wizard">
 
-# Migrate from an exported ARM template
-bal migrate azure -i /path/to/template.json -o migrated/
+Currently, wizard-based migration is not available for Azure Logic Apps. Please use the CLI instructions in the next tab.
 
-# Generate report only
-bal migrate azure -i /path/to/logic-apps-project/ --report-only
-```
+</TabItem>
+<TabItem value="code" label="CLI" default>
+You can migrate Azure Logic Apps projects using the Ballerina CLI tool. Follow these steps:
+
+### CLI prerequisite
+- Ensure Ballerina is installed, and the `bal` command is available in your environment.
+
+### Steps
+1. **Install the migration tool:**
+   Install the migration tool by running:
+   ```bash
+   bal tool pull migrate-logicapps
+   ```
+2. **Run the migration command:**
+   Use the following command syntax to migrate your projects:
+   ```bash
+   bal migrate-logicapps <source-project-directory-or-file> [-o|--out <output-directory>] [-v|--verbose] [-m|--multi-root]
+   ```
+
+#### Key parameters
+- `<source-project-directory-or-file>`: Path to the directory containing multiple Logic App JSON files or a single Logic App JSON file to be migrated.
+- `-o, --out <output-directory>`: (Optional) Directory where the new Ballerina package will be created.
+  - For a project directory input, the new Ballerina package is created inside the source project directory.
+  - For a single JSON file, the new Ballerina package is created in the same directory as the source file.
+- `-v, --verbose`: (Optional) Enable verbose output during conversion.
+- `-m, --multi-root`: (Optional) Treat each child directory as a separate project and convert all of them. The source must be a directory containing multiple Logic App JSON files.
+
+### Examples
+
+Here are some example commands you can use:
+
+- Migrate a Logic Apps JSON file to a specific output directory:
+  ```bash
+  bal migrate-logicapps /path/to/logic-app-control-flow.json --out /path/to/output-dir
+  ```
+
+- Migrate all Logic Apps JSON files in a directory (multi-root mode):
+  ```bash
+  bal migrate-logicapps /path/to/logic-apps-file-directory --out /path/to/output-dir --multi-root
+  ```
+
+> **NOTE:** In multi-root mode, ensure that only Logic Apps JSON files are present in the directory. Do not include any unrelated JSON files.
+</TabItem>
+</Tabs>
 
 ## Component mapping
 


### PR DESCRIPTION
## Purpose
$subject.

## Preview
[1]
<img width="899" height="910" alt="Screenshot 2026-05-06 at 11 22 07" src="https://github.com/user-attachments/assets/66783072-4be1-4190-9355-f43829b86811" />


[2]
<img width="842" height="201" alt="Screenshot 2026-05-06 at 11 22 16" src="https://github.com/user-attachments/assets/d2515a35-532f-42cb-867f-c62294677ec5" />

## Remarks
- Please note that the default tab will be the `CLI` tab (as per the [1] screenshot) since `Wizard` is not supported for Azure Logic Apps. 
- However, if the viewer manually click on the `Wizard` tab, a message will be displayed as per the [2] screenshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Azure Logic Apps migration documentation with a tabbed interface (Wizard and CLI)
  * Wizard tab indicates wizard-based migration is not currently available
  * CLI tab provides prerequisites, step-by-step instructions, command parameters, and detailed migration examples
  * Removed Component mapping section, example workflow, and Migration report documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->