### PR TITLE
Update FAQ doc

### DIFF
--- a/en/docs/reference/faq.md
+++ b/en/docs/reference/faq.md
@@ -1,38 +1,24 @@
 ---
 title: FAQ
 description: Frequently asked questions about WSO2 Integrator.
+keywords: [wso2 integrator, faq, frequently asked questions, troubleshooting]
 ---
 
 # FAQ
 
-## General
+## About WSO2 Integrator
 
 ### What is WSO2 Integrator?
 
-WSO2 Integrator is a Ballerina-powered integration platform that combines low-code visual design and pro-code development. It allows developers to build, test, and deploy integrations that connect APIs, databases, messaging systems, SaaS applications, and AI services. The platform includes a VS Code extension with a visual flow designer, a comprehensive connector library, and built-in observability.
+WSO2 Integrator is a Ballerina-powered integration platform that combines low-code visual design and pro-code development. It allows developers to build, test, and deploy integrations that connect APIs, databases, messaging systems, SaaS applications, and AI services. The platform includes a VS Code extension with a visual designer, a comprehensive connector library, and built-in observability.
 
-### How does WSO2 Integrator relate to WSO2 Micro Integrator (MI)?
+### What types of integrations can I build?
 
-WSO2 Integrator is a new Ballerina-based integration platform that offers a low-code visual designer with pro-code parity. WSO2 MI continues to be fully supported as part of the WSO2 Integration Platform, with its own dedicated documentation at [mi.docs.wso2.com](https://mi.docs.wso2.com).
+WSO2 Integrator supports three primary integration types:
 
-The two products take different approaches to integration development:
-
-| | WSO2 Integrator | WSO2 MI |
-|---|---|---|
-| **Language** | Ballerina | XML (Synapse) |
-| **Development** | Code-first with visual designer | XML artifact editing with Integration Studio |
-| **Deployment** | Executable JARs, Docker images | CAR files |
-| **Connectors** | Ballerina Central packages | Synapse connectors |
-
-If you are starting a new project, WSO2 Integrator is the recommended choice. If you have existing MI deployments, see the [Migration from WSO2 MI](/docs/tutorials/migration/from-wso2-mi) guide or continue using MI with its [dedicated documentation](https://mi.docs.wso2.com).
-
-### What version of Ballerina does WSO2 Integrator use?
-
-WSO2 Integrator 1.0.0 is built on Ballerina Swan Lake Update 12 (2201.12.x). The exact distribution version is specified in each project's `Ballerina.toml` file under the `[package].distribution` field.
-
-### Is WSO2 Integrator open source?
-
-WSO2 Integrator builds on Ballerina, which is open source under the Apache 2.0 license. The WSO2 Integrator VS Code extension and tooling are provided by WSO2. Check the WSO2 licensing page for specific license details.
+- **Services:** Network-accessible endpoints (HTTP, GraphQL, gRPC, WebSocket) that respond to incoming requests
+- **Automations:** Scheduled or manually triggered jobs that run without an external request (cron-based, interval-based, or one-time)
+- **Event Handlers:** Reactive integrations triggered by messages from Kafka, RabbitMQ, NATS, MQTT, or other event sources
 
 ### What protocols and standards does WSO2 Integrator support?
 
@@ -46,11 +32,19 @@ WSO2 Integrator supports a wide range of protocols and data formats through Ball
 - **Data formats:** JSON, XML, CSV, YAML, TOML, EDI, HL7/FHIR
 - **Security:** OAuth 2.0, JWT, Basic Auth, mutual TLS
 
+### What version of Ballerina does WSO2 Integrator use?
+
+WSO2 Integrator is built on the Ballerina Swan Lake distribution. The exact distribution version is specified in each project's `Ballerina.toml` file under the `[package].distribution` field. See the [Release Notes](/docs/reference/release-notes) for the version shipped with your installer.
+
+### Is WSO2 Integrator open source?
+
+WSO2 Integrator builds on Ballerina, which is open source under the Apache 2.0 license. The WSO2 Integrator VS Code extension and tooling are provided by WSO2. Check the WSO2 licensing page for specific license details.
+
 ## Development
 
 ### Do I need to know Ballerina to use WSO2 Integrator?
 
-Not to get started. The visual designer handles most common integration scenarios through drag-and-drop configuration. However, learning Ballerina unlocks advanced capabilities such as custom data transformations, complex error handling, and concurrency patterns. The visual designer and code editor sync bidirectionally, so you can switch between modes at any time.
+Not to get started. The visual designer handles most common integration scenarios through visual configuration. However, learning Ballerina unlocks advanced capabilities such as custom data transformations, complex error handling, and concurrency patterns. The visual designer and code editor sync bidirectionally, so you can switch between modes at any time.
 
 ### Can I use existing Ballerina packages?
 
@@ -60,7 +54,7 @@ Yes. Any package published on [Ballerina Central](https://central.ballerina.io) 
 
 WSO2 Integrator provides a VS Code extension that includes:
 
-- Visual flow designer with drag-and-drop interface
+- Visual designer
 - Sequence diagram view
 - Pro-code editor with IntelliSense and type checking
 - Integrated debugger with breakpoints and variable inspection
@@ -85,36 +79,17 @@ Yes. Ballerina has a built-in test framework (`ballerina/test`) that supports:
 
 Run tests with `bal test` and generate reports with `bal test --test-report --code-coverage`.
 
-### How do I handle secrets and sensitive configuration?
+## AI integrations
 
-Use separate configuration files for secrets and reference them via the `BAL_CONFIG_FILES` environment variable. In Kubernetes, mount secrets as files or inject them as environment variables using `BAL_CONFIG_VAR_*` prefixes. Never commit secrets to version control in `Config.toml`. See the [Environment Variables](/docs/reference/config/environment-variables) reference for details.
+### Does WSO2 Integrator support building AI agents and RAG?
 
-## Architecture
+Yes. WSO2 Integrator includes first-class support for AI agents, retrieval-augmented generation (RAG), Model Context Protocol (MCP) servers, and direct LLM calls. See [AI Integrations](/docs/genai/overview) for the full set of building blocks.
 
-### What types of integrations can I build?
+### Which LLM and vector store providers are supported?
 
-WSO2 Integrator supports three primary integration types:
+WSO2 Integrator ships connectors for major LLM providers (OpenAI, Anthropic, Azure OpenAI, Google) and vector stores (Pinecone, Weaviate, in-memory). See the [Connectors catalog](/docs/connectors/catalog/ai-ml/ai-machine-learning) for the current list.
 
-- **Services:** Network-accessible endpoints (HTTP, GraphQL, gRPC, WebSocket) that respond to incoming requests
-- **Automations:** Scheduled or manually triggered jobs that run without an external request (cron-based, interval-based, or one-time)
-- **Event Handlers:** Reactive integrations triggered by messages from Kafka, RabbitMQ, NATS, MQTT, or other event sources
-
-### What is the Integration Control Plane (ICP)?
-
-The ICP is a monitoring and management dashboard for deployed integrations. It provides:
-
-- Real-time metrics (request count, error rate, latency percentiles)
-- Log aggregation and search
-- Artifact discovery (services, listeners, connectors)
-- Integration lifecycle management (activate, deactivate, restart)
-
-See the [ICP API Reference](/docs/reference/api/icp-api) for programmatic access.
-
-### How does concurrency work?
-
-Ballerina uses strands (lightweight threads) managed by its own scheduler. You can run code concurrently using named workers within a function or by starting asynchronous calls with the `start` keyword. Workers can communicate through message passing. The runtime handles strand scheduling and context switching transparently.
-
-## Deployment
+## Deploy and operate
 
 ### Where can I deploy WSO2 Integrator applications?
 
@@ -122,7 +97,7 @@ WSO2 Integrator supports multiple deployment targets:
 
 - **Docker containers:** Generate Dockerfiles and images with `bal build --cloud=docker`
 - **Kubernetes:** Generate K8s manifests with `bal build --cloud=k8s` and configure via `Cloud.toml`
-- **WSO2 Devant:** Deploy to WSO2's managed iPaaS platform
+- **WSO2 Integration Platform:** Deploy to WSO2's managed platform
 - **Bare metal / VM:** Run the executable JAR directly with `bal run` or `java -jar`
 - **GraalVM native:** Build native executables with `bal build --graalvm` for fast startup
 - **Serverless:** Deploy to AWS Lambda or Azure Functions
@@ -141,6 +116,10 @@ Use `Config.toml` for environment-specific values and provide them at deployment
 
 This allows you to use the same built artifact across development, staging, and production by varying only the configuration.
 
+### How do I handle secrets and sensitive configuration?
+
+Use separate configuration files for secrets and reference them via the `BAL_CONFIG_FILES` environment variable. In Kubernetes, mount secrets as files or inject them as environment variables using `BAL_CONFIG_VAR_*` prefixes. Never commit secrets to version control in `Config.toml`. See the [Environment Variables](/docs/reference/config/environment-variables) reference for details.
+
 ### Does WSO2 Integrator support horizontal scaling?
 
 Yes. Ballerina services are stateless by default, making them suitable for horizontal scaling. Configure autoscaling in `Cloud.toml` with `[cloud.deployment.autoscaling]` settings, or use your Kubernetes cluster's HPA (Horizontal Pod Autoscaler) directly.
@@ -156,18 +135,44 @@ WSO2 Integrator supports observability through:
 
 Enable observability by setting `observabilityIncluded = true` in `Ballerina.toml` under `[build-options]`.
 
+### What is the Integration Control Plane (ICP)?
+
+The ICP is a monitoring and management dashboard for deployed integrations. It provides:
+
+- Real-time metrics (request count, error rate, latency percentiles)
+- Log aggregation and search
+- Artifact discovery (services, listeners, connectors)
+- Integration lifecycle management (activate, deactivate, restart)
+
+See the [ICP API Reference](/docs/reference/api/icp-api) for programmatic access.
+
 ## Migration
+
+### How does WSO2 Integrator relate to WSO2 Micro Integrator (MI)?
+
+WSO2 Integrator is a new Ballerina-based integration platform that offers a low-code visual designer with pro-code parity. WSO2 MI continues to be fully supported as part of the WSO2 Integration Platform, with its own dedicated documentation at [mi.docs.wso2.com](https://mi.docs.wso2.com).
+
+The two products take different approaches to integration development:
+
+| | WSO2 Integrator | WSO2 MI |
+|---|---|---|
+| **Language** | Ballerina | XML (Synapse) |
+| **Development** | Code-first with visual designer | XML artifact editing with Integration Studio |
+| **Deployment** | Executable JARs, Docker images | CAR files |
+| **Connectors** | Ballerina Central packages | Synapse connectors |
+
+If you are starting a new project, WSO2 Integrator is the recommended choice. If you have existing MI deployments, see [Coming from WSO2 MI](/docs/tutorials/migration/from-wso2-mi) or continue using MI with its [dedicated documentation](https://mi.docs.wso2.com).
 
 ### Can I migrate from MuleSoft or TIBCO?
 
-Yes. WSO2 provides migration guides and tooling to help transition from other integration platforms. See the [Migration from MuleSoft](/docs/tutorials/migration/from-mulesoft) and [Migration from TIBCO](/docs/tutorials/migration/from-tibco) guides for platform-specific guidance. For migrating from WSO2 MI, see [Coming from WSO2 MI](/docs/tutorials/migration/from-wso2-mi).
+Yes. WSO2 provides migration guides and tooling to help transition from other integration platforms. See [Coming from MuleSoft](/docs/tutorials/migration/coming-from-mulesoft) and [Coming from TIBCO](/docs/tutorials/migration/coming-from-tibco) for platform-specific guidance. For migrating third-party integrations programmatically, see [Migrate third-party integrations](/docs/develop/create-integrations/migrate-third-party-integrations).
 
 ### Can I run WSO2 MI and WSO2 Integrator side by side?
 
-Yes. The two products use different runtimes and can coexist in the same environment. This allows you to adopt WSO2 Integrator for new projects while continuing to run your existing MI deployments. You can also migrate MI integrations incrementally using the [migration tools](/docs/develop/tools/migration-tools/overview). For MI-specific guidance, refer to the [MI documentation](https://mi.docs.wso2.com).
+Yes. The two products use different runtimes and can coexist in the same environment. This allows you to adopt WSO2 Integrator for new projects while continuing to run your existing MI deployments. You can also migrate MI integrations incrementally using [Migrate third-party integrations](/docs/develop/create-integrations/migrate-third-party-integrations). For MI-specific guidance, refer to the [MI documentation](https://mi.docs.wso2.com).
 
 ## What's next
 
-- [Get Started](/docs/get-started/install) -- Install and set up WSO2 Integrator
-- [Build an API Integration](/docs/get-started/build-api-integration) -- Build your first integration
-- [Glossary](/docs/reference/glossary) -- Definitions of key terms
+- [Get Started](/docs/get-started/install) — Install and set up WSO2 Integrator
+- [Build an API Integration](/docs/get-started/build-api-integration) — Build your first integration
+- [Glossary](/docs/reference/glossary) — Definitions of key terms

--- a/en/docs/reference/faq.md
+++ b/en/docs/reference/faq.md
@@ -151,20 +151,7 @@ See the [ICP API Reference](/docs/reference/api/icp-api) for programmatic access
 
 ## Migration
 
-### How does WSO2 Integrator relate to WSO2 Micro Integrator (MI)?
-
-WSO2 Integrator is a new Ballerina-based integration platform that offers a low-code visual designer with pro-code parity. WSO2 MI continues to be fully supported as part of the WSO2 Integration Platform, with its own dedicated documentation at [mi.docs.wso2.com](https://mi.docs.wso2.com).
-
-The two products take different approaches to integration development:
-
-| | WSO2 Integrator | WSO2 MI |
-|---|---|---|
-| **Language** | Ballerina | XML (Synapse) |
-| **Development** | Code-first with visual designer | XML artifact editing with Integration Studio |
-| **Deployment** | Executable JARs, Docker images | CAR files |
-| **Connectors** | Ballerina Central packages | Synapse connectors |
-
-If you are starting a new project, WSO2 Integrator is the recommended choice. If you have existing MI deployments, see [Coming from WSO2 MI](/docs/tutorials/migration/from-wso2-mi) or continue using MI with its [dedicated documentation](https://mi.docs.wso2.com).
+<!-- TODO: Add an MI positioning question (how WSO2 Integrator relates to WSO2 MI)-->
 
 ### Can I migrate from MuleSoft or TIBCO?
 

--- a/en/docs/reference/faq.md
+++ b/en/docs/reference/faq.md
@@ -10,15 +10,18 @@ keywords: [wso2 integrator, faq, frequently asked questions, troubleshooting]
 
 ### What is WSO2 Integrator?
 
-WSO2 Integrator is a Ballerina-powered integration platform that combines low-code visual design and pro-code development. It allows developers to build, test, and deploy integrations that connect APIs, databases, messaging systems, SaaS applications, and AI services. The platform includes a VS Code extension with a visual designer, a comprehensive connector library, and built-in observability.
+WSO2 Integrator is a Ballerina-powered integration platform that combines low-code visual design and pro-code development. It allows developers to build, test, and deploy integrations that connect APIs, databases, messaging systems, SaaS applications, and AI services. The WSO2 Integrator IDE offers a visual designer and a code editor with full bidirectional sync, alongside a comprehensive connector library and built-in observability.
 
-### What types of integrations can I build?
+### How can integrations be triggered?
 
-WSO2 Integrator supports three primary integration types:
+WSO2 Integrator supports several entry points for kicking off an integration:
 
 - **Services:** Network-accessible endpoints (HTTP, GraphQL, gRPC, WebSocket) that respond to incoming requests
 - **Automations:** Scheduled or manually triggered jobs that run without an external request (cron-based, interval-based, or one-time)
-- **Event Handlers:** Reactive integrations triggered by messages from Kafka, RabbitMQ, NATS, MQTT, or other event sources
+- **Event handlers:** Reactive integrations triggered by messages from Kafka, RabbitMQ, NATS, MQTT, or other event sources
+- **File-driven flows:** Integrations triggered by changes on a local file system or an SFTP/FTP location
+
+Any of these entry points can use AI agents, data transformations, and connectors to build any integration pattern.
 
 ### What protocols and standards does WSO2 Integrator support?
 
@@ -38,13 +41,13 @@ WSO2 Integrator is built on the Ballerina Swan Lake distribution. The exact dist
 
 ### Is WSO2 Integrator open source?
 
-WSO2 Integrator builds on Ballerina, which is open source under the Apache 2.0 license. The WSO2 Integrator VS Code extension and tooling are provided by WSO2. Check the WSO2 licensing page for specific license details.
+WSO2 Integrator builds on Ballerina, which is open source under the Apache 2.0 license. The WSO2 Integrator IDE and tooling are provided by WSO2. Check the WSO2 licensing page for specific license details.
 
 ## Development
 
 ### Do I need to know Ballerina to use WSO2 Integrator?
 
-Not to get started. The visual designer handles most common integration scenarios through visual configuration. However, learning Ballerina unlocks advanced capabilities such as custom data transformations, complex error handling, and concurrency patterns. The visual designer and code editor sync bidirectionally, so you can switch between modes at any time.
+Not to get started. WSO2 Integrator offers full parity between the visual designer and the code editor, so any integration can be built end-to-end in low-code. Developers already comfortable with Ballerina may find pro-code more familiar for complex flows, but neither mode locks you out of any capability. Changes in one view are instantly reflected in the other.
 
 ### Can I use existing Ballerina packages?
 
@@ -52,7 +55,7 @@ Yes. Any package published on [Ballerina Central](https://central.ballerina.io) 
 
 ### What IDE support is available?
 
-WSO2 Integrator provides a VS Code extension that includes:
+The WSO2 Integrator IDE includes:
 
 - Visual designer
 - Sequence diagram view
@@ -64,7 +67,7 @@ WSO2 Integrator provides a VS Code extension that includes:
 
 ### How do I debug my integrations?
 
-WSO2 Integrator supports standard VS Code debugging. Set breakpoints in either the visual designer or the code editor, then launch the debugger. You can also use remote debugging by running `bal run --debug <port>` and attaching the VS Code debugger to the specified port.
+WSO2 Integrator supports standard breakpoint-based debugging. Set breakpoints in either the visual designer or the code editor, then launch the debugger from the IDE. You can also use remote debugging by running `bal run --debug <port>` and attaching the IDE's debugger to the specified port.
 
 ### Can I write tests for my integrations?
 
@@ -87,7 +90,7 @@ Yes. WSO2 Integrator includes first-class support for AI agents, retrieval-augme
 
 ### Which LLM and vector store providers are supported?
 
-WSO2 Integrator ships connectors for major LLM providers (OpenAI, Anthropic, Azure OpenAI, Google) and vector stores (Pinecone, Weaviate, in-memory). See the [Connectors catalog](/docs/connectors/catalog/ai-ml/ai-machine-learning) for the current list.
+WSO2 Integrator ships connectors for major LLM providers and vector stores. See the [Connectors catalog](/docs/connectors/catalog/ai-ml/ai-machine-learning) for the current list.
 
 ## Deploy and operate
 
@@ -118,7 +121,7 @@ This allows you to use the same built artifact across development, staging, and 
 
 ### How do I handle secrets and sensitive configuration?
 
-Use separate configuration files for secrets and reference them via the `BAL_CONFIG_FILES` environment variable. In Kubernetes, mount secrets as files or inject them as environment variables using `BAL_CONFIG_VAR_*` prefixes. Never commit secrets to version control in `Config.toml`. See the [Environment Variables](/docs/reference/config/environment-variables) reference for details.
+WSO2 Integrator uses `Config.toml` files for runtime configuration. For secrets, keep them in a separate `Config.toml` (or another file referenced via the `BAL_CONFIG_FILES` environment variable) that is not checked into version control. Never commit secret values to git, whether they sit in `Config.toml` or anywhere else. In Kubernetes, mount the secret file from a `Secret`, or inject individual values as environment variables using `BAL_CONFIG_VAR_*` prefixes. See the [Environment Variables](/docs/reference/config/environment-variables) reference for details.
 
 ### Does WSO2 Integrator support horizontal scaling?
 


### PR DESCRIPTION
## Purpose

The FAQ page had several structural and content issues: the Architecture grouping mixed deploy-time concerns (ICP), language internals (concurrency), and product fundamentals (integration types); secrets sat under Development but belong with Deploy & Operate per the IA boundary rule; version-specific Ballerina version numbers will rot; and some links were broken (`from-mulesoft` instead of `coming-from-mulesoft`, etc.).

## Goals

- Regroup questions to mirror the WSO2 Integrator IA sections (About / Develop / AI integrations / Deploy & Operate / Migration).
- Remove or generalize content that goes stale or is too low-level for an FAQ.
- Add an AI integrations section that mirrors the top-level IA section.
- Fix terminology drift and broken cross-links.

## Approach

Single commit on top of `main`. The file goes from 5 sections + 20 questions to 5 sections + 21 questions.

**Sections**
- `## General` → `## About WSO2 Integrator`
- `## Architecture` removed — its questions move to About (integration types) and Deploy and operate (ICP); concurrency removed.
- `## AI integrations` added — two short pointers into `/docs/genai/`.
- `## Deployment` → `## Deploy and operate`.

**Question moves**
- "What types of integrations can I build?" Architecture → About.
- "What is the Integration Control Plane (ICP)?" Architecture → Deploy and operate.
- "How do I handle secrets and sensitive configuration?" Development → Deploy and operate.
- "How does WSO2 Integrator relate to WSO2 MI?" General → Migration.

**Removed**
- "How does concurrency work?" — covered in depth by `/docs/reference/language/concurrency`.

**Added (AI integrations section)**
- "Does WSO2 Integrator support building AI agents and RAG?"
- "Which LLM and vector store providers are supported?"

**Content edits**
- "What version of Ballerina?" Dropped hardcoded `1.0.0` / `Update 12 (2201.12.x)`. Points to `Ballerina.toml` and release notes instead.
- Terminology fixes per `en/content-gen/00-rules.md`: `WSO2 Devant` → `WSO2 Integration Platform`; `iPaaS platform` → `Integration Platform`; `drag-and-drop interface/configuration` → `visual designer`/`visual configuration`; `visual flow designer` → `visual designer`.
- Broken link fixes: `from-mulesoft` → `coming-from-mulesoft`; `from-tibco` → `coming-from-tibco`; non-existent `migration-tools/overview` → `migrate-third-party-integrations`.
- Added `keywords` frontmatter; `What's next` separators switched to em dashes.

## Release note

Restructure the FAQ page to align with the WSO2 Integrator IA: drop the Architecture grouping, add an AI integrations section, move ICP and secrets under Deploy and operate, and fix terminology and broken migration links.

## Documentation

This PR is the documentation update.

## Training

N/A — no training material changes.

## Certification

N/A — no impact on certification exams.

## Marketing

N/A.

## Automation tests

N/A — documentation-only change.

## Security checks

- Followed secure coding standards: yes (markdown only)
- Ran FindSecurityBugs plugin and verified report: N/A (no source code)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples

N/A.

## Migrations (if applicable)

N/A.

## Test environment

Built locally with the Docusaurus 3.9.2 toolchain in `en/`.

## Learning

Used the IA boundary rule (Develop = code on your machine; Deploy & Operate = once it leaves your machine) to decide where secrets and ICP belong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized FAQ with clearer top-level sections covering integration types, ICP overview, and deployment/operation wording (managed platform renamed)
  * Clarified Ballerina distribution/version guidance and linked Release Notes; updated licensing wording
  * Standardized terminology (visual designer, debugging) and developer guidance parity
  * Added AI integrations section (agents, RAG, MCP, direct LLM calls) and supported LLM/vector-store providers
  * Added secrets/sensitive configuration subsection and updated Migration guidance with external migration links

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/325)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->