### PR TITLE
Update Runtime Security doc

### DIFF
--- a/en/docs/deploy-operate/secure/runtime-security.md
+++ b/en/docs/deploy-operate/secure/runtime-security.md
@@ -46,9 +46,9 @@ java -version
 # Ensure JDK 17.0.x or later with latest patch
 ```
 
-## Keystores and truststores
+## Keystores and Truststores
 
-Creating keystores and truststores is covered in detail in [Keystores and truststores](keystore-truststore.md). That page covers:
+Creating keystores and truststores is covered in detail in [Keystores and Truststores](keystore-truststore.md). That page covers:
 
 - Generating keystores and truststores using `keytool`
 - Configuring TLS and mutual TLS for HTTP and gRPC services
@@ -190,7 +190,7 @@ spec:
 
 ## What's next
 
-- [Keystores and truststores](keystore-truststore.md) — Create and configure TLS certificates, keystores, and truststores
+- [Keystores and Truststores](keystore-truststore.md) — Create and configure TLS certificates, keystores, and truststores
 - [Authentication](authentication.md) — Configure authentication for services
-- [API security and rate limiting](api-security-rate-limiting.md) — Secure your API endpoints
-- [Secrets and encryption](secrets-encryption.md) — Manage secrets and encryption
+- [API Security and Rate Limiting](api-security-rate-limiting.md) — Secure your API endpoints
+- [Secrets and Encryption](secrets-encryption.md) — Manage secrets and encryption

--- a/en/docs/deploy-operate/secure/runtime-security.md
+++ b/en/docs/deploy-operate/secure/runtime-security.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 6
 title: Runtime Security
 description: Best practices for securing integrations in WSO2 Integrator at runtime, including JVM hardening, keystores, non-root execution, and network policies.
 keywords: [wso2 integrator, runtime security, jvm hardening, non-root, container security, network policy]

--- a/en/docs/deploy-operate/secure/runtime-security.md
+++ b/en/docs/deploy-operate/secure/runtime-security.md
@@ -1,13 +1,18 @@
 ---
 sidebar_position: 2
 title: Runtime Security
-description: Best practices for securing integrations in WSO2 Integrator at runtime, including JVM hardening, non-root execution, and network policies.
-keywords: [wso2 integrator, runtime security, jvm hardening, non-root, network policy, security]
+description: Best practices for securing integrations in WSO2 Integrator at runtime, including JVM hardening, keystores, non-root execution, and network policies.
+keywords: [wso2 integrator, runtime security, jvm hardening, non-root, container security, network policy]
 ---
 
 # Runtime Security
 
 Securing integrations in WSO2 Integrator at runtime involves hardening the JVM, managing keystores and certificates, running as non-root, and applying network-level controls. This page covers production security best practices.
+
+:::info Prerequisites
+- WSO2 Integrator installed and a working integration ([Install guide](../../get-started/install.md))
+- A target environment: Linux VM, Docker, or Kubernetes cluster
+:::
 
 ## JVM hardening
 
@@ -43,7 +48,7 @@ java -version
 
 ## Keystores and truststores
 
-Creating keystores, truststores is covered in detail in [Keystores and Truststores](keystore-truststore.md). That page covers:
+Creating keystores and truststores is covered in detail in [Keystores and truststores](keystore-truststore.md). That page covers:
 
 - Generating keystores and truststores using `keytool`
 - Configuring TLS and mutual TLS for HTTP and gRPC services

--- a/en/docs/deploy-operate/secure/runtime-security.md
+++ b/en/docs/deploy-operate/secure/runtime-security.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 2
 title: Runtime Security
 description: Best practices for securing integrations in WSO2 Integrator at runtime, including JVM hardening, keystores, non-root execution, and network policies.
 keywords: [wso2 integrator, runtime security, jvm hardening, non-root, container security, network policy]


### PR DESCRIPTION
## Summary
- Apply the Microsoft Style Guide and IA terminology rules to `en/docs/deploy-operate/secure/runtime-security.md`.
- Title-case the page title, H1, page-reference H2 (`Keystores and Truststores`), and What's-next link labels (`API Security and Rate Limiting`, `Secrets and Encryption`).
- Keep generic action subheadings in sentence case (`Disable unnecessary features`, `Non-root execution`, etc.).
- Add a `keywords` frontmatter field and a Prerequisites admonition.
- Set `sidebar_position: 2` for the Secure section.
- Fix grammar in the keystores section ("Creating keystores, truststores" → "Creating keystores and truststores").
- Switch the What's next separators from `--` to `—` (em dash).

## Test plan
- [ ] `npm run typecheck` from `en/` passes
- [ ] `npm run build` from `en/` passes
- [ ] Page renders correctly at `/deploy-operate/secure/runtime-security`
- [ ] All cross-links resolve