### PR TITLE
Fix Cloud.toml reference docs

### DIFF
--- a/en/docs/reference/config/cloud-toml.md
+++ b/en/docs/reference/config/cloud-toml.md
@@ -32,8 +32,7 @@ Configures the Docker container image that is built during `bal build`.
 repository = "wso2inc"
 name = "order-service"
 tag = "v1.2.0"
-base = "ballerina/jvm-runtime:2.0"
-user = { run_as = "ballerina" }
+base = "ballerina/jvm-runtime:3.1"
 ```
 
 | Field | Type | Default | Description |
@@ -41,8 +40,23 @@ user = { run_as = "ballerina" }
 | `repository` | string | `""` | Docker registry or repository prefix (e.g., `"docker.io/wso2inc"`, `"ghcr.io/myorg"`). |
 | `name` | string | Package name | Container image name. Defaults to the Ballerina package name. |
 | `tag` | string | `"latest"` | Image version tag. |
-| `base` | string | Ballerina default | Base image for the Dockerfile. Override to use a custom JVM runtime image. |
-| `user.run_as` | string | `"ballerina"` | The non-root user the container process runs as. |
+| `base` | string | `"ballerina/jvm-runtime:3.1"` | Base image for the Dockerfile. Override to use a custom JVM runtime image. |
+| `entrypoint` | string | Ballerina default | Custom container entrypoint command. |
+
+## `[[container.copy.files]]`
+
+Copies additional files into the container image at build time.
+
+```toml
+[[container.copy.files]]
+sourceFile = "./resources/config.xml"
+target = "/home/ballerina/config.xml"
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sourceFile` | string | Yes | Path to the local file to copy into the image. |
+| `target` | string | Yes | Absolute path inside the container where the file is placed. |
 
 ## `[cloud.deployment]`
 
@@ -50,25 +64,30 @@ Defines Kubernetes deployment resource requests and limits.
 
 ```toml
 [cloud.deployment]
+replicas = 1
 min_memory = "256Mi"
 max_memory = "512Mi"
 min_cpu = "200m"
 max_cpu = "1000m"
+internal_domain_name = "order-service.internal"
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `replicas` | int | `1` | Fixed number of pod replicas. When set, autoscaling is still applied on top of this baseline. |
 | `min_memory` | string | `"100Mi"` | Minimum memory allocation (Kubernetes resource request). |
-| `max_memory` | string | `"256Mi"` | Maximum memory limit (Kubernetes resource limit). |
-| `min_cpu` | string | `"500m"` | Minimum CPU allocation in millicores (Kubernetes resource request). |
+| `max_memory` | string | `"512Mi"` | Maximum memory limit (Kubernetes resource limit). |
+| `min_cpu` | string | `"200m"` | Minimum CPU allocation in millicores (Kubernetes resource request). |
 | `max_cpu` | string | `"500m"` | Maximum CPU limit in millicores (Kubernetes resource limit). |
+| `internal_domain_name` | string | `""` | Internal cluster DNS name for service-to-service communication. |
 
 ## `[cloud.deployment.autoscaling]`
 
-Configures horizontal pod autoscaling for Kubernetes deployments.
+Configures horizontal pod autoscaling for Kubernetes deployments. HPA is enabled by default when a `PodAutoscalerModel` is present.
 
 ```toml
 [cloud.deployment.autoscaling]
+enable = true
 min_replicas = 2
 max_replicas = 5
 cpu = 60
@@ -77,52 +96,49 @@ memory = 80
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `min_replicas` | int | `1` | Minimum number of pod replicas. |
-| `max_replicas` | int | `2` | Maximum number of pod replicas. |
+| `enable` | bool | `true` | Set to `false` to disable HPA generation entirely. |
+| `min_replicas` | int | Deployment replicas | Minimum number of pod replicas. |
+| `max_replicas` | int | Deployment replicas + 1 | Maximum number of pod replicas. |
 | `cpu` | int | `50` | Target CPU utilization percentage that triggers scaling. |
-| `memory` | int | `80` | Target memory utilization percentage that triggers scaling. |
+| `memory` | int | `0` | Target memory utilization percentage that triggers scaling. `0` disables memory-based scaling. |
 
 ## `[cloud.deployment.probes.liveness]`
 
 Configures the Kubernetes liveness probe. The liveness probe determines if the container is still running and should be restarted if it fails.
 
+> **Note:** `initialDelaySeconds` is hardcoded to `30` seconds by the compiler and cannot be overridden from `Cloud.toml`.
+
 ```toml
 [cloud.deployment.probes.liveness]
 port = 9091
 path = "/probes/healthz"
-initialDelaySeconds = 30
-periodSeconds = 10
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `port` | int | Service port | Port the liveness probe hits. |
 | `path` | string | `"/probes/healthz"` | HTTP path for the liveness check endpoint. |
