### PR TITLE
Update troubleshooting doc

### DIFF
--- a/en/docs/reference/appendix/troubleshooting.md
+++ b/en/docs/reference/appendix/troubleshooting.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: Troubleshooting
 description: Troubleshooting guide — common errors, strand dump tool, profiler usage, port conflicts, and dependency issues.
+keywords: [wso2 integrator, troubleshooting, errors, strand dump, profiler, debugging, diagnostics]
 ---
 
 # Troubleshooting
@@ -62,6 +63,31 @@ ERROR: incompatible types: expected 'string', found 'string?'
 | Antivirus scanning build directory | Exclude `target/` directory from real-time scanning |
 | Insufficient memory | Increase JVM heap: `export BAL_JAVA_OPTS="-Xmx2g"` |
 | Cold cache | First build is slower; subsequent builds reuse cached artifacts |
+
+### Version conflicts
+
+**Symptom:** Build fails due to incompatible transitive dependency versions.
+
+```
+ERROR: version conflict for 'ballerina/io': required '1.6.0' by 'ballerinax/kafka' but '1.5.0' by 'ballerinax/rabbitmq'
+```
+
+**Solutions:**
+
+| Approach | Steps |
+|----------|-------|
+| Update all dependencies | Delete `Dependencies.toml`; run `bal build --sticky=false` |
+| Pin a specific version | Add explicit dependency in `Ballerina.toml` with the required version |
+| Check compatibility | Ensure all dependencies target the same Ballerina distribution version |
+| Use dependency override | Add `[[dependency]]` section in `Ballerina.toml` to force a version |
+
+```toml
+# Ballerina.toml - Force a specific dependency version
+[[dependency]]
+org = "ballerina"
+name = "io"
+version = "1.6.0"
+```
 
 ## Runtime errors
 
@@ -147,13 +173,31 @@ http:Client client = check new ("https://api.example.com", {
 });
 ```
 
+### Missing platform dependencies
+
+**Symptom:** Runtime error about missing Java classes or native libraries.
+
+```
+ERROR: java.lang.ClassNotFoundException: com.mysql.cj.jdbc.Driver
+```
+
+**Solutions:**
+
+```toml
+# Add platform-specific Java dependencies in Ballerina.toml
+[[platform.java17.dependency]]
+groupId = "mysql"
+artifactId = "mysql-connector-java"
+version = "8.0.33"
+```
+
 ## Diagnostic tools
 
 ### Strand dump tool
 
 The strand dump tool captures the state of all active strands in a running Ballerina application, similar to a thread dump in Java. It is useful for diagnosing deadlocks, stuck operations, and concurrency issues.
 
-#### Generating a strand dump
+To generate a strand dump, find the process ID and signal the running JVM:
 
 ```bash
 # Find the PID of the running Ballerina process
@@ -165,8 +209,6 @@ kill -SIGTRAP <PID>
 # Alternative: Use bal command
 bal strand-dump <PID>
 ```
-
-#### Strand dump output
 
 The dump shows each strand's status, current function, and call stack:
 
@@ -194,7 +236,7 @@ Waiting: 1
 Blocked: 1
 ```
 
-#### Strand states
+Strand states reported in the dump:
 
 | State | Description |
 |-------|-------------|
@@ -208,7 +250,7 @@ Blocked: 1
 
 The Ballerina profiler identifies performance bottlenecks by recording CPU and memory usage during execution.
 
-#### Running with profiler
+Run the profiler against a Ballerina file or package:
 
 ```bash
 # Profile a Ballerina program
@@ -217,8 +259,6 @@ bal profile <ballerina-file-or-package>
 # Profile with specific options
 bal profile --cpu --memory myservice.bal
 ```
-
-#### Profiler output
 
 The profiler generates an HTML report at `target/profiler/index.html` containing:
 
