### PR TITLE
[Migration tool] Update migration tools overview docs

### DIFF
--- a/en/docs/develop/tools/migration-tools/migrate-from-azure-logic-apps.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-azure-logic-apps.md
@@ -20,7 +20,7 @@ The Azure Logic Apps migration tool converts Logic Apps workflow definitions (AR
 <Tabs>
 <TabItem value="ui" label="WSO2 Integrator">
 
-Currently, WSO2 Intregrator wizard-based migration is not available for Azure Logic Apps. Please use the CLI instructions in the next tab.
+Currently, WSO2 Integrator wizard-based migration is not available for Azure Logic Apps. Please use the CLI instructions in the next tab.
 
 </TabItem>
 <TabItem value="code" label="CLI" default>

--- a/en/docs/develop/tools/migration-tools/migrate-from-azure-logic-apps.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-azure-logic-apps.md
@@ -12,15 +12,15 @@ import TabAwareToc from '@site/src/components/TabAwareToc';
 
 ## Overview
 
-The Azure Logic Apps migration tool converts Logic Apps workflow definitions (ARM templates and workflow JSON) to Ballerina code. It handles triggers, actions, connectors, control flow, error handling patterns and more.
+The Azure Logic Apps migration tool converts Logic Apps workflow definitions (ARM templates and workflow JSON) to Ballerina code. It handles triggers, actions, connectors, control flow, error handling patterns, and more.
 
 ## Run the Azure Logic Apps migration tool
 
 <TabAwareToc />
 <Tabs>
-<TabItem value="ui" label="Wizard">
+<TabItem value="ui" label="WSO2 Integrator">
 
-Currently, wizard-based migration is not available for Azure Logic Apps. Please use the CLI instructions in the next tab.
+Currently, WSO2 Intregrator wizard-based migration is not available for Azure Logic Apps. Please use the CLI instructions in the next tab.
 
 </TabItem>
 <TabItem value="code" label="CLI" default>

--- a/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-mulesoft.md
@@ -12,13 +12,13 @@ import TabAwareToc from '@site/src/components/TabAwareToc';
 
 ## Overview
 
-The MuleSoft migration tool converts MuleSoft Anypoint flows (XML configurations) to Ballerina code. It handles HTTP listeners, request connectors, DataWeave transformations, routers, error handling patterns and more.
+The MuleSoft migration tool converts MuleSoft Anypoint flows (XML configurations) to Ballerina code. It handles HTTP listeners, request connectors, DataWeave transformations, routers, error handling patterns, and more.
 
 ## Run the MuleSoft migration tool
 
 <TabAwareToc />
 <Tabs>
-<TabItem value="ui" label="Wizard" default>
+<TabItem value="ui" label="WSO2 Integrator" default>
 
 The migration wizard guides you through a 5-step process to convert your MuleSoft project(s) into a WSO2 Integrator project.
 

--- a/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
+++ b/en/docs/develop/tools/migration-tools/migrate-from-tibco-businessworks.md
@@ -12,13 +12,13 @@ import TabAwareToc from '@site/src/components/TabAwareToc';
 
 ## Overview
 
-The TIBCO migration tool converts TIBCO BusinessWorks process definitions to Ballerina code. It handles process flows, activities, transitions, shared resources, error handling configurations and more.
+The TIBCO migration tool converts TIBCO BusinessWorks process definitions to Ballerina code. It handles process flows, activities, transitions, shared resources, error handling configurations, and more.
 
 ## Run the TIBCO migration tool
 
 <TabAwareToc />
 <Tabs>
-<TabItem value="ui" label="Wizard" default>
+<TabItem value="ui" label="WSO2 Integrator" default>
 
 The migration wizard guides you through a 5-step process to convert your TIBCO BusinessWorks project(s) into a WSO2 Integrator project.
 

--- a/en/docs/develop/tools/migration-tools/migration-tools.md
+++ b/en/docs/develop/tools/migration-tools/migration-tools.md
@@ -38,25 +38,38 @@ After migration, complete the following post-migration steps:
 
 ## Tool summary
 
-### MuleSoft
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="mulesoft" label="MuleSoft" default>
+
 - Converts MuleSoft Anypoint flows (XML configurations) to Ballerina code.
 - Handles HTTP listeners, request connectors, DataWeave transformations, routers, error handling patterns, and more.
 - **Rule-based migration** is supported via both the WSO2 Integrator and the CLI tool.
 - **AI enhancement** is currently available only in the WSO2 Integrator to further automate migration and resolve unmapped elements.
 - See [Migrate from MuleSoft](migrate-from-mulesoft.md) for detailed instructions.
 
-### TIBCO BusinessWorks
+</TabItem>
+<TabItem value="tibco" label="TIBCO BusinessWorks">
+
 - Converts TIBCO BusinessWorks process definitions to Ballerina code.
 - Handles process flows, activities, transitions, shared resources, error handling configurations, and more.
 - **Rule-based migration** is supported via both the WSO2 Integrator and the CLI tool.
 - **AI enhancement** is currently available only in the WSO2 Integrator to further automate migration and resolve unmapped elements.
 - See [Migrate from TIBCO BusinessWorks](migrate-from-tibco-businessworks.md) for detailed instructions.
 
-### Azure Logic Apps
+</TabItem>
+<TabItem value="logicapps" label="Azure Logic Apps">
+
 - Converts Logic Apps workflow definitions (ARM templates and workflow JSON) to Ballerina code.
 - Handles triggers, actions, connectors, control flow, error handling patterns, and more.
 - **Migration is fully AI-powered and available only via the CLI tool.** WSO2 Integrator support is not available for Logic Apps at this time.
 - See [Migrate from Azure Logic Apps](migrate-from-azure-logic-apps.md) for detailed instructions.
+
+</TabItem>
+</Tabs>
+
 
 ## Command reference
 

--- a/en/docs/develop/tools/migration-tools/migration-tools.md
+++ b/en/docs/develop/tools/migration-tools/migration-tools.md
@@ -30,10 +30,10 @@ Migration can be initiated using either the WSO2 Integrator migration wizard (UI
 After migration, complete the following post-migration steps:
 
 1. **Review:** Check the migration report and migration summary markdown files to understand what was done during migration and identify any items that may need manual attention.
-3. **Implement:** Complete any manually flagged items (custom logic, complex transformations, or unsupported elements).
-2. **Configure:** Set up `Config.toml` with connection details and environment-specific values.
+2. **Implement:** Complete any manually flagged items (custom logic, complex transformations, or unsupported elements).
+3. **Configure:** Set up `Config.toml` with connection details and environment-specific values.
 4. **Test:** Review any auto-migrated tests, and add or update tests as needed to ensure the migrated integrations behave as expected compared to the source system.
-5. **Deploy** Deploy to the WSO2 Integrator runtime.
+5. **Deploy:** Deploy to the WSO2 Integrator runtime.
 
 ## Tool summary
 

--- a/en/docs/develop/tools/migration-tools/migration-tools.md
+++ b/en/docs/develop/tools/migration-tools/migration-tools.md
@@ -11,16 +11,17 @@ WSO2 Integrator provides migration tools to help you move existing integrations 
 
 ## Supported platforms and features
 
-| Source platform | WSO2 Integrator | CLI | AI Enhancement | Command |
-|---|:---:|:---:|:---:|---|
-| [MuleSoft](migrate-from-mulesoft.md) | ✓ | ✓ | ✓ | `bal migrate-mule` |
-| [TIBCO BusinessWorks](migrate-from-tibco-businessworks.md) | ✓ | ✓ | ✓ | `bal migrate-tibco` |
-| [Azure Logic Apps](migrate-from-azure-logic-apps.md) |  | ✓ | ✓ | `bal migrate-logicapps` |
+| Source platform | WSO2 Integrator | CLI | Rule-based | AI-powered |
+|---|:---:|:---:|:---:|:---:|
+| [MuleSoft](migrate-from-mulesoft.md)         | ✓ | ✓ | ✓ | ✓ (optional, currently not available in CLI) |
+| [TIBCO BusinessWorks](migrate-from-tibco-businessworks.md) | ✓ | ✓ | ✓ | ✓ (optional, currently not available in CLI) |
+| [Azure Logic Apps](migrate-from-azure-logic-apps.md)      | ✗ | ✓ | ✗ | ✓ (mandatory)   |
 
 **Legend:**
 - **WSO2 Integrator:** Migration supported via the WSO2 Integrator migration wizard UI.
 - **CLI:** Migration supported via the Ballerina CLI tool.
-- **AI Enhancement (WSO2 Integrator only):** AI-powered migration enhancement is available only in the WSO2 Integrator for MuleSoft and TIBCO.
+- **Rule-based:** Deterministic, rules-driven migration (non-AI). Available for MuleSoft and TIBCO only.
+- **AI-powered:** Migration uses AI. For MuleSoft and TIBCO, this is an optional enhancement (currently only available in WSO2 Integrator, not CLI). For Logic Apps, migration is performed entirely by AI and is mandatory.
 
 
 ## Migration workflow
@@ -40,21 +41,21 @@ After migration, complete the following post-migration steps:
 ### MuleSoft
 - Converts MuleSoft Anypoint flows (XML configurations) to Ballerina code.
 - Handles HTTP listeners, request connectors, DataWeave transformations, routers, error handling patterns, and more.
-- Migration is supported via both the WSO2 Integrator wizard (UI) and the CLI tool.
-- AI enhancement is available only in the wizard (UI) to further automate migration and resolve unmapped elements.
+- **Rule-based migration** is supported via both the WSO2 Integrator and the CLI tool.
+- **AI enhancement** is currently available only in the WSO2 Integrator to further automate migration and resolve unmapped elements.
 - See [Migrate from MuleSoft](migrate-from-mulesoft.md) for detailed instructions.
 
 ### TIBCO BusinessWorks
 - Converts TIBCO BusinessWorks process definitions to Ballerina code.
 - Handles process flows, activities, transitions, shared resources, error handling configurations, and more.
-- Migration is supported via both the WSO2 Integrator wizard (UI) and the CLI tool.
-- AI enhancement is available only in the wizard (UI) to further automate migration and resolve unmapped elements.
+- **Rule-based migration** is supported via both the WSO2 Integrator and the CLI tool.
+- **AI enhancement** is currently available only in the WSO2 Integrator to further automate migration and resolve unmapped elements.
 - See [Migrate from TIBCO BusinessWorks](migrate-from-tibco-businessworks.md) for detailed instructions.
 
 ### Azure Logic Apps
 - Converts Logic Apps workflow definitions (ARM templates and workflow JSON) to Ballerina code.
 - Handles triggers, actions, connectors, control flow, error handling patterns, and more.
-- Migration is currently supported only via the CLI tool. Wizard (UI) and AI enhancement are not available for Logic Apps at this time.
+- **Migration is fully AI-powered and available only via the CLI tool.** WSO2 Integrator support is not available for Logic Apps at this time.
 - See [Migrate from Azure Logic Apps](migrate-from-azure-logic-apps.md) for detailed instructions.
 
 ## Command reference

--- a/en/docs/develop/tools/migration-tools/migration-tools.md
+++ b/en/docs/develop/tools/migration-tools/migration-tools.md
@@ -1,43 +1,71 @@
 ---
 sidebar_position: 1
 title: Migration tools
-description: Migrate integrations from WSO2 MI, MuleSoft, TIBCO, and Azure Logic Apps to WSO2 Integrator.
+description: Migrate integrations from MuleSoft, TIBCO BusinessWorks, and Azure Logic Apps to WSO2 Integrator.
 ---
 
 # Migration Tools
 
-WSO2 Integrator provides migration tools that help you move existing integrations from other platforms to WSO2 Integrator. The tools analyze your existing integration artifacts, generate equivalent Ballerina code, and produce a migration report highlighting items that require manual attention.
+WSO2 Integrator provides migration tools to help you move existing integrations from other platforms to WSO2 Integrator. These tools analyze your integration artifacts, generate equivalent Ballerina code, and produce a migration report highlighting items that require manual attention.
 
-## Supported platforms
 
-| Source platform | Command | Status |
-|---|---|---|
-| [WSO2 MI](migrate-from-mi.md) | `bal migrate mi` | Available |
-| [MuleSoft](migrate-from-mulesoft.md) | `bal migrate mule` | Available |
-| [TIBCO BusinessWorks](migrate-from-tibco-businessworks.md) | `bal migrate tibco` | Available |
-| [Azure Logic Apps](migrate-from-azure-logic-apps.md) | `bal migrate azure` | Available |
+## Supported platforms and features
+
+| Source platform | WSO2 Integrator | CLI | AI Enhancement | Command |
+|---|:---:|:---:|:---:|---|
+| [MuleSoft](migrate-from-mulesoft.md) | ✓ | ✓ | ✓ | `bal migrate-mule` |
+| [TIBCO BusinessWorks](migrate-from-tibco-businessworks.md) | ✓ | ✓ | ✓ | `bal migrate-tibco` |
+| [Azure Logic Apps](migrate-from-azure-logic-apps.md) |  | ✓ | ✓ | `bal migrate-logicapps` |
+
+**Legend:**
+- **WSO2 Integrator:** Migration supported via the WSO2 Integrator migration wizard UI.
+- **CLI:** Migration supported via the Ballerina CLI tool.
+- **AI Enhancement (WSO2 Integrator only):** AI-powered migration enhancement is available only in the WSO2 Integrator for MuleSoft and TIBCO.
+
 
 ## Migration workflow
 
-Follow these steps for a successful migration:
+Migration can be initiated using either the WSO2 Integrator migration wizard (UI) or the CLI tool. The table above shows the capabilities supported by each migration tool. For step-by-step instructions and screenshots, refer to the dedicated migration pages for each platform.
 
-1. **Assess** — Run the migration tool with `--report-only` to understand the scope.
-2. **Generate** — Run the full migration to produce Ballerina code.
-3. **Review** — Check the migration report for items needing manual attention.
-4. **Configure** — Set up `Config.toml` with connection details and environment-specific values.
-5. **Implement** — Complete any manually flagged items (custom mediators, complex transformations).
-6. **Test** — Write tests for the migrated integrations and compare behavior.
-7. **Deploy** — Deploy to WSO2 Integrator runtime.
+After migration, complete the following post-migration steps:
+
+1. **Review:** Check the migration report and migration summary markdown files to understand what was done during migration and identify any items that may need manual attention.
+3. **Implement:** Complete any manually flagged items (custom logic, complex transformations, or unsupported elements).
+2. **Configure:** Set up `Config.toml` with connection details and environment-specific values.
+4. **Test:** Review any auto-migrated tests, and add or update tests as needed to ensure the migrated integrations behave as expected compared to the source system.
+5. **Deploy** Deploy to the WSO2 Integrator runtime.
+
+## Tool summary
+
+### MuleSoft
+- Converts MuleSoft Anypoint flows (XML configurations) to Ballerina code.
+- Handles HTTP listeners, request connectors, DataWeave transformations, routers, error handling patterns, and more.
+- Migration is supported via both the WSO2 Integrator wizard (UI) and the CLI tool.
+- AI enhancement is available only in the wizard (UI) to further automate migration and resolve unmapped elements.
+- See [Migrate from MuleSoft](migrate-from-mulesoft.md) for detailed instructions.
+
+### TIBCO BusinessWorks
+- Converts TIBCO BusinessWorks process definitions to Ballerina code.
+- Handles process flows, activities, transitions, shared resources, error handling configurations, and more.
+- Migration is supported via both the WSO2 Integrator wizard (UI) and the CLI tool.
+- AI enhancement is available only in the wizard (UI) to further automate migration and resolve unmapped elements.
+- See [Migrate from TIBCO BusinessWorks](migrate-from-tibco-businessworks.md) for detailed instructions.
+
+### Azure Logic Apps
+- Converts Logic Apps workflow definitions (ARM templates and workflow JSON) to Ballerina code.
+- Handles triggers, actions, connectors, control flow, error handling patterns, and more.
+- Migration is currently supported only via the CLI tool. Wizard (UI) and AI enhancement are not available for Logic Apps at this time.
+- See [Migrate from Azure Logic Apps](migrate-from-azure-logic-apps.md) for detailed instructions.
 
 ## Command reference
 
 | Command | Description |
 |---|---|
-| `bal migrate mi -i <dir>` | Migrate from WSO2 MI |
-| `bal migrate mule -i <dir>` | Migrate from MuleSoft |
-| `bal migrate tibco -i <dir>` | Migrate from TIBCO BusinessWorks |
-| `bal migrate azure -i <dir>` | Migrate from Azure Logic Apps |
-| `-o <dir>` | Output directory |
-| `--report-only` | Generate migration report without code |
-| `--artifacts <types>` | Migrate specific artifact types |
-| `--version <ver>` | Source platform version |
+| `bal migrate-mule <source-project-directory-or-file>` | Migrate from MuleSoft |
+| `bal migrate-tibco <source-project-directory-or-file>` | Migrate from TIBCO BusinessWorks |
+| `bal migrate-logicapps <source-project-directory-or-file>` | Migrate from Azure Logic Apps |
+| `-o, --out <output-directory>` | Output directory of the migration |
+| `-v, --verbose` | Enable verbose output |
+| `-m, --multi-root` | (MuleSoft/TIBCO) Treat each child directory as a separate project and convert each.<br/>(Logic Apps) Treat each JSON file in the directory as a separate project and convert each. |
+| `-d, --dry-run` | (MuleSoft/TIBCO) Analyze and generate a migration report without generating Ballerina code |
+| `-k, --keep-structure` | (MuleSoft/TIBCO) Preserve original project structure |


### PR DESCRIPTION
## Purpose
Update docs in  **develop/tools/migration-tools**
## Preview
<img width="856" height="801" alt="Screenshot 2026-05-07 at 13 18 37" src="https://github.com/user-attachments/assets/c8405cc5-af36-442a-8c71-1810fc17c1a5" />

<img width="856" height="801" alt="Screenshot 2026-05-07 at 13 18 46" src="https://github.com/user-attachments/assets/d5a97792-25e2-4cdc-a493-7e058df16fc9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized migration docs with clarified tab labels (now “WSO2 Integrator”) and aligned UI content for Azure Logic Apps, MuleSoft, and TIBCO BusinessWorks
  * Removed prior WSO2 MI coverage; added per-source capability summaries and a feature matrix for wizard/CLI and AI availability
  * Revised post-migration checklist and workflow steps
  * Updated CLI command names and standardized option flags for migration commands
<!-- end of auto-generated comment: release notes by coderabbit.ai -->