-| `initialDelaySeconds` | int | `10` | Seconds to wait before the first probe after container start. |
-| `periodSeconds` | int | `10` | How often (in seconds) the probe is performed. |
 
 ## `[cloud.deployment.probes.readiness]`
 
 Configures the Kubernetes readiness probe. The readiness probe determines if the container is ready to accept traffic.
 
+> **Note:** `initialDelaySeconds` is hardcoded to `30` seconds by the compiler and cannot be overridden from `Cloud.toml`.
+
 ```toml
 [cloud.deployment.probes.readiness]
 port = 9091
 path = "/probes/readyz"
-initialDelaySeconds = 15
-periodSeconds = 5
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `port` | int | Service port | Port the readiness probe hits. |
 | `path` | string | `"/probes/readyz"` | HTTP path for the readiness check endpoint. |
-| `initialDelaySeconds` | int | `10` | Seconds to wait before the first probe after container start. |
-| `periodSeconds` | int | `10` | How often (in seconds) the probe is performed. |
 
 ## `[[cloud.config.files]]`
 
-Mounts local configuration files into the container as Kubernetes ConfigMaps.
+Mounts local configuration files into the container as Kubernetes ConfigMaps. Use this for Ballerina `Config.toml` files.
 
 ```toml
 [[cloud.config.files]]
@@ -149,6 +165,70 @@ file = "./Secret.toml"
 |-------|------|----------|-------------|
 | `file` | string | Yes | Path to the local secret configuration file. |
 
+## `[[cloud.config.maps]]`
+
+Mounts arbitrary local files or directories as Kubernetes ConfigMaps at a custom container path.
+
+```toml
+[[cloud.config.maps]]
+file = "./resources/log4j2.xml"
+mount_dir = "/home/ballerina/conf"
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `file` | string | Yes | Path to the local file or directory to mount. |
+| `mount_dir` | string | Yes | Container directory where the file is mounted. Relative paths are resolved under the Ballerina home directory. |
+
+## `[[cloud.secret.files]]`
+
+Mounts arbitrary local files or directories as Kubernetes Secrets at a custom container path.
+
+```toml
+[[cloud.secret.files]]
+file = "./resources/keystore.p12"
+mount_dir = "/home/ballerina/security"
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `file` | string | Yes | Path to the local file or directory to mount as a secret. |
+| `mount_dir` | string | No | Container directory where the secret is mounted. Defaults to the Ballerina secrets mount path. |
+
+## `[[cloud.config.envs]]`
+
+Injects environment variables from existing Kubernetes ConfigMap keys.
+
+```toml
+[[cloud.config.envs]]
+name = "DB_URL"
+key_ref = "database_url"
+config_name = "app-config"
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No | Name of the environment variable in the container. Defaults to the value of `key_ref`. |
+| `key_ref` | string | Yes | Key inside the referenced ConfigMap. |
+| `config_name` | string | Yes | Name of the Kubernetes ConfigMap to read from. |
+
+## `[[cloud.secret.envs]]`
+
+Injects environment variables from existing Kubernetes Secret keys.
+
+```toml
+[[cloud.secret.envs]]
+name = "DB_PASSWORD"
+key_ref = "database_password"
+secret_name = "app-secrets"
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No | Name of the environment variable in the container. Defaults to the value of `key_ref`. |
+| `key_ref` | string | Yes | Key inside the referenced Secret. |
+| `secret_name` | string | Yes | Name of the Kubernetes Secret to read from. |
+
 ## `[[cloud.deployment.storage.volumes]]`
 
 Declares persistent volume claims for stateful workloads.