@@ -242,7 +282,7 @@ bal run -- -Cballerina.log.level=DEBUG
 bal run -- -Cballerina.http.log.level=DEBUG
 ```
 
-#### Log levels
+Available log levels:
 
 | Level | Description | Use Case |
 |-------|-------------|----------|
@@ -253,52 +293,7 @@ bal run -- -Cballerina.http.log.level=DEBUG
 | `DEBUG` | Detailed debug information | Development troubleshooting |
 | `TRACE` | Very detailed trace output | Deep debugging (high overhead) |
 
-## Dependency issues
-
-### Version conflicts
-
-**Symptom:** Build fails due to incompatible transitive dependency versions.
-
-```
-ERROR: version conflict for 'ballerina/io': required '1.6.0' by 'ballerinax/kafka' but '1.5.0' by 'ballerinax/rabbitmq'
-```
-
-**Solutions:**
-
-| Approach | Steps |
-|----------|-------|
-| Update all dependencies | Delete `Dependencies.toml`; run `bal build --sticky=false` |
-| Pin a specific version | Add explicit dependency in `Ballerina.toml` with the required version |
-| Check compatibility | Ensure all dependencies target the same Ballerina distribution version |
-| Use dependency override | Add `[[dependency]]` section in `Ballerina.toml` to force a version |
-
-```toml
-# Ballerina.toml - Force a specific dependency version
-[[dependency]]
-org = "ballerina"
-name = "io"
-version = "1.6.0"
-```
-
-### Missing platform dependencies
-
-**Symptom:** Runtime error about missing Java classes or native libraries.
-
-```
-ERROR: java.lang.ClassNotFoundException: com.mysql.cj.jdbc.Driver
-```
-
-**Solutions:**
-
-```toml
-# Add platform-specific Java dependencies in Ballerina.toml
-[[platform.java17.dependency]]
-groupId = "mysql"
-artifactId = "mysql-connector-java"
-version = "8.0.33"
-```
-
-## VS code extension issues
+## VS Code extension issues
 
 ### Language server not starting
 
@@ -355,15 +350,14 @@ bal clean && bal build
 
 | Resource | URL |
 |----------|-----|
-| WSO2 Integrator Documentation | This documentation site |
 | Ballerina Discord | [discord.gg/ballerinalang](https://discord.gg/ballerinalang) |
 | Ballerina GitHub Issues | [github.com/ballerina-platform/ballerina-lang/issues](https://github.com/ballerina-platform/ballerina-lang/issues) |
 | Stack Overflow | [stackoverflow.com/questions/tagged/ballerina](https://stackoverflow.com/questions/tagged/ballerina) |
 | WSO2 Support | [wso2.com/support/](https://wso2.com/support/) |
 
-## See also
+## What's next
 
-- [System Requirements](system-requirements.md) -- Platform and version requirements
-- [Installation Guide](/docs/get-started/install) -- Installation instructions
-- [Error Codes Reference](/docs/reference/error-codes) -- All error codes with resolution steps
-- [FAQ](/docs/reference/faq) -- Frequently asked questions
+- [System Requirements](system-requirements.md) — Platform and version requirements
+- [Installation Guide](/docs/get-started/install) — Installation instructions
+- [Error Codes Reference](/docs/reference/error-codes) — All error codes with resolution steps
+- [FAQ](/docs/reference/faq) — Frequently asked questions


### PR DESCRIPTION
## Purpose

The troubleshooting page had a misplaced grouping (Dependency issues mixed build-time and runtime symptoms), deep four-level headings under Diagnostic tools, and small style misses (VS Code casing, See also section, `--` separators).

## Approach

- Move Version conflicts under Common build errors and Missing platform dependencies under Runtime errors, where the symptoms actually surface; drop the Dependency issues section.
- Flatten the four-level headings under Diagnostic tools to inline intros.
- Fix VS Code casing in the section heading, add `keywords`, rename See also to What's next with em dashes, and drop the meta documentation row from Getting help.