### PR TITLE
Fix connector example create integration links

### DIFF
--- a/en/docs/connectors/catalog/ai-ml/azure.ai.search.index/example.md
+++ b/en/docs/connectors/catalog/ai-ml/azure.ai.search.index/example.md
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Setting up the Azure AI Search Index integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Azure AI Search Index connector
 

--- a/en/docs/connectors/catalog/ai-ml/azure.ai.search/example.md
+++ b/en/docs/connectors/catalog/ai-ml/azure.ai.search/example.md
@@ -24,7 +24,7 @@ flowchart LR
 
 ## Setting up the Azure AI Search integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Azure AI Search connector
 

--- a/en/docs/connectors/catalog/ai-ml/milvus/example.md
+++ b/en/docs/connectors/catalog/ai-ml/milvus/example.md
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Setting up the Milvus integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Milvus connector
 

--- a/en/docs/connectors/catalog/ai-ml/mistral/example.md
+++ b/en/docs/connectors/catalog/ai-ml/mistral/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the Mistral integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Mistral connector
 

--- a/en/docs/connectors/catalog/ai-ml/openai.audio/example.md
+++ b/en/docs/connectors/catalog/ai-ml/openai.audio/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the OpenAI Audio integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the OpenAI Audio connector
 

--- a/en/docs/connectors/catalog/ai-ml/openai.finetunes/example.md
+++ b/en/docs/connectors/catalog/ai-ml/openai.finetunes/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the OpenAI Fine-Tunes integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the OpenAI Fine-Tunes connector
 

--- a/en/docs/connectors/catalog/ai-ml/openai/example.md
+++ b/en/docs/connectors/catalog/ai-ml/openai/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the OpenAI integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the OpenAI connector
 

--- a/en/docs/connectors/catalog/built-in/email/example.md
+++ b/en/docs/connectors/catalog/built-in/email/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the Email SMTP integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Email SMTP connector
 

--- a/en/docs/connectors/catalog/built-in/ftp/example.md
+++ b/en/docs/connectors/catalog/built-in/ftp/example.md
@@ -31,7 +31,7 @@ flowchart LR
 
 ### Setting up the FTP integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the FTP connector
 
@@ -136,7 +136,7 @@ flowchart LR
 
 ### Setting up the FTP integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the FTP trigger
 

--- a/en/docs/connectors/catalog/built-in/graphql/example.md
+++ b/en/docs/connectors/catalog/built-in/graphql/example.md
@@ -30,7 +30,7 @@ flowchart LR
 
 ### Setting up the GraphQL integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the GraphQL connector
 
@@ -127,7 +127,7 @@ No external service accounts or API keys are required for this trigger type.
 
 ### Setting up the GraphQL Service integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the GraphQL Service trigger
 

--- a/en/docs/connectors/catalog/built-in/grpc/example.md
+++ b/en/docs/connectors/catalog/built-in/grpc/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the gRPC integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the gRPC connector
 

--- a/en/docs/connectors/catalog/built-in/mqtt/example.md
+++ b/en/docs/connectors/catalog/built-in/mqtt/example.md
@@ -30,7 +30,7 @@ flowchart LR
 
 ### Setting up the MQTT integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the MQTT connector
 
@@ -130,7 +130,7 @@ flowchart LR
 
 ### Setting up the MQTT integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the MQTT trigger
 

--- a/en/docs/connectors/catalog/built-in/tcp/example.md
+++ b/en/docs/connectors/catalog/built-in/tcp/example.md
@@ -30,7 +30,7 @@ flowchart LR
 
 ### Setting up the TCP integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the TCP connector
 
@@ -116,7 +116,7 @@ flowchart LR
 
 ### Setting up the TCP integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the TCP trigger
 

--- a/en/docs/connectors/catalog/built-in/udp/example.md
+++ b/en/docs/connectors/catalog/built-in/udp/example.md
@@ -18,7 +18,7 @@ flowchart LR
 
 ## Setting up the UDP integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the UDP connector
 

--- a/en/docs/connectors/catalog/built-in/websocket/example.md
+++ b/en/docs/connectors/catalog/built-in/websocket/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the WebSocket integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the WebSocket connector
 

--- a/en/docs/connectors/catalog/built-in/websub/example.md
+++ b/en/docs/connectors/catalog/built-in/websub/example.md
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Setting up the Websubhub Publisher integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Websubhub Publisher connector
 

--- a/en/docs/connectors/catalog/communication/intercom/connector-overview.md
+++ b/en/docs/connectors/catalog/communication/intercom/connector-overview.md
@@ -50,4 +50,4 @@ Check the issue tracker for open issues that interest you. We look forward to re
 
 - [Setup guide](setup-guide.md) — Create an Intercom app and obtain your access token
 - [Action reference](action-reference.md) — Browse all available operations and sample code
