### PR TITLE
Fix ICP port references in manage/icp docs

### DIFF
--- a/en/docs/manage/icp/install-icp.md
+++ b/en/docs/manage/icp/install-icp.md
@@ -50,13 +50,14 @@ evaluation and development only.
 
 All configuration lives in `conf/deployment.toml`. The defaults work
 out of the box for local evaluation — ICP will start with the embedded H2
-database, listen on `https://localhost:9445`, and create an `admin` user.
+database, listen on `https://localhost:9446`, and create an `admin` user.
 
 ### Essential Settings
 
 | Setting                  | Default                  | Description                              |
 | ------------------------ | ------------------------ | ---------------------------------------- |
-| `serverPort`             | `9445`                   | HTTPS port for the console and API       |
+| `serverPort`             | `9446`                   | HTTPS port for the console and API       |
+| `runtimeListenerPort`    | `9445`                   | HTTPS port for runtime heartbeat connections |
 | `serverHost`             | `0.0.0.0`                | Bind address                             |
 | `logLevel`               | `INFO`                   | `DEBUG`, `INFO`, `WARN`, or `ERROR`      |
 | `frontendJwtHMACSecret`  | (default key)            | JWT signing secret — change in production |
@@ -117,10 +118,9 @@ The ICP config file ships with `opensearchUrl`, `opensearchUsername`, and `opens
 
 ### Reverse Proxy
 
-ICP serves the console, API, and runtime listener on a single HTTPS port
-(`9445` by default). To expose ICP through a reverse proxy:
+ICP serves the console and API on port `9446` by default. To expose ICP through a reverse proxy:
 
-1. Point the proxy at `https://<icp-host>:9445` (the backend is HTTPS with a
+1. Point the proxy at `https://<icp-host>:9446` (the backend is HTTPS with a
    self-signed certificate, so configure the proxy to trust it or skip
    verification for the upstream).
 
@@ -159,18 +159,18 @@ bin\icp.bat
 ```
 
 The server logs its startup to the console. Once you see the listener ready
-message, ICP is available at `https://localhost:9445`.
+message, ICP is available at `https://localhost:9446`.
 
 **Note:** ICP ships with a self-signed certificate. Your browser will show a
 security warning on first visit — accept it to proceed.
 
 ## Sign In
 
-Navigate to `https://<host>:9445/login`. Enter username `admin` and password
+Navigate to `https://<host>:9446/login`. Enter username `admin` and password
 `admin`, then click **Sign In**.
 
 After login the browser redirects to the organization home at
-`https://<host>:9445/organizations/default`.
+`https://<host>:9446/organizations/default`.
 
 **Warning:** Change the default admin password immediately via **Access-control**
 > **Users** > **Reset Password**. See [Access Control](access-control.md) for

--- a/en/docs/manage/icp/manage-environments.md
+++ b/en/docs/manage/icp/manage-environments.md
@@ -32,7 +32,7 @@ The Environments page shows a table with columns:
 A search bar and **+ Create** button appear at the top. Pagination controls sit
 at the bottom.
 
-URL pattern: `https://<host>:9445/organizations/default/environments`
+URL pattern: `https://<host>:9446/organizations/default/environments`
 
 ## Create an Environment
 

--- a/en/docs/manage/icp/manage-projects.md
+++ b/en/docs/manage/icp/manage-projects.md
@@ -19,7 +19,7 @@ Each card shows:
 
 A search bar filters projects by name. A **+ Create** button sits at top-right.
 
-URL pattern: `https://<host>:9445/organizations/default`
+URL pattern: `https://<host>:9446/organizations/default`
 
 ## Create a Project
 

--- a/en/docs/manage/icp/observability-setup.md
+++ b/en/docs/manage/icp/observability-setup.md
@@ -412,7 +412,7 @@ For plain HTTP OpenSearch (no TLS), use `http://` and drop `-k`.
 
 ### Check ICP Console
 
-1. Log into the ICP Console at `https://<icp-host>:9445`.
+1. Log into the ICP Console at `https://<icp-host>:9446`.
 2. Navigate to **Projects → \<project\> → Components → \<component\>**.
 3. The component overview shows the service endpoints and environment cards with runtime status.
 4. Click the **Logs** icon in the sidebar (📋) — you should see runtime log entries with timestamps, log levels, and messages. Use the environment, level, and time range filters to narrow results.


### PR DESCRIPTION
## Summary

- Port `9446` is the user-facing HTTPS port (console, GraphQL, auth, observability APIs) — corrected in all user-facing URLs across `install-icp.md`, `manage-projects.md`, `manage-environments.md`, and `observability-setup.md`
- Port `9445` is for runtime heartbeat connections only — runtime-facing references in `connect-runtime.md` and `mi-profile/` were left unchanged
- Added `runtimeListenerPort` (default `9445`) to the Essential Settings table in `install-icp.md` to document both ports explicitly

## Test plan

- [ ] Verify `serverPort` default in `install-icp.md` Essential Settings shows `9446`
- [ ] Verify `runtimeListenerPort` row with `9445` is present in the same table
- [ ] Verify all console/login URLs in `install-icp.md` use port `9446`
- [ ] Verify URL patterns in `manage-projects.md` and `manage-environments.md` use `9446`
- [ ] Verify `observability-setup.md` console login URL uses `9446`
- [ ] Confirm `connect-runtime.md` and `mi-profile/connect-runtime-mi.md` still reference `9445` for runtime connections