### PR TITLE
Refactor OpenAPI tool documentation and examples

### DIFF
--- a/en/docs/develop/tools/integration-tools/openapi-tool.md
+++ b/en/docs/develop/tools/integration-tools/openapi-tool.md
@@ -48,9 +48,6 @@ bal openapi -i openapi.yaml --mode service
 
 # Specify output directory
 bal openapi -i openapi.yaml --mode service -o generated/
-
-# Generate from a remote URL
-bal openapi -i https://petstore3.swagger.io/api/v3/openapi.json --mode service
 ```
 
 ### Generated service structure
@@ -153,8 +150,8 @@ Create a type-safe HTTP client that wraps all API operations defined in the spec
 # Generate a client connector
 bal openapi -i openapi.yaml --mode client
 
-# Generate with a specific client class name
-bal openapi -i openapi.yaml --mode client --client-methods resource
+# Generate client with remote methods
+bal openapi -i openapi.yaml --mode client --client-methods remote
 ```
 
 ### Using the generated client
@@ -172,11 +169,11 @@ final api:Client orderClient = check new (apiUrl, {
 
 function getOrders(string? status) returns api:Order[]|error {
     // The client method name matches the operationId from the spec
-    return check orderClient->getOrders(status = status);
+    return orderClient->getOrders(status = status);
 }
 
 function createOrder(api:OrderRequest req) returns api:Order|error {
-    return check orderClient->createOrder(req);
+    return orderClient->createOrder(req);
 }
 ```
 
@@ -191,7 +188,7 @@ bal openapi -i openapi.yaml
 
 # This creates both:
 #   openapi_service.bal  -- Service stub
-#   openapi_client.bal   -- Client connector
+#   client.bal           -- Client connector
 #   types.bal            -- Shared types
 ```
 
@@ -216,10 +213,13 @@ Generate an OpenAPI specification from an existing Ballerina HTTP service:
 
 ```bash
 # Export OpenAPI spec from a Ballerina project
-bal openapi -i service.bal --mode export
+bal openapi -i service.bal
+
+# Export as a JSON file
+bal openapi -i service.bal --json
 
 # Export to a specific file
-bal openapi -i service.bal --mode export -o api-spec/openapi.yaml
+bal openapi -i service.bal -o api-spec/
 ```
 
 Given this service:
@@ -244,7 +244,7 @@ The tool produces an OpenAPI YAML describing the paths, request/response schemas
 | `bal openapi -i <spec>` | Generate service and client from spec |
 | `bal openapi -i <spec> --mode service` | Generate service only |
 | `bal openapi -i <spec> --mode client` | Generate client only |
-| `bal openapi -i <service.bal> --mode export` | Export OpenAPI from service |
+| `bal openapi -i <service.bal>` | Export OpenAPI from service |
 | `-o <dir>` | Output directory |
 | `--nullable` | Make fields nullable by default |
 | `--client-methods resource` | Use resource methods in client |
@@ -271,19 +271,33 @@ bal openapi -i openapi.yaml --mode client --operations getOrders,createOrder
 bal openapi -i openapi.yaml --nullable
 ```
 
-## Workflow example
+## Workflow examples
 
-A typical workflow for building an API integration:
+**Connecting to an external API**
 
-1. **Obtain the OpenAPI spec** from the API provider.
-2. **Generate the client**: `bal openapi -i partner-api.yaml --mode client`
-3. **Write integration logic** using the generated client types.
-4. **Generate your own service**: `bal openapi -i my-api.yaml --mode service`
-5. **Implement the service** resource functions with your integration logic.
-6. **Export your spec**: `bal openapi -i service.bal --mode export` to share with consumers.
+If the API provider supplies an OpenAPI spec, generate a type-safe client from it — no need to manually configure endpoints, methods, or request/response types. Everything is inferred from the spec. Without this, you would fall back to a generic HTTP connector and handle all of that yourself.
+
+1. Obtain the OpenAPI spec from the API provider.
+2. Generate the client: `bal openapi -i partner-api.yaml --mode client`
+3. Use the generated client and types in your integration logic.
+
+**Contract-first service design**
+
+Design your API as an OpenAPI spec first, then generate service stubs from it. Fill in the implementation knowing you cannot drift from the agreed contract.
+
+1. Author your OpenAPI spec.
+2. Generate service stubs: `bal openapi -i my-api.yaml --mode service`
+3. Implement the generated resource functions.
+
+**Publishing your API**
+
+Once your service is built, export its OpenAPI specification and share it with consumers. They can then use it to generate their own type-safe clients, just as you would when connecting to an external API.
+
+1. Export the spec from your service: `bal openapi -i service.bal`
+2. Share the generated spec with your API consumers.
 
 ## What's next
 
 - [GraphQL Tool](graphql-tool.md) -- Generate GraphQL services from SDL schemas
 - [gRPC Tool](grpc-tool.md) -- Generate gRPC services from Protocol Buffer definitions
-- [Visual Flow Designer](/docs/develop/design-logic/flow-designer) -- Build logic visually on top of generated stubs
+- [Visual Flow Designer](/docs/develop/design-logic/visual-flow-designer) -- Build logic visually on top of generated stubs


### PR DESCRIPTION
## Purpose

Updated commands and examples for OpenAPI tool usage, including client generation and service export. Removed outdated comments and clarified client method options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `bal openapi` tool documentation with refined command examples for generating services/clients and exporting OpenAPI definitions
  * Improved code snippet examples for better clarity on OpenAPI operations
  * Expanded workflow examples section with more detailed guidance
  * Updated command reference table, generated client filenames documentation, and related navigation links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->