-- [Connectors overview](../../overview.md) — Explore other available connectors
+- [Connectors overview](../../../overview.md) — Explore other available connectors

--- a/en/docs/connectors/catalog/communication/intercom/example.md
+++ b/en/docs/connectors/catalog/communication/intercom/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the Intercom integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Intercom connector
 

--- a/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
+++ b/en/docs/connectors/catalog/communication/twilio/4.0.x/overview.md
@@ -27,13 +27,13 @@ Actions are operations you invoke on Twilio from your integration — sending me
 |--------|---------|
 | `Client` | SMS/MMS messaging, WhatsApp messaging, voice calls, phone number management, account and balance operations, call and message log retrieval |
 
-See the **[Action Reference](action-reference.md)** for the full list of operations, parameters, and sample code for each client.
+See the **[Action Reference](actions.md)** for the full list of operations, parameters, and sample code for each client.
 
 ## Documentation
 
-* **[Setup Guide](setup-guide.md)**: This guide walks you through obtaining the Twilio credentials required to use the Ballerina Twilio connector.
+* **[Setup Guide](../setup-guide.md)**: This guide walks you through obtaining the Twilio credentials required to use the Ballerina Twilio connector.
 
-* **[Action Reference](action-reference.md)**: Full reference for all clients — operations, parameters, return types, and sample code.
+* **[Action Reference](actions.md)**: Full reference for all clients — operations, parameters, return types, and sample code.
 
 ## How to contribute
 

