### PR TITLE
Revamp the EDI data format and tool docs

### DIFF
--- a/en/docs/develop/tools/integration-tools/edi-tool.md
+++ b/en/docs/develop/tools/integration-tools/edi-tool.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 9
 title: EDI Tool
-description: Generate Ballerina types and parsers from EDI schema definitions for B2B data exchange.
+description: Generate Ballerina types and parsers from EDI schema definitions.
 ---
 
 # EDI tool

--- a/en/docs/develop/tools/integration-tools/edi-tool.md
+++ b/en/docs/develop/tools/integration-tools/edi-tool.md
@@ -4,13 +4,69 @@ title: EDI Tool
 description: Generate Ballerina types and parsers from EDI schema definitions for B2B data exchange.
 ---
 
-# EDI Tool
+# EDI tool
 
 The `bal edi` tool generates Ballerina code from EDI (Electronic Data Interchange) schema definitions, enabling B2B integration with trading partners using standards such as X12 and EDIFACT. The generated code includes record types for EDI segments and transaction sets, along with parser and serializer functions that convert between raw EDI text and type-safe Ballerina records.
 
+The EDI tool uses JSON schema files to describe EDI message structures — segments, fields, delimiters, and data types — and generates code from them.
+
+**Sample EDI schema:**
+
+```json
+{
+  "name": "SimpleOrder",
+  "delimiters": {
+    "segment": "~",
+    "field": "*",
+    "component": ":",
+    "repetition": "^"
+  },
+  "segments": [
+    {
+      "code": "HDR",
+      "tag": "header",
+      "minOccurances": 1,
+      "fields": [
+        { "tag": "code" },
+        { "tag": "orderId" },
+        { "tag": "organization" },
+        { "tag": "date" }
+      ]
+    },
+    {
+      "code": "ITM",
+      "tag": "items",
+      "maxOccurances": -1,
+      "fields": [
+        { "tag": "code" },
+        { "tag": "item" },
+        { "tag": "quantity", "dataType": "int" }
+      ]
+    }
+  ]
+}
+```
+
+**Sample EDI:**
+
+```text
+HDR*HDR123*ACME_CORP*20240519~
+ITM*Pen*10~
+ITM*Notebook*5~
+ITM*Eraser*3~
+ITM*Ruler*7~
+ITM*Stapler*2~
+```
+
 ## Prerequisites
 