@@ -156,17 +236,45 @@ Declares persistent volume claims for stateful workloads.
 ```toml
 [[cloud.deployment.storage.volumes]]
 name = "data-volume"
-mountPath = "/data"
-readOnly = false
+local_path = "/home/ballerina/data"
 size = "5Gi"
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Name of the persistent volume claim. |
-| `mountPath` | string | Yes | Container path where the volume is mounted. |
-| `readOnly` | boolean | No | Whether the volume is mounted as read-only. Defaults to `false`. |
+| `local_path` | string | Yes | Absolute container path where the volume is mounted. |
 | `size` | string | No | Requested storage size (e.g., `"1Gi"`, `"500Mi"`). |
+
+## `[settings]`
+
+Controls build-level behaviour for artifact generation.
+
+```toml
+[settings]
+singleYAML = true
+buildImage = true
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `singleYAML` | bool | `true` | When `true`, all Kubernetes resources are written into a single YAML file. |
+| `buildImage` | bool | `true` | When `false`, skips Docker image build and only generates Kubernetes YAML artifacts. |
+
+## `[graalvm.builder]`
+
+Customises the GraalVM native-image build stage. Only relevant when building with `--cloud=k8s` and a GraalVM toolchain.
+
+```toml
+[graalvm.builder]
+base = "ghcr.io/graalvm/native-image-community:21-muslib-ol9"
+buildCmd = "native-image -jar app.jar -o app --no-fallback"
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `base` | string | `"ghcr.io/graalvm/native-image-community:21-ol9"` | Builder image used for the native compilation stage. |
+| `buildCmd` | string | Generated | Full native-image command. Override only when the generated command needs custom flags not expressible via `graalvm.buildArgs`. |
 
 ## Complete example
 
@@ -177,31 +285,39 @@ name = "order-service"
 tag = "v1.2.0"
 
 [cloud.deployment]
+replicas = 1
 min_memory = "256Mi"
 max_memory = "512Mi"
 min_cpu = "200m"
 max_cpu = "1000m"
 
 [cloud.deployment.autoscaling]
+enable = true
 min_replicas = 2
 max_replicas = 10
 cpu = 60
+memory = 80
 
 [cloud.deployment.probes.liveness]
 port = 9091
 path = "/probes/healthz"
-initialDelaySeconds = 30
-periodSeconds = 10
 
 [cloud.deployment.probes.readiness]
 port = 9091
 path = "/probes/readyz"
-initialDelaySeconds = 15
-periodSeconds = 5
 
 [[cloud.config.files]]
 file = "./Config.toml"
 
 [[cloud.config.secrets]]
 file = "./Secret.toml"
+
+[[cloud.deployment.storage.volumes]]
+name = "data-volume"
+local_path = "/home/ballerina/data"
+size = "5Gi"
+
+[settings]
+singleYAML = true
+buildImage = true
 ```

--- a/en/docs/reference/config/cloud-toml.md
+++ b/en/docs/reference/config/cloud-toml.md
@@ -83,7 +83,7 @@ internal_domain_name = "order-service.internal"
 
 ## `[cloud.deployment.autoscaling]`
 
-Configures horizontal pod autoscaling for Kubernetes deployments. HPA is enabled by default when a `PodAutoscalerModel` is present.
+Configures horizontal pod autoscaling for Kubernetes deployments. HPA is enabled by default unless `enable = false` is set.
 
 ```toml
 [cloud.deployment.autoscaling]


### PR DESCRIPTION
## Summary

Corrected the `Cloud.toml` reference page by cross-checking every field against the `module-ballerina-c2c` source (`CloudTomlResolver.java`, `DeploymentModel.java`, `HPAHandler.java`, `PodAutoscalerModel.java`, `DockerModel.java`, `DockerGenConstants.java`).

**Errors fixed:**
- `container.image.base` default: `"ballerina/jvm-runtime:2.0"` → `"ballerina/jvm-runtime:3.1"`
- `cloud.deployment.max_memory` default: `"256Mi"` → `"512Mi"`
- `cloud.deployment.min_cpu` default: `"500m"` → `"200m"`
- `cloud.deployment.storage.volumes`: field `mountPath` → `local_path` (the wrong name was silently ignored); removed undocumented `readOnly` field
- Probes: removed `initialDelaySeconds` and `periodSeconds` as configurable fields (they are not read from TOML); added note that `initialDelaySeconds` is hardcoded to `30`
- `cloud.deployment.autoscaling.memory` default: `80` → `0` (memory scaling is disabled by default)
- Removed non-existent `container.image.user.run_as` field

**Missing sections added:**
- `[[container.copy.files]]` — copy files into the container image
- `container.image.entrypoint` field
- `cloud.deployment.replicas` and `cloud.deployment.internal_domain_name` fields
- `cloud.deployment.autoscaling.enable` field
- `[[cloud.config.maps]]` — arbitrary ConfigMap file mounts with `file` and `mount_dir`
- `[[cloud.secret.files]]` — arbitrary Secret file mounts with `file` and `mount_dir`
- `[[cloud.config.envs]]` — inject env vars from ConfigMap keys
- `[[cloud.secret.envs]]` — inject env vars from Secret keys
- `[settings]` — `singleYAML`, `buildImage`
- `[graalvm.builder]` — `base`, `buildCmd`

## Test plan
- [ ] Verify rendered page on staging
- [ ] Confirm field names match `module-ballerina-c2c` source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloud.toml configuration reference with new container `base` field and enhanced autoscaling settings including `enable` flag with updated defaults
  * Fixed probe configuration—`initialDelaySeconds` now hardcoded to 30 seconds
  * Added new config and secret mapping sections for enhanced configuration management
  * Updated persistent storage volume configuration format
  * Refreshed complete configuration example with latest schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->