--- a/en/docs/connectors/catalog/communication/twilio/actions.md
+++ b/en/docs/connectors/catalog/communication/twilio/actions.md
@@ -23,7 +23,7 @@ Full Twilio REST API access — messaging, voice calls, phone numbers, recording
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auth` | `AuthTokenConfig|ApiKeyConfig` | Required | Authentication configuration — either Auth Token or API Key based. |
+| `auth` | <code>AuthTokenConfig&#124;ApiKeyConfig</code> | Required | Authentication configuration — either Auth Token or API Key based. |
 | `httpVersion` | `HttpVersion` | `HTTP_2_0` | HTTP protocol version. |
 | `timeout` | `decimal` | `60` | Request timeout in seconds. |
 | `retryConfig` | `RetryConfig` | `()` | Retry configuration for failed requests. |

--- a/en/docs/connectors/catalog/communication/twilio/example.md
+++ b/en/docs/connectors/catalog/communication/twilio/example.md
@@ -148,7 +148,7 @@ flowchart LR
 
 ### Setting up the Twilio integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the Twilio trigger
 

--- a/en/docs/connectors/catalog/communication/twilio/overview.md
+++ b/en/docs/connectors/catalog/communication/twilio/overview.md
@@ -29,14 +29,14 @@ Actions are operations you invoke on Twilio from your integration — sending me
 |--------|---------|
 | `Client` | Messaging (SMS/MMS/WhatsApp), voice calls, phone numbers, recordings, conferences, accounts, usage |
 
-See the **[Action Reference](action-reference.md)** for the full list of operations, parameters, and sample code for each client.
+See the **[Action Reference](actions.md)** for the full list of operations, parameters, and sample code for each client.
 
 ## Documentation
 
 * **[Setup Guide](setup-guide.md)**: This guide walks you through creating a Twilio account and obtaining the credentials required to use the Twilio connector.
 
 
-* **[Action Reference](action-reference.md)**: Full reference for all clients — operations, parameters, return types, and sample code.
+* **[Action Reference](actions.md)**: Full reference for all clients — operations, parameters, return types, and sample code.
 
 * **[Example](example.md)**: Learn how to build and configure an integration using the **Twilio** connector, including connection setup, operation configuration, execution flow, and event-driven trigger setup.
 

--- a/en/docs/connectors/catalog/crm-sales/salesforce/example.md
+++ b/en/docs/connectors/catalog/crm-sales/salesforce/example.md
@@ -150,7 +150,7 @@ flowchart LR
 
 ### Setting up the Salesforce Event Integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the Salesforce Event Integration trigger
 

--- a/en/docs/connectors/catalog/database/mssql/example.md
+++ b/en/docs/connectors/catalog/database/mssql/example.md
@@ -30,7 +30,7 @@ flowchart LR
 
 ### Setting up the MSSQL integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the MSSQL connector
 
@@ -139,7 +139,7 @@ flowchart LR
 
 ### Setting up the MSSQL CDC integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the CDC for Microsoft SQL Server trigger
 

--- a/en/docs/connectors/catalog/database/postgresql/example.md
+++ b/en/docs/connectors/catalog/database/postgresql/example.md
@@ -135,7 +135,7 @@ flowchart LR
 
 ### Setting up the PostgreSQL CDC integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the PostgreSQL CDC trigger
 

--- a/en/docs/connectors/catalog/database/redis/example.md
+++ b/en/docs/connectors/catalog/database/redis/example.md
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Setting up the Redis integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../getting-started/create-integration.md) guide to set up your project first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your project first, then return here to add the connector.
 
 ## Adding the Redis connector
 

--- a/en/docs/connectors/catalog/developer-tools/github/example.md
+++ b/en/docs/connectors/catalog/developer-tools/github/example.md
@@ -140,7 +140,7 @@ flowchart LR
 
 ### Setting up the GitHub integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the GitHub trigger
 

--- a/en/docs/connectors/catalog/messaging/asb/example.md
+++ b/en/docs/connectors/catalog/messaging/asb/example.md
@@ -29,7 +29,7 @@ flowchart LR
 
 ### Setting up the ASB integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the ASB connector
 
@@ -131,7 +131,7 @@ flowchart LR
 
 ### Setting up the ASB MessageReceiver integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the ASB MessageReceiver connector
 
@@ -241,7 +241,7 @@ flowchart LR
 
 ### Setting up the Azure Service Bus integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the Azure Service Bus trigger
 

--- a/en/docs/connectors/catalog/messaging/confluent.cregistry/example.md
+++ b/en/docs/connectors/catalog/messaging/confluent.cregistry/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the Confluent Schema Registry integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Confluent Schema Registry connector
 

--- a/en/docs/connectors/catalog/messaging/gcloud.pubsub/example.md
+++ b/en/docs/connectors/catalog/messaging/gcloud.pubsub/example.md
@@ -24,7 +24,7 @@ flowchart LR
 
 ## Setting up the Pub/Sub integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the Pub/Sub connector
 

--- a/en/docs/connectors/catalog/messaging/java.jms/example.md
+++ b/en/docs/connectors/catalog/messaging/java.jms/example.md
@@ -29,7 +29,7 @@ flowchart LR
 
 ### Setting up the Java JMS integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the Java JMS connector
 
@@ -129,7 +129,7 @@ flowchart LR
 
 ### Setting up the java.jms integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the java.jms connector
 

--- a/en/docs/connectors/catalog/messaging/kafka/example.md
+++ b/en/docs/connectors/catalog/messaging/kafka/example.md
@@ -252,7 +252,7 @@ flowchart LR
 
 ### Setting up the Kafka integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the Kafka trigger
 

--- a/en/docs/connectors/catalog/messaging/nats/example.md
+++ b/en/docs/connectors/catalog/messaging/nats/example.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Setting up the NATS integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ## Adding the NATS connector
 

--- a/en/docs/connectors/catalog/messaging/rabbitmq/example.md
+++ b/en/docs/connectors/catalog/messaging/rabbitmq/example.md
@@ -31,7 +31,7 @@ flowchart LR
 
 ### Setting up the RabbitMQ integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 ### Adding the RabbitMQ connector
 
@@ -130,7 +130,7 @@ flowchart LR
 
 ### Setting up the RabbitMQ integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the RabbitMQ trigger
 

--- a/en/docs/connectors/catalog/messaging/solace/example.md
+++ b/en/docs/connectors/catalog/messaging/solace/example.md
@@ -28,7 +28,7 @@ flowchart LR
 
 #### Setting up the Solace MessageProducer integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 #### Adding the Solace MessageProducer connector
 
@@ -125,7 +125,7 @@ flowchart LR
 
 #### Setting up the Solace MessageConsumer integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the connector.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
 
 #### Adding the Solace MessageConsumer connector
 
@@ -220,7 +220,7 @@ flowchart LR
 
 ### Setting up the Solace integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-new-integration.md) guide to set up your integration first, then return here to add the trigger.
+> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the trigger.
 
 ### Adding the Solace trigger
 


### PR DESCRIPTION
## Purpose
Fix broken “Create a New Integration” links in the connector catalog example guides.

## Goals
Ensure all connector catalog `example.md` files point to the existing Create a New Integration guide.

## Approach
Updated broken relative links in the connector catalog example guides to use the canonical target:

`../../../../develop/create-integrations/create-a-new-integration.md`

This fixes stale targets such as `create-new-integration.md`, `../develop/create-integrations/create-new-integration.md`, and `../getting-started/create-integration.md`.

## Release note
Fixed broken Create a New Integration links in the connector example documentation.

## Documentation
This PR updates product documentation directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "New to WSO2 Integrator?" links across connector example documentation in AI-ML, built-in, communication, CRM, database, developer-tools, and messaging categories to reference the correct integration guide page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->