-The EDI tool is included with the Ballerina distribution:
+Execute the command below to pull the EDI tool from [Ballerina Central](https://central.ballerina.io/).
+
+```bash
+bal tool pull edi
+```
+
+Verify the tool using the following command.
 
 ```bash
 bal edi --help
@@ -18,260 +74,117 @@ bal edi --help
 
 ## Generating code from an EDI schema
 
+Use `codegen` to generate typed Ballerina records and parser functions from a single EDI schema file.
+
 ```bash
-# Generate Ballerina types from an EDI schema
-bal edi -i schema.json -o generated/
-
-# Generate from a specific EDI standard
-bal edi --standard x12 --version 005010 --transaction 850 -o generated/
-
-# Generate a complete EDI package
-bal edi codegen -i edi-schemas/ -o generated_edi/
+bal edi codegen -i path/to/schema.json -o modules/orders/main.bal
 ```
 
-### EDI schema definition
+This generates the following functions in the output file:
 
-EDI schemas are defined in JSON format, describing the structure of segments, elements, and transaction sets:
+- `fromEdiString` — Convert an EDI string to a Ballerina record
+- `toEdiString` — Convert a Ballerina record to an EDI string
+- `getSchema` — Get the EDI schema as an `EdiSchema` object
+- `fromEdiStringWithSchema` — Convert an EDI string to a Ballerina record using a pre-loaded schema
+- `toEdiStringWithSchema` — Convert a Ballerina record to an EDI string using a pre-loaded schema
 
-```json
-{
-    "name": "PurchaseOrder850",
-    "tag": "850",
-    "segments": [
-        {
-            "tag": "ST",
-            "name": "TransactionSetHeader",
-            "elements": [
-                {"name": "transactionSetId", "type": "string"},
-                {"name": "transactionSetControlNumber", "type": "string"}
-            ]
-        },
-        {
-            "tag": "BEG",
-            "name": "BeginningSegment",
-            "elements": [
-                {"name": "purposeCode", "type": "string"},
-                {"name": "orderTypeCode", "type": "string"},
-                {"name": "purchaseOrderNumber", "type": "string"},
-                {"name": "date", "type": "string"}
-            ]
-        },
-        {
-            "tag": "PO1",
-            "name": "LineItem",
-            "maxOccurs": -1,
-            "elements": [
-                {"name": "assignedId", "type": "string"},
-                {"name": "quantity", "type": "int"},
-                {"name": "unitOfMeasure", "type": "string"},
-                {"name": "unitPrice", "type": "float"},
-                {"name": "productId", "type": "string"}
-            ]
-        }
-    ]
-}
-```
-
-### Generated Ballerina types
+It also generates the corresponding Ballerina record types:
 
 ```ballerina
-// Auto-generated from EDI schema
-type PurchaseOrder850 record {|
-    TransactionSetHeader st;
-    BeginningSegment beg;
-    LineItem[] po1 = [];
-    TransactionSetTrailer se;
+public type Header_Type record {|
+   string code = "HDR";
+   string orderId?;
+   string organization?;
+   string date?;
 |};
 
-type TransactionSetHeader record {|
-    string transactionSetId;
-    string transactionSetControlNumber;
+public type Items_Type record {|
+   string code = "ITM";
+   string item?;
+   int? quantity?;
 |};
 
-type BeginningSegment record {|
-    string purposeCode;
-    string orderTypeCode;
-    string purchaseOrderNumber;
-    string date;
-|};
-
-type LineItem record {|
-    string assignedId;
-    int quantity;
-    string unitOfMeasure;
-    float unitPrice;
-    string productId;
-|};
-
-type TransactionSetTrailer record {|
-    int numberOfSegments;
-    string transactionSetControlNumber;
+public type SimpleOrder record {|
+   Header_Type header;
+   Items_Type[] items = [];
 |};
 ```
 
-### Generated parser and serializer
+### Using the generated code
 
-```ballerina
-// Parse raw EDI text to typed record
-public function fromEdiString(string ediText) returns PurchaseOrder850|error {
-    // Auto-generated parsing logic
-}
-
-// Convert typed record to EDI text
-public function toEdiString(PurchaseOrder850 purchaseOrder) returns string|error {
-    // Auto-generated serialization logic
-}
-```
-
-## Using generated EDI code
-
-### Parsing incoming EDI messages
+**Parsing incoming EDI messages:**
 
 ```ballerina
 import ballerina/log;
-import generated_edi as edi;
+import <add-the-project-name>.orders;
 
-function processIncomingPurchaseOrder(string rawEdi) returns error? {
-    // Parse EDI to typed record
-    edi:PurchaseOrder850 po = check edi:fromEdiString(rawEdi);
+function processIncomingOrder(string rawEdi) returns error? {
+    // Parse EDI text into a typed SimpleOrder record
+    orders:SimpleOrder newOrder = check orders:fromEdiString(rawEdi);
 
-    log:printInfo("Purchase order received",
-        poNumber = po.beg.purchaseOrderNumber,
-        lineItems = po.po1.length()
+    log:printInfo("Order received",
+        orderId = newOrder.header.orderId,
+        organization = newOrder.header.organization
     );
 
-    // Process each line item
-    foreach edi:LineItem item in po.po1 {
-        check processLineItem(item);
+    foreach orders:Items_Type item in newOrder.items {
+        log:printInfo("Item", item = item.item, quantity = item?.quantity);
     }
-}
-
-function processLineItem(edi:LineItem item) returns error? {
-    log:printInfo("Processing item",
-        productId = item.productId,
-        quantity = item.quantity,
-        unitPrice = item.unitPrice
-    );
-    // Business logic: check inventory, update order system, etc.
 }
 ```
 
-### Generating outbound EDI messages
+**Generating outbound EDI messages:**
 
 ```ballerina
-import generated_edi as edi;
+import <add-the-project-name>.orders;
 
-function generatePurchaseOrderAck(string poNumber, string controlNumber)
-        returns string|error {
-    edi:PurchaseOrder855 ack = {
-        st: {
-            transactionSetId: "855",
-            transactionSetControlNumber: controlNumber
+function generateOrderEdi() returns string|error {
+    orders:SimpleOrder newOrder = {
+        header: {
+            orderId: "ORD-001",
+            organization: "HealthCare Inc.",
+            date: "20240101"
         },
-        bak: {
-            purposeCode: "AC",  // Acknowledge
-            orderNumber: poNumber,
-            date: getCurrentDate()
-        },
-        se: {
-            numberOfSegments: 3,
-            transactionSetControlNumber: controlNumber
-        }
+        items: [
+            {item: "Aspirin", quantity: 100},
+            {item: "Insulin", quantity: 50}
+        ]
     };
 
-    return edi:toEdiString(ack);
+    return orders:toEdiString(newOrder);
 }
 ```
 
-### B2B integration service
+## Generating a library package
 
-A complete example that receives EDI purchase orders over HTTP and converts them to JSON for internal processing:
-
-```ballerina
-import ballerina/http;
-import ballerina/log;
-import generated_edi as edi;
-
-configurable int servicePort = 8090;
-
-service /b2b on new http:Listener(servicePort) {
-
-    // Receive EDI purchase order from trading partner
-    resource function post edi/inbound(http:Request request)
-            returns json|http:BadRequest|error {
-        string rawEdi = check request.getTextPayload();
-
-        // Parse EDI
-        edi:PurchaseOrder850|error po = edi:fromEdiString(rawEdi);
-        if po is error {
-            log:printError("Failed to parse EDI", 'error = po);
-            return <http:BadRequest>{body: {message: "Invalid EDI format"}};
-        }
-
-        // Convert to internal JSON format
-        json internalOrder = {
-            poNumber: po.beg.purchaseOrderNumber,
-            orderDate: po.beg.date,
-            items: from edi:LineItem item in po.po1
-                select {
-                    productId: item.productId,
-                    quantity: item.quantity,
-                    unitPrice: item.unitPrice
-                }
-        };
-
-        log:printInfo("EDI order processed",
-            poNumber = po.beg.purchaseOrderNumber);
-
-        return internalOrder;
-    }
-
-    // Generate outbound EDI for trading partner
-    resource function post edi/outbound(json orderData)
-            returns string|error {
-        // Build EDI from JSON
-        string poNumber = check orderData.poNumber;
-        string edi = check generateOutboundEdi(orderData);
-        return edi;
-    }
-}
-```
-
-## Working with X12 and EDIFACT
-
-### X12 standards
+Use `libgen` to generate a complete Ballerina library package from a directory of EDI schemas. The library organizes each schema into a separate module and includes REST connectors for EDI-to-JSON and JSON-to-EDI conversions.
 
 ```bash
-# Generate code for X12 850 (Purchase Order)
-bal edi --standard x12 --version 005010 --transaction 850
-
-# Generate code for X12 810 (Invoice)
-bal edi --standard x12 --version 005010 --transaction 810
-
-# Generate code for X12 856 (Advance Ship Notice)
-bal edi --standard x12 --version 005010 --transaction 856
+bal edi libgen -p <org/package> -i path/to/schemas/ -o path/to/output/
 ```
 
-### EDIFACT standards
+Generated packages can be published to Ballerina Central and reused across projects.
+
+## Converting EDI schemas
+
+The EDI tool can convert standard EDI schema formats into the Ballerina JSON schema format used by `codegen` and `libgen`.
+
+### X12 schema conversion
 
 ```bash
-# Generate code for EDIFACT ORDERS
-bal edi --standard edifact --version d96a --transaction ORDERS
-
-# Generate code for EDIFACT INVOIC
-bal edi --standard edifact --version d96a --transaction INVOIC
+bal edi convertX12Schema -i path/to/x12-schema -o path/to/output/
 ```
 
-## EDI libraries
-
-Install pre-built EDI packages from Ballerina Central for common transaction sets:
+### EDIFACT schema conversion
 
 ```bash
-# Add X12 850 package
-bal add ballerinax/edi.x12.d05010x.v850
+bal edi convertEdifactSchema -v <version> -t <transaction-type> -o path/to/output/
+```
 
-# Add EDIFACT ORDERS package
-bal add ballerinax/edi.edifact.d96a.vORDERS
+### ESL schema conversion
+
+```bash
+bal edi convertESL -b path/to/definitions -i path/to/esl-schema -o path/to/output/
 ```
 
 ## Command reference
@@ -281,38 +194,71 @@ bal add ballerinax/edi.edifact.d96a.vORDERS
 Generates Ballerina record types and utility functions from a single EDI schema definition file.
 
 ```bash
-bal edi codegen -i <schema-path> -o <output-path> [options]
+bal edi codegen -i <schema-path> -o <output-path>
 ```
 
-| Flag | Alias | Required | Default | Description |
-|------|-------|----------|---------|-------------|
-| `-i`, `--input` | — | Yes | — | Path to the EDI schema file (JSON format) |
-| `-o`, `--output` | — | Yes | — | Output directory for generated Ballerina source files |
-| `-p`, `--package` | — | No | — | Package name for the generated module |
+| Flag | Required | Description |
+| --- | --- | --- |
+| `-i`, `--input` | Yes | Path to the EDI schema file (JSON format) |
+| `-o`, `--output` | Yes | Output path for the generated Ballerina source file |
 
 ### bal edi libgen
 
 Generates a complete Ballerina library package from a collection of EDI schemas.
 
 ```bash
-bal edi libgen -i <schema-directory> -o <output-path> [options]
+bal edi libgen -p <org/package> -i <schema-directory> -o <output-path>
 ```
 
-| Flag | Alias | Required | Default | Description |
-|------|-------|----------|---------|-------------|
-| `-i`, `--input` | — | Yes | — | Path to the directory containing EDI schema files or a collection definition file |
-| `-o`, `--output` | — | Yes | — | Output directory for the generated library package |
-| `-p`, `--package` | — | No | — | Package name for the generated library |
-| `--org` | — | No | — | Organization name for the generated package |
+| Flag | Required | Description |
+| --- | --- | --- |
+| `-p`, `--package` | Yes | Package identifier in `org/package` format |
+| `-i`, `--input` | Yes | Path to the directory containing EDI schema files |
+| `-o`, `--output` | Yes | Output directory for the generated library package |
 
-## Supported EDI standards
+### bal edi convertX12Schema
 
-| Standard | Description | Typical use |
-|---|---|---|
-| X12 | ANSI ASC X12 | North American B2B (orders, invoices, shipping) |
-| EDIFACT | UN/EDIFACT | International B2B commerce |
-| HL7 | Health Level 7 v2.x | Healthcare messaging |
-| Custom | User-defined schemas | Proprietary EDI formats |
+Converts an X12 schema to the Ballerina EDI schema format.
+
+```bash
+bal edi convertX12Schema -i <input> -o <output> [options]
+```
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `-i`, `--input` | Yes | Path to the X12 schema file or directory |
+| `-o`, `--output` | Yes | Output directory for the converted schema |
+| `-H`, `--headers` | No | Enable headers mode |
+| `-c`, `--collection` | No | Enable collection mode |
+| `-d`, `--segdet` | No | Path to the segment details file |
+
+### bal edi convertEdifactSchema
+
+Converts an EDIFACT schema to the Ballerina EDI schema format.
+
+```bash
+bal edi convertEdifactSchema -v <version> -t <type> -o <output>
+```
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `-v`, `--version` | Yes | EDIFACT version (e.g., `d96a`) |
+| `-t`, `--type` | Yes | Transaction type (e.g., `ORDERS`, `INVOIC`) |
+| `-o`, `--output` | Yes | Output directory for the converted schema |
+
+### bal edi convertESL
+
+Converts an ESL (EDI Schema Language) file to the Ballerina EDI schema format.
+
+```bash
+bal edi convertESL -b <definitions> -i <input> -o <output>
+```
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `-b`, `--basedef` | Yes | Path to the ESL base definitions |
+| `-i`, `--input` | Yes | Path to the ESL schema file |
+| `-o`, `--output` | Yes | Output directory for the converted schema |
 
 ## What's next
 

--- a/en/docs/develop/tools/integration-tools/edi-tool.md
+++ b/en/docs/develop/tools/integration-tools/edi-tool.md
@@ -49,7 +49,7 @@ The EDI tool uses JSON schema files to describe EDI message structures — segme
 
 **Sample EDI:**
 
-```text
+```bash
 HDR*HDR123*ACME_CORP*20240519~
 ITM*Pen*10~
 ITM*Notebook*5~

--- a/en/docs/develop/tools/integration-tools/edi-tool.md
+++ b/en/docs/develop/tools/integration-tools/edi-tool.md
@@ -110,51 +110,6 @@ public type SimpleOrder record {|
 |};
 ```
 
-### Using the generated code
-
-**Parsing incoming EDI messages:**
-
-```ballerina
-import ballerina/log;
-import <add-the-project-name>.orders;
-
-function processIncomingOrder(string rawEdi) returns error? {
-    // Parse EDI text into a typed SimpleOrder record
-    orders:SimpleOrder newOrder = check orders:fromEdiString(rawEdi);
-
-    log:printInfo("Order received",
-        orderId = newOrder.header.orderId,
-        organization = newOrder.header.organization
-    );
-
-    foreach orders:Items_Type item in newOrder.items {
-        log:printInfo("Item", item = item.item, quantity = item?.quantity);
-    }
-}
-```
-
-**Generating outbound EDI messages:**
-
-```ballerina
-import <add-the-project-name>.orders;
-
-function generateOrderEdi() returns string|error {
-    orders:SimpleOrder newOrder = {
-        header: {
-            orderId: "ORD-001",
-            organization: "HealthCare Inc.",
-            date: "20240101"
-        },
-        items: [
-            {item: "Aspirin", quantity: 100},
-            {item: "Insulin", quantity: 50}
-        ]
-    };
-
-    return orders:toEdiString(newOrder);
-}
-```
-
 ## Generating a library package
 
 Use `libgen` to generate a complete Ballerina library package from a directory of EDI schemas. The library organizes each schema into a separate module and includes REST connectors for EDI-to-JSON and JSON-to-EDI conversions.

--- a/en/docs/develop/tools/integration-tools/edi-tool.md
+++ b/en/docs/develop/tools/integration-tools/edi-tool.md
@@ -6,9 +6,79 @@ description: Generate Ballerina types and parsers from EDI schema definitions.
 
 # EDI tool
 
-The `bal edi` tool generates Ballerina code from EDI (Electronic Data Interchange) schema definitions, enabling B2B integration with trading partners using standards such as X12 and EDIFACT. The generated code includes record types for EDI segments and transaction sets, along with parser and serializer functions that convert between raw EDI text and type-safe Ballerina records.
+The `bal edi` tool generates Ballerina code from EDI (Electronic Data Interchange) schema definitions, enabling B2B integration with trading partners using standards such as **X12** and **EDIFACT**. The generated code includes record types for EDI segments and transaction sets, along with parser and serializer functions that convert between raw EDI text and type-safe Ballerina records.
 
-The EDI tool uses JSON schema files to describe EDI message structures — segments, fields, delimiters, and data types — and generates code from them.
+## Prerequisites
+
+Execute the command below to pull the EDI tool from [Ballerina Central](https://central.ballerina.io/).
+
+```bash
+bal tool pull edi
+```
+
+Verify the tool using the following command.
+
+```bash
+bal edi --help
+```
+
+## Generating types from an EDIFACT schema
+
+EDIFACT is the international EDI standard used globally, with message types such as `ORDERS`, `INVOIC`, and `DESADV`.
+
+### Step 1 — Convert the EDIFACT schema
+
+Convert an EDIFACT message type to the Ballerina EDI schema format by specifying the version and transaction type.
+
+```bash
+bal edi convertEdifactSchema -v <version> -t <transaction-type> -o path/to/output/
+```
+
+For example, to convert an `ORDERS` message in version `d96a`:
+
+```bash
+bal edi convertEdifactSchema -v d96a -t ORDERS -o path/to/output
+```
+
+### Step 2 — Generate Ballerina code
+
+Use `codegen` to generate typed Ballerina records and parser functions from the converted schema.
+
+```bash
+bal edi codegen -i path/to/output/schema.json -o modules/orders/main.bal
+```
+
+This generates the following functions in the output file along with the relevant record types.
+
+- `fromEdiString` — Convert an EDI string to a Ballerina record
+- `toEdiString` — Convert a Ballerina record to an EDI string
+- `getSchema` — Get the EDI schema as an `EdiSchema` object
+- `fromEdiStringWithSchema` — Convert an EDI string to a Ballerina record using a pre-loaded schema
+- `toEdiStringWithSchema` — Convert a Ballerina record to an EDI string using a pre-loaded schema
+
+## Generating types from an X12 schema
+
+X12 is a widely used EDI standard in North America, covering transaction sets for orders, invoices, shipping notices, and more.
+
+### Step 1 — Convert the X12 schema
+
+Convert an X12 schema to the Ballerina EDI schema format.
+
+```bash
+bal edi convertX12Schema -i path/to/x12-schema -o path/to/output
+```
+
+### Step 2 — Generate Ballerina code
+
+Use `codegen` to generate typed Ballerina records and parser functions from the converted schema.
+
+```bash
+bal edi codegen -i path/to/output/schema.json -o modules/orders/main.bal
+```
+
+## Generating types from a custom schema
+
+For EDI formats that are not X12 or EDIFACT, the tool accepts a JSON-based schema format that lets you describe segment structures, fields, delimiters, and data types directly.
 
 **Sample EDI schema:**
 
@@ -49,7 +119,7 @@ The EDI tool uses JSON schema files to describe EDI message structures — segme
 
 **Sample EDI:**
 
-```bash
+```edi
 HDR*HDR123*ACME_CORP*20240519~
 ITM*Pen*10~
 ITM*Notebook*5~
@@ -58,37 +128,13 @@ ITM*Ruler*7~
 ITM*Stapler*2~
 ```
 
-## Prerequisites
-
-Execute the command below to pull the EDI tool from [Ballerina Central](https://central.ballerina.io/).
-
-```bash
-bal tool pull edi
-```
-
-Verify the tool using the following command.
-
-```bash
-bal edi --help
-```
-
-## Generating code from an EDI schema
-
-Use `codegen` to generate typed Ballerina records and parser functions from a single EDI schema file.
+Run `codegen` directly on the custom schema file:
 
 ```bash
 bal edi codegen -i path/to/schema.json -o modules/orders/main.bal
 ```
 
-This generates the following functions in the output file:
-
-- `fromEdiString` — Convert an EDI string to a Ballerina record
-- `toEdiString` — Convert a Ballerina record to an EDI string
-- `getSchema` — Get the EDI schema as an `EdiSchema` object
-- `fromEdiStringWithSchema` — Convert an EDI string to a Ballerina record using a pre-loaded schema
-- `toEdiStringWithSchema` — Convert a Ballerina record to an EDI string using a pre-loaded schema
-
-It also generates the corresponding Ballerina record types:
+This generates the corresponding Ballerina record types along with edi functions:
 
 ```ballerina
 public type Header_Type record {|
@@ -120,50 +166,26 @@ bal edi libgen -p <org/package> -i path/to/schemas/ -o path/to/output/
 
 Generated packages can be published to Ballerina Central and reused across projects.
 
-## Converting EDI schemas
-
-The EDI tool can convert standard EDI schema formats into the Ballerina JSON schema format used by `codegen` and `libgen`.
-
-### X12 schema conversion
-
-```bash
-bal edi convertX12Schema -i path/to/x12-schema -o path/to/output/
-```
-
-### EDIFACT schema conversion
-
-```bash
-bal edi convertEdifactSchema -v <version> -t <transaction-type> -o path/to/output/
-```
-
-### ESL schema conversion
-
-```bash
-bal edi convertESL -b path/to/definitions -i path/to/esl-schema -o path/to/output/
-```
-
 ## Command reference
 
-### bal edi codegen
+| Command | Description |
+| --- | --- |
+| `bal edi codegen -i <schema> -o <output>` | Generate Ballerina records and functions from a schema file |
+| `bal edi libgen -p <org/package> -i <dir> -o <output>` | Generate a library package from a directory of schemas |
+| `bal edi convertEdifactSchema -v <version> -t <type> -o <output>` | Convert an EDIFACT spec to Ballerina EDI schema format |
+| `bal edi convertX12Schema -i <input> -o <output>` | Convert an X12 schema to Ballerina EDI schema format |
+| `bal edi convertESL -b <definitions> -i <input> -o <output>` | Convert an ESL schema to Ballerina EDI schema format |
 
-Generates Ballerina record types and utility functions from a single EDI schema definition file.
+### Flag reference
 
-```bash
-bal edi codegen -i <schema-path> -o <output-path>
-```
+#### bal edi codegen
 
 | Flag | Required | Description |
 | --- | --- | --- |
 | `-i`, `--input` | Yes | Path to the EDI schema file (JSON format) |
 | `-o`, `--output` | Yes | Output path for the generated Ballerina source file |
 
-### bal edi libgen
-
-Generates a complete Ballerina library package from a collection of EDI schemas.
-
-```bash
-bal edi libgen -p <org/package> -i <schema-directory> -o <output-path>
-```
+#### bal edi libgen
 
 | Flag | Required | Description |
 | --- | --- | --- |
@@ -171,13 +193,7 @@ bal edi libgen -p <org/package> -i <schema-directory> -o <output-path>
 | `-i`, `--input` | Yes | Path to the directory containing EDI schema files |
 | `-o`, `--output` | Yes | Output directory for the generated library package |
 
-### bal edi convertX12Schema
-
-Converts an X12 schema to the Ballerina EDI schema format.
-
-```bash
-bal edi convertX12Schema -i <input> -o <output> [options]
-```
+#### bal edi convertX12Schema
 
 | Flag | Required | Description |
 | --- | --- | --- |
@@ -187,13 +203,7 @@ bal edi convertX12Schema -i <input> -o <output> [options]
 | `-c`, `--collection` | No | Enable collection mode |
 | `-d`, `--segdet` | No | Path to the segment details file |
 
-### bal edi convertEdifactSchema
-
-Converts an EDIFACT schema to the Ballerina EDI schema format.
-
-```bash
-bal edi convertEdifactSchema -v <version> -t <type> -o <output>
-```
+#### bal edi convertEdifactSchema
 
 | Flag | Required | Description |
 | --- | --- | --- |
@@ -201,13 +211,7 @@ bal edi convertEdifactSchema -v <version> -t <type> -o <output>
 | `-t`, `--type` | Yes | Transaction type (e.g., `ORDERS`, `INVOIC`) |
 | `-o`, `--output` | Yes | Output directory for the converted schema |
 
-### bal edi convertESL
-
-Converts an ESL (EDI Schema Language) file to the Ballerina EDI schema format.
-
-```bash
-bal edi convertESL -b <definitions> -i <input> -o <output>
-```
+#### bal edi convertESL
 
 | Flag | Required | Description |
 | --- | --- | --- |

--- a/en/docs/reference/data-formats/edi.md
+++ b/en/docs/reference/data-formats/edi.md
@@ -4,7 +4,57 @@ title: EDI
 
 # EDI
 
-Electronic Data Interchange (EDI) is a standard format for exchanging business documents such as purchase orders, invoices, and shipping notices between organizations. The `ballerina/edi` module (v1.5.3) provides schema-driven, bidirectional conversion between EDI text and JSON.
+Electronic Data Interchange (EDI) is a set of standards that enables organizations to electronically exchange business documents such as purchase orders, invoices, and shipping notices in a structured, computer-readable format. Common EDI standards include X12 and UN/EDIFACT. The `ballerina/edi` module provides schema-driven, bidirectional conversion between EDI text and JSON.
+
+## EDI data format
+
+An EDI message is a sequence of **segments**. Each segment begins with a couple of character segment identifiers (e.g., `HDR`, `ITM`) followed by one or more **data elements** separated by a data element separator. A segment ends with a segment terminator. For example:
+
+```
+HDR*ORDER_1201*ABC_Store*2008-01-01~
+ITM*A-250*12~
+```
+
+In this example, `*` is the data element separator and `~` is the segment terminator. A **composite data element** contains multiple **component elements** separated by a component element separator (e.g., `:`). Data elements can also repeat within a segment using a repetition separator.
+
+The following JSON schema defines the structure of the above EDI message for use with the `ballerina/edi` module:
+
+```json
+{
+  "name": "SimpleOrder",
+  "delimiters": {
+    "segment": "~",
+    "field": "*",
+    "component": ":",
+    "repetition": "^"
+  },
+  "segments": [
+    {
+      "code": "HDR",
+      "tag": "header",
+      "minOccurances": 1,
+      "fields": [
+        { "tag": "code" },
+        { "tag": "orderId" },
+        { "tag": "organization" },
+        { "tag": "date" }
+      ]
+    },
+    {
+      "code": "ITM",
+      "tag": "items",
+      "maxOccurances": -1,
+      "fields": [
+        { "tag": "code" },
+        { "tag": "item" },
+        { "tag": "quantity", "dataType": "int" }
+      ]
+    }
+  ]
+}
+```
+
+Each `segments` entry maps a segment code to a set of ordered field definitions. The `tag` value becomes the JSON property name in the parsed output, and `maxOccurances: -1` allows a segment to repeat any number of times.
 
 ## Module
 
@@ -19,8 +69,8 @@ import ballerina/edi;
 import ballerina/io;
 
 public function main() returns error? {
-    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("resources/schema.json"));
-    string ediText = check io:fileReadString("resources/order.edi");
+    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("path/to/schema.json"));
+    string ediText = check io:fileReadString("path/to/order.edi");
     json orderData = check edi:fromEdiString(ediText, schema);
     io:println(orderData.toJsonString());
 }
@@ -60,7 +110,7 @@ import ballerina/edi;
 import ballerina/io;
 
 public function main() returns error? {
-    json order = {
+    json newOrder = {
         "header": {
             "code": "HDR",
             "orderId": "ORDER_1201",
@@ -72,8 +122,8 @@ public function main() returns error? {
             {"code": "ITM", "item": "B-250", "quantity": 10}
         ]
     };
-    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("resources/schema.json"));
-    string ediText = check edi:toEdiString(order, schema);
+    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("schema.json"));
+    string ediText = check edi:toEdiString(newOrder, schema);
     io:println(ediText);
 }
 ```
@@ -81,7 +131,9 @@ public function main() returns error? {
 **Output:**
 
 ```
-HDR*ORDER_1201*ABC_Store*2008-01-01~ITM*A-250*12~ITM*B-250*10~
+HDR*ORDER_1201*ABC_Store*2008-01-01~
+ITM*A-250*12~
+ITM*B-250*10~
 ```
 
 ### Load a schema
@@ -92,14 +144,18 @@ import ballerina/io;
 
 public function main() returns error? {
     // Load from a JSON file
-    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("resources/schema.json"));
+    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("path/to/schema.json"));
+
+    io:println("Schema 01:", schema);
 
     // Or load from an inline JSON string
-    edi:EdiSchema schema2 = check edi:getSchema(string `{
+    edi:EdiSchema orderSchema = check edi:getSchema(string `{
         "name": "SimpleOrder",
         "delimiters": {"segment": "~", "field": "*", "component": ":"},
         "segments": []
     }`);
+
+    io:println("Schema 02:", orderSchema);
 }
 ```
 
@@ -132,11 +188,11 @@ EDI schemas are JSON documents that define how to parse and serialize EDI data. 
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `segment` | `string` | Required | Delimiter between segments (e.g., `~`). |
-| `field` | `string` | Required | Delimiter between fields within a segment (e.g., `*`). |
-| `component` | `string` | Required | Delimiter between components within a field (e.g., `:`). |
-| `subcomponent` | `string` | `"NOT_USED"` | Delimiter between sub-components. |
-| `repetition` | `string` | `"NOT_USED"` | Delimiter for repeating fields. |
+| `segment` | `string` | Required | Segment terminator that marks the end of a segment (e.g., `~`). |
+| `field` | `string` | Required | Data element separator between data elements within a segment (e.g., `*`). |
+| `component` | `string` | Required | Component element separator between components within a composite data element (e.g., `:`). |
+| `subcomponent` | `string` | `"NOT_USED"` | Sub-component element separator, for further subdivision within a component. |
+| `repetition` | `string` | `"NOT_USED"` | Repetition separator for data elements that repeat within a segment (e.g., `^`). |
 | `decimalSeparator` | `string` | — | Custom decimal separator for numeric fields. |
 
 ### Segment definition

--- a/en/docs/reference/data-formats/edi.md
+++ b/en/docs/reference/data-formats/edi.md
@@ -10,51 +10,34 @@ Electronic Data Interchange (EDI) is a set of standards that enables organizatio
 
 An EDI message is a sequence of **segments**. Each segment begins with a couple of character segment identifiers (e.g., `HDR`, `ITM`) followed by one or more **data elements** separated by a data element separator. A segment ends with a segment terminator. For example:
 
-```bash
+```edi
 HDR*ORDER_1201*ABC_Store*2008-01-01~
 ITM*A-250*12~
 ```
 
 In this example, `*` is the data element separator and `~` is the segment terminator. A **composite data element** contains multiple **component elements** separated by a component element separator (e.g., `:`). Data elements can also repeat within a segment using a repetition separator.
 
-The following JSON schema defines the structure of the above EDI message for use with the `ballerina/edi` module:
+## Getting started
 
-```json
-{
-  "name": "SimpleOrder",
-  "delimiters": {
-    "segment": "~",
-    "field": "*",
-    "component": ":",
-    "repetition": "^"
-  },
-  "segments": [
-    {
-      "code": "HDR",
-      "tag": "header",
-      "minOccurances": 1,
-      "fields": [
-        { "tag": "code" },
-        { "tag": "orderId" },
-        { "tag": "organization" },
-        { "tag": "date" }
-      ]
-    },
-    {
-      "code": "ITM",
-      "tag": "items",
-      "maxOccurances": -1,
-      "fields": [
-        { "tag": "code" },
-        { "tag": "item" },
-        { "tag": "quantity", "dataType": "int" }
-      ]
-    }
-  ]
+### Using prebuilt EDIFACT packages
+
+The fastest path for standard EDIFACT documents is to import a prebuilt package — no schema writing required. Prebuilt packages for common EDIFACT D03A message types are available under the `ballerinax` organization.
+
+```ballerina
+import ballerinax/edifact.d03a.finance.mINVOIC;
+
+public function main() returns error? {
+    string ediText = check io:fileReadString("resources/invoice.edi");
+    mINVOIC:EDI_INVOIC_Invoice invoiceMsg = check mINVOIC:fromEdiString(ediText);
+    // Process the typed invoice data
 }
 ```
 
-Each `segments` entry maps a segment code to a set of ordered field definitions. The `tag` value becomes the JSON property name in the parsed output, and `maxOccurances: -1` allows a segment to repeat any number of times.
+See [prebuilt EDIFACT packages](#prebuilt-edifact-packages) for the full list.
+
+### Generating types from a schema
+
+For EDIFACT or X12 documents not covered by prebuilt packages, use the [EDI Tool](../../develop/tools/integration-tools/edi-tool.md) to generate Ballerina types and parser functions from the standard spec. This gives you a typed API without writing a schema by hand.
 
 ## Module
 
@@ -78,7 +61,7 @@ public function main() returns error? {
 
 **Sample EDI input:**
 
-```bash
+```edi
 HDR*ORDER_1201*ABC_Store*2008-01-01~
 ITM*A-250*12~
 ITM*A-45*100~
@@ -130,7 +113,7 @@ public function main() returns error? {
 
 **Output:**
 
-```bash
+```edi
 HDR*ORDER_1201*ABC_Store*2008-01-01~
 ITM*A-250*12~
 ITM*B-250*10~
@@ -167,11 +150,52 @@ public function main() returns error? {
 | `toEdiString` | `toEdiString(json msg, EdiSchema schema) returns string\|Error` | Serialize JSON into EDI text using a schema. |
 | `getSchema` | `getSchema(string\|json schema) returns EdiSchema\|error` | Load and validate an EDI schema from a JSON string or object. |
 
-## Schema reference
+## Custom EDI schemas
+
+For EDI formats not covered by prebuilt packages — or when you need to tune a generated schema for partner-specific variations — define the structure as a JSON schema. The following JSON schema defines the structure of the simple order EDI format shown above.
+
+```json
+{
+  "name": "SimpleOrder",
+  "delimiters": {
+    "segment": "~",
+    "field": "*",
+    "component": ":",
+    "repetition": "^"
+  },
+  "segments": [
+    {
+      "code": "HDR",
+      "tag": "header",
+      "minOccurances": 1,
+      "fields": [
+        { "tag": "code" },
+        { "tag": "orderId" },
+        { "tag": "organization" },
+        { "tag": "date" }
+      ]
+    },
+    {
+      "code": "ITM",
+      "tag": "items",
+      "maxOccurances": -1,
+      "fields": [
+        { "tag": "code" },
+        { "tag": "item" },
+        { "tag": "quantity", "dataType": "int" }
+      ]
+    }
+  ]
+}
+```
+
+Each `segments` entry maps a segment code to a set of ordered field definitions. The `tag` value becomes the JSON property name in the parsed output, and `maxOccurances: -1` allows a segment to repeat any number of times.
+
+### Schema reference
 
 EDI schemas are JSON documents that define how to parse and serialize EDI data. A schema specifies delimiters, segment structures, field types, and occurrence constraints.
 
-### Schema structure
+#### Schema structure
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -184,7 +208,7 @@ EDI schemas are JSON documents that define how to parse and serialize EDI data. 
 | `segments` | `EdiUnitSchema[]` | `[]` | Array of segment and segment group definitions. |
 | `segmentDefinitions` | `map` | `{}` | Reusable segment definitions referenced by code. |
 
-### Delimiters
+#### Delimiters
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -195,7 +219,7 @@ EDI schemas are JSON documents that define how to parse and serialize EDI data. 
 | `repetition` | `string` | `"NOT_USED"` | Repetition separator for data elements that repeat within a segment (e.g., `^`). |
 | `decimalSeparator` | `string` | — | Custom decimal separator for numeric fields. |
 
-### Segment definition
+#### Segment definition
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -206,7 +230,7 @@ EDI schemas are JSON documents that define how to parse and serialize EDI data. 
 | `maxOccurances` | `int` | `1` | Maximum occurrences (`-1` for unlimited). |
 | `fields` | `EdiFieldSchema[]` | `[]` | Array of field definitions. |
 
-### Field definition
+#### Field definition
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -219,7 +243,7 @@ EDI schemas are JSON documents that define how to parse and serialize EDI data. 
 | `length` | `int\|Range` | `-1` | Length constraint (fixed integer or min/max range). |
 | `components` | `EdiComponentSchema[]` | `[]` | Sub-elements within this field (for composite types). |
 
-### Example schema
+#### Example schema
 
 ```json
 {

--- a/en/docs/reference/data-formats/edi.md
+++ b/en/docs/reference/data-formats/edi.md
@@ -10,7 +10,7 @@ Electronic Data Interchange (EDI) is a set of standards that enables organizatio
 
 An EDI message is a sequence of **segments**. Each segment begins with a couple of character segment identifiers (e.g., `HDR`, `ITM`) followed by one or more **data elements** separated by a data element separator. A segment ends with a segment terminator. For example:
 
-```
+```bash
 HDR*ORDER_1201*ABC_Store*2008-01-01~
 ITM*A-250*12~
 ```
@@ -78,7 +78,7 @@ public function main() returns error? {
 
 **Sample EDI input:**
 
-```
+```bash
 HDR*ORDER_1201*ABC_Store*2008-01-01~
 ITM*A-250*12~
 ITM*A-45*100~
@@ -122,7 +122,7 @@ public function main() returns error? {
             {"code": "ITM", "item": "B-250", "quantity": 10}
         ]
     };
-    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("schema.json"));
+    edi:EdiSchema schema = check edi:getSchema(check io:fileReadJson("path/to/schema.json"));
     string ediText = check edi:toEdiString(newOrder, schema);
     io:println(ediText);
 }
@@ -130,7 +130,7 @@ public function main() returns error? {
 
 **Output:**
 
-```
+```bash
 HDR*ORDER_1201*ABC_Store*2008-01-01~
 ITM*A-250*12~
 ITM*B-250*10~


### PR DESCRIPTION
## Purpose
> $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote EDI Tool guide in new doc format with frontmatter, clearer structure, and setup/check instructions.
  * Added and documented codegen and libgen workflows, generated helpers/types, schema conversion commands, and comprehensive CLI command/flag reference.
  * Expanded parsing/serialization examples with a new sample, updated paths/variable names, and multi-line EDI output formatting.
  * Refreshed “What’s next” links and delimiters table formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/343)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->