### PR TITLE
docs: add Ballerina example links to built-in connector docs

### DIFF
--- a/en/docs/connectors/catalog/built-in/email/example.md
+++ b/en/docs/connectors/catalog/built-in/email/example.md
@@ -98,3 +98,9 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/email_connector_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/email_connector_sample)
+
+## More code examples
+
+The `Email` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-email/tree/master/examples), covering SMTP email sending and message configuration use cases.
+
+1. [Gmail SMTP client](https://github.com/ballerina-platform/module-ballerina-email/tree/master/examples/gmail-smtp-client) - Send email through Gmail SMTP using the Ballerina Email connector.

--- a/en/docs/connectors/catalog/built-in/ftp/example.md
+++ b/en/docs/connectors/catalog/built-in/ftp/example.md
@@ -237,3 +237,9 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/ftp_trigger_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/ftp_trigger_sample)
+
+## More code examples
+
+The `FTP` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-ftp/tree/master/examples), covering FTP file transfer and file-processing use cases.
+
+1. [COVID-19 stat publisher](https://github.com/ballerina-platform/module-ballerina-ftp/tree/master/examples/covid19-stat-publisher) - Process files from an FTP location and publish extracted COVID-19 statistics.

--- a/en/docs/connectors/catalog/built-in/graphql/example.md
+++ b/en/docs/connectors/catalog/built-in/graphql/example.md
@@ -230,3 +230,15 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/graphql_trigger_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/graphql_trigger_sample)
+
+## More code examples
+
+The `GraphQL` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-graphql/tree/master/examples), covering GraphQL APIs, queries, mutations, subscriptions, and integration use cases.
+
+1. [Snowtooth](https://github.com/ballerina-platform/module-ballerina-graphql/tree/master/examples/snowtooth) - Implement the popular Snowtooth GraphQL API using Ballerina GraphQL services.
+
+2. [Star Wars](https://github.com/ballerina-platform/module-ballerina-graphql/tree/master/examples/starwars) - Build a GraphQL API based on the Star Wars domain model with queryable resources.
+
+3. [News Alerts](https://github.com/ballerina-platform/module-ballerina-graphql/tree/master/examples/news_alerts) - Create a news alert GraphQL API with real-time updates using GraphQL subscriptions.
+
+4. [GitHub Issue Tracker](https://github.com/ballerina-platform/module-ballerina-graphql/tree/master/examples/simple_github_issue_tracker) - Implement a custom GitHub issue tracker GraphQL API with integration scenarios and subscriptions.

--- a/en/docs/connectors/catalog/built-in/grpc/example.md
+++ b/en/docs/connectors/catalog/built-in/grpc/example.md
@@ -96,3 +96,15 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/grpc_connector_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/grpc_connector_sample)
+
+## More code examples
+
+The `gRPC` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-grpc/tree/master/examples), covering gRPC services, clients, streaming, compression, and microservice use cases.
+
+1. [Asynchronous streaming](https://github.com/ballerina-platform/module-ballerina-grpc/tree/master/examples/async-streaming) - Implement asynchronous gRPC streaming with separate client and server components.
+
+2. [Online boutique microservice](https://github.com/ballerina-platform/module-ballerina-grpc/tree/master/examples/online-boutique-microservice) - Build a microservice-based online boutique sample using gRPC services and generated protobuf contracts.
+
+3. [Program analyzer](https://github.com/ballerina-platform/module-ballerina-grpc/tree/master/examples/program-analyzer) - Explore gRPC client and server communication with compression enabled.
+
+4. [Route guide](https://github.com/ballerina-platform/module-ballerina-grpc/tree/master/examples/route-guide) - Learn common gRPC patterns using a route guide service with unary and streaming RPC interactions.

--- a/en/docs/connectors/catalog/built-in/http/example.md
+++ b/en/docs/connectors/catalog/built-in/http/example.md
@@ -199,3 +199,15 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/http_trigger_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/http_trigger_sample)
+
+## More code examples
+
+The `HTTP` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-http/tree/master/examples), covering HTTP services, clients, security, REST API design, and streaming use cases.
+
+1. [Ballerina Secure Token Service (STS)](https://github.com/ballerina-platform/module-ballerina-http/tree/master/examples/ballerina-sts) - Implement a secure token service that demonstrates HTTP service security and token-based access flows.
+
+2. [Pet Clinic REST API](https://github.com/ballerina-platform/module-ballerina-http/tree/master/examples/petclinic) - Build a REST API for a pet clinic application using HTTP services, resources, and data persistence.
+
+3. [Server-sent events](https://github.com/ballerina-platform/module-ballerina-http/tree/master/examples/server-sent-events) - Explore server-sent event examples for streaming updates from an HTTP service to clients.
+
+4. [Snowpeak REST API](https://github.com/ballerina-platform/module-ballerina-http/tree/master/examples/snowpeak) - Learn REST API design patterns using an HTTP service and client implementation.

--- a/en/docs/connectors/catalog/built-in/mqtt/example.md
+++ b/en/docs/connectors/catalog/built-in/mqtt/example.md
@@ -212,3 +212,9 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mqtt_trigger_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/mqtt_trigger_sample)
+
+## More code examples
+
+The `MQTT` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-mqtt/tree/main/examples), covering MQTT publish-subscribe messaging and IoT-style event flows.
+
+1. [Temperature sensor](https://github.com/ballerina-platform/module-ballerina-mqtt/tree/main/examples/temperature-sensor) - Implement a temperature sensor scenario using MQTT topics and message publishing.

--- a/en/docs/connectors/catalog/built-in/tcp/example.md
+++ b/en/docs/connectors/catalog/built-in/tcp/example.md
@@ -191,3 +191,11 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/tcp_trigger_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/tcp_trigger_sample)
+
+## More code examples
+
+The `TCP` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-tcp/tree/master/examples), covering TCP clients, services, and socket-based messaging use cases.
+
+1. [HTTP client server](https://github.com/ballerina-platform/module-ballerina-tcp/tree/master/examples/http-client-server) - Build a simple HTTP-style client and server over TCP connections.
+
+2. [TCP chat server](https://github.com/ballerina-platform/module-ballerina-tcp/tree/master/examples/tcp-chat-server) - Implement a chat server using TCP socket communication.

--- a/en/docs/connectors/catalog/built-in/udp/example.md
+++ b/en/docs/connectors/catalog/built-in/udp/example.md
@@ -81,3 +81,9 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/udp_connector_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/udp_connector_sample)
+
+## More code examples
+
+The `UDP` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-udp/tree/main/examples), covering UDP datagram communication and lightweight network services.
+
+1. [Simple file server](https://github.com/ballerina-platform/module-ballerina-udp/tree/main/examples/simple-file-server) - Implement a simple file server using UDP datagram-based communication.

--- a/en/docs/connectors/catalog/built-in/websocket/example.md
+++ b/en/docs/connectors/catalog/built-in/websocket/example.md
@@ -91,3 +91,13 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/websocket_connector_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/websocket_connector_sample)
+
+## More code examples
+
+The `WebSocket` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-websocket/tree/main/examples), covering WebSocket services, clients, and real-time messaging use cases.
+
+1. [Chat application](https://github.com/ballerina-platform/module-ballerina-websocket/tree/main/examples/chat-application) - Build a real-time chat application using WebSocket client and service interactions.
+
+2. [Taxi service management](https://github.com/ballerina-platform/module-ballerina-websocket/tree/main/examples/taxi-service-management) - Implement a taxi-service management scenario with real-time WebSocket communication.
+
+3. [Tic-tac-toe](https://github.com/ballerina-platform/module-ballerina-websocket/tree/main/examples/tic-tac-toe) - Create an interactive tic-tac-toe game using bidirectional WebSocket messaging.

--- a/en/docs/connectors/catalog/built-in/websub/example.md
+++ b/en/docs/connectors/catalog/built-in/websub/example.md
@@ -96,3 +96,13 @@ Try this sample in WSO2 Integration Platform.
 [![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/websub_connector_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/websub_connector_sample)
+
+## More code examples
+
+The `WebSub Hub` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerina-websubhub/tree/main/examples), covering WebSub hub implementations and publish-subscribe delivery patterns.
+
+1. [In-memory hub](https://github.com/ballerina-platform/module-ballerina-websubhub/tree/main/examples/in-memory-hub) - Implement a WebSub hub that stores subscription state in memory.
+
+2. [JMS WebSub hub](https://github.com/ballerina-platform/module-ballerina-websubhub/tree/main/examples/jms-websubhub) - Build a WebSub hub backed by JMS-based message delivery.
+
+3. [Kafka hub](https://github.com/ballerina-platform/module-ballerina-websubhub/tree/main/examples/kafka-hub) - Implement a WebSub hub backed by Kafka-based event distribution.


### PR DESCRIPTION
## Purpose
Improve built-in connector example documentation by linking readers to additional Ballerina Platform sample projects.

## Goals
Add “More code examples” sections to built-in connector example pages so users can discover related, working sample implementations from the relevant Ballerina module repositories.

## Approach
Updated the built-in connector `example.md` files to append a `More code examples` section with links to verified GitHub examples.

Updated connectors:
- HTTP
- gRPC
- GraphQL
- FTP
- WebSocket
- UDP
- TCP
- MQTT
- Email
- WebSub Hub

All links were verified against GitHub and returned `200 OK`.

## User stories
As a WSO2 Integrator user, I want each built-in connector example page to link to additional practical Ballerina samples so that I can learn more usage patterns beyond the basic walkthrough.

## Release note
Added additional Ballerina code example links to built-in connector documentation pages.

## Documentation
This PR updates product documentation directly under `en/docs/connectors/catalog/built-in/**/example.md`.

## Training
N/A. This change only updates connector documentation links and does not affect training content.

## Certification
N/A. This documentation-only change does not introduce new product behavior or certification exam impact.

## Marketing
N/A. This is a documentation enhancement and does not require marketing content.

## Automation tests
- Unit tests  
  N/A. Documentation-only change.

- Integration tests  
  N/A. Documentation-only change.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no, not applicable for documentation-only changes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Added links to additional Ballerina Platform sample repositories for built-in connectors, including examples for HTTP, gRPC, GraphQL, FTP, WebSocket, UDP, TCP, MQTT, Email, and WebSub Hub.

## Related PRs
N/A

## Migrations (if applicable)
N/A. No migration impact.

## Test environment
Documentation link verification was performed locally on macOS. All added GitHub example links returned `200 OK`.

## Learning
Reviewed existing connector documentation patterns that use `More code examples` sections and followed the same style for built-in connector pages. Verified the corresponding Ballerina Platform module repositories and their example directories before adding links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Enhanced connector documentation** with new "More code examples" sections across all built-in connectors (Email, FTP, GraphQL, gRPC, HTTP, MQTT, TCP, UDP, WebSocket, and WebSub), providing direct links to additional real-world implementation examples for easier learning and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->