### PR TITLE
Replace BI with default profile in ICP docs

### DIFF
--- a/en/docs/deploy-operate/observe/integration-control-plane-icp.md
+++ b/en/docs/deploy-operate/observe/integration-control-plane-icp.md
@@ -26,7 +26,7 @@ Key capabilities:
 
 ### Configuring the integration node with ICP
 
-ICP allows you to connect BI and MI runtimes to the ICP server for centralized management and monitoring.
+ICP allows you to connect default profile and MI runtimes to the ICP server for centralized management and monitoring.
 This guide will walk you through the steps to connect your integration runtime to the ICP server.
 
 1. Navigate to the home view of WSO2 Integrator.

--- a/en/docs/manage/icp/connect-runtime.md
+++ b/en/docs/manage/icp/connect-runtime.md
@@ -32,7 +32,7 @@ or when the component does not exist in ICP yet.
 1. Navigate to **Runtimes** in the sidebar.
 2. Find the target environment card (e.g. *dev*) and click **Add Runtime**.
 3. Click **Generate Secret**.
-4. The **BI** tab is selected by default. Copy the `Config.toml` snippet shown.
+4. The **default profile** tab is selected by default. Copy the `Config.toml` snippet shown.
 
 > The secret is displayed only once. Copy it before closing the dialog.
 
@@ -115,20 +115,20 @@ Full heartbeat acknowledged by ICP server
 
 The runtime now appears under **Runtimes** in the ICP console with status **RUNNING**.
 
-## Multiple BI Nodes
+## Multiple default profile Nodes
 
-Each BI node needs a unique `runtime` value but can share the same `project`,
+Each default profile node needs a unique `runtime` value but can share the same `project`,
 `integration`, `environment`, and `secret`. All nodes appear as separate runtimes
 under the same component in ICP.
 
 ```toml
 # Node 1
 [wso2.icp.runtime.bridge]
-runtime = "bi-node-1"
+runtime = "default-profile-node-1"
 
 # Node 2
 [wso2.icp.runtime.bridge]
-runtime = "bi-node-2"
+runtime = "default-profile-node-2"
 ```
 
 ## Troubleshooting
@@ -136,7 +136,7 @@ runtime = "bi-node-2"
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `Full heartbeat rejected` | Wrong or revoked secret | Generate a new secret in the console |
-| Runtime shows but status is not RUNNING | Heartbeats stopped | Check the BI process is alive and network is reachable |
+| Runtime shows but status is not RUNNING | Heartbeats stopped | Check the default profile process is alive and network is reachable |
 | `PKIX path building failed` | Self-signed ICP certificate | Set `enableSSL = false` (non-production) or provide the CA via `cert` |
 
 ## Next Step

--- a/en/docs/manage/icp/icp-console-overview.md
+++ b/en/docs/manage/icp/icp-console-overview.md
@@ -61,17 +61,17 @@ To add another (e.g. *staging*), see
 
 Full details: [Manage Projects](manage-projects.md).
 
-### 3. Create a BI Integration
+### 3. Create a default profile Integration
 
 1. Inside the project, click **+ Create**.
-2. Enter a **Display Name**. Integration Type defaults to **BI**.
+2. Enter a **Display Name**. Integration Type defaults to **default profile**.
 3. Click **Create**.
 
 Full details: [Manage Integrations](manage-integrations.md).
 
 ### 4. Connect a Runtime
 
-1. Generate a secret and configure your BI runtime — see [Connect an Integration to ICP](connect-runtime.md).
+1. Generate a secret and configure your default profile runtime — see [Connect an Integration to ICP](connect-runtime.md).
 2. Start the runtime. It appears in the Runtimes table with status **RUNNING**.
 
 Full details: [Manage Runtimes](manage-runtimes.md).

--- a/en/docs/manage/icp/install-icp.md
+++ b/en/docs/manage/icp/install-icp.md
@@ -133,7 +133,7 @@ ICP serves the console and API on port `9446` by default. To expose ICP through 
    backendObservabilityEndpoint = "https://icp.example.com/icp/observability"
    ```
 
-3. BI runtimes connect to ICP for heartbeats. If they also go through the
+3. default profile runtimes connect to ICP for heartbeats. If they also go through the
    proxy, set `serverUrl` in the runtime's `Config.toml` to the proxy URL:
 
    ```toml
@@ -196,5 +196,5 @@ When a project is created, ICP also auto-creates a
 ## Next Steps
 
 1. **[ICP Console Overview](icp-console-overview.md)** — Learn the console layout and navigation.
-2. **[Connect an Integration to ICP](connect-runtime.md)** — Register a BI runtime with heartbeats.
+2. **[Connect an Integration to ICP](connect-runtime.md)** — Register a default profile runtime with heartbeats.
 3. **[Observability Setup](observability-setup.md)** — Add centralized logs and metrics.

--- a/en/docs/manage/icp/manage-integrations.md
+++ b/en/docs/manage/icp/manage-integrations.md
@@ -1,12 +1,12 @@
 ---
 title: Manage Integrations
-description: Create and manage BI integrations (components) in the ICP Console.
+description: Create and manage default profile integrations (components) in the ICP Console.
 ---
 
 # Manage Integrations
 
 Integrations (also called *components*) represent a deployable unit — a Ballerina
-application in the case of BI. Each integration belongs to a project and runs in
+application in the case of default profile. Each integration belongs to a project and runs in
 one or more environments.
 
 ## Create an Integration
@@ -20,7 +20,7 @@ one or more environments.
 | Project          | Auto     | Pre-filled with the current project. Can be changed via dropdown.            |
 | Display Name     | Yes      | Human-readable name (placeholder: *Enter display name here*).               |
 | Name             | Auto     | Slug from Display Name. Click the edit icon to override.                                |
-| Integration Type | Yes      | Dropdown: **BI** (Ballerina Integrator) or **MI** (Micro Integrator). Defaults to BI. |
+| Integration Type | Yes      | Dropdown: **default profile** or **MI** (Micro Integrator). Defaults to default profile. |
 | Description      | No       | Multi-line text area (placeholder: *Enter description here*).               |
 
 3. Click **Create**.
@@ -36,7 +36,7 @@ displays:
 
 - Environment name and runtime count badge (e.g. *"0 runtimes"* or *"1/1 Online"*).
 - Refresh icon.
-- For BI integrations: **Entry Points** tab listing services/APIs, and a
+- For default profile integrations: **Entry Points** tab listing services/APIs, and a
   **Supporting Artifacts** tab (when artifacts are present).
 - **+ Add Runtime** link when no runtimes are registered.
 
@@ -69,7 +69,7 @@ When runtimes are present, a table shows:
 | ----------------- | ----------------------------------- |
 | Runtime Name      | Display name (or `-` if unset)      |
 | Runtime ID        | UUID                                |
-| Type              | BI                                  |
+| Type              | default profile                     |
 | Status            | RUNNING, OFFLINE, etc.              |
 | Version           | Runtime version                     |
 | Platform          | e.g. *Ballerina 2201.13.2 (Swan Lake Update 13)* |

--- a/en/docs/manage/icp/manage-projects.md
+++ b/en/docs/manage/icp/manage-projects.md
@@ -28,8 +28,8 @@ URL pattern: `https://<host>:9446/organizations/default`
 
 | Field            | Required | Description                                                                 |
 | ---------------- | -------- | --------------------------------------------------------------------------- |
-| Display Name     | Yes      | Human-readable name (e.g. `My BI Project`)                                  |
-| Name             | Auto     | URL-safe slug derived from the display name (e.g. `my-bi-project`). Click the edit icon to override. |
+| Display Name     | Yes      | Human-readable name (e.g. `My default profile Project`)                     |
+| Name             | Auto     | URL-safe slug derived from the display name (e.g. `my-default-profile-project`). Click the edit icon to override. |
 | Description      | No       | Free-text description (placeholder: *Enter Description here*)               |
 
 3. The **Create** button enables once Display Name is filled.
@@ -60,7 +60,7 @@ Clicking a project card navigates to the project home. The page shows:
 
 - Project avatar, display name, and description at the top.
 - An **Integrations** section with a searchable table and a **+ Create** button.
-- An **Integration Types** summary card on the right showing the count of integrations (Total, BI, MI).
+- An **Integration Types** summary card on the right showing the count of integrations (Total, default profile, MI).
 - If no integrations exist: *"No integrations found — Create your first integration to get started."*
 
 ### Project Sidebar

--- a/en/docs/manage/icp/manage-runtimes.md
+++ b/en/docs/manage/icp/manage-runtimes.md
@@ -5,7 +5,7 @@ description: View runtimes, generate secrets, and manage runtime connections in 
 
 # Manage Runtimes
 
-Runtimes are BI (or MI) processes that connect to ICP via heartbeats. The
+Runtimes are default profile (or MI) processes that connect to ICP via heartbeats. The
 Runtimes page is available at every level — organization, project, and
 integration — each scoped accordingly.
 
@@ -25,7 +25,7 @@ Runtimes are grouped by environment. Each environment section shows:
 | ----------------- | ----------------------------------------------------- |
 | Runtime Name      | Display name (`-` if not configured)                  |
 | Runtime ID        | UUID assigned on first heartbeat                      |
-| Type              | BI or MI                                              |
+| Type              | default profile or MI                                 |
 | Component         | Integration name this runtime belongs to              |
 | Status            | **RUNNING** (green badge), OFFLINE, etc.              |
 | Version           | Runtime version (or `—` if not reported)              |

--- a/en/docs/manage/icp/observability-setup.md
+++ b/en/docs/manage/icp/observability-setup.md
@@ -1,11 +1,11 @@
 ---
 title: Observability Setup
-description: Set up centralized logs and metrics monitoring for BI runtimes using Fluent Bit and OpenSearch.
+description: Set up centralized logs and metrics monitoring for default profile runtimes using Fluent Bit and OpenSearch.
 ---
 
 # Observability Setup
 
-ICP provides centralized observability for BI runtimes. Logs and metrics are collected via Fluent Bit, stored in OpenSearch, and displayed in the ICP Console.
+ICP provides centralized observability for default profile runtimes. Logs and metrics are collected via Fluent Bit, stored in OpenSearch, and displayed in the ICP Console.
 
 For MI runtimes, see [MI Observability Setup](mi-profile/observability-setup-mi.md).
 
@@ -13,15 +13,15 @@ For MI runtimes, see [MI Observability Setup](mi-profile/observability-setup-mi.
 
 ```mermaid
 flowchart LR
-    BI["BI Runtime"] -- "app.log" --> FB["Fluent Bit"]
-    BI -- "metrics.log" --> FB
+    Runtime["default profile Runtime"] -- "app.log" --> FB["Fluent Bit"]
+    Runtime -- "metrics.log" --> FB
     FB -- "HTTP" --> OS["OpenSearch"]
-    BI -- "heartbeat" --> ICP["ICP Server"]
+    Runtime -- "heartbeat" --> ICP["ICP Server"]
     OS -- "query" --> ICP
     Console["ICP Console\n(Browser)"] -- "GraphQL / REST" --> ICP
 ```
 
-1. The BI runtime writes structured logs to two separate files: application logs and metrics logs.
+1. The default profile runtime writes structured logs to two separate files: application logs and metrics logs.
 2. Fluent Bit tails both files and ships each to its own OpenSearch index.
 3. ICP Server queries OpenSearch when a user opens the Logs or Metrics page in the Console.
 
@@ -32,7 +32,7 @@ flowchart LR
 | ICP Server | Running, with OpenSearch connection configured in `deployment.toml` (see [Install ICP — OpenSearch](install-icp.md#opensearch-observability)) |
 | Integration | Connected to ICP with heartbeats working (see [Connect an Integration to ICP](connect-runtime.md)) |
 | OpenSearch | Deployed and reachable from ICP Server and Fluent Bit |
-| Fluent Bit | Installed on the machine running the BI runtime |
+| Fluent Bit | Installed on the machine running the default profile runtime |
 
 ## Step 1: Deploy OpenSearch
 
@@ -202,7 +202,7 @@ The log file paths must match the Fluent Bit input `Path` patterns. Adjust both 
 
 ## Step 4: Configure Fluent Bit
 
-Fluent Bit tails the BI log files and ships them to OpenSearch.
+Fluent Bit tails the default profile log files and ships them to OpenSearch.
 
 You need three config files side by side:
 
@@ -216,8 +216,8 @@ Since the integration writes app logs and metrics to separate files, Fluent Bit 
 
 | Input `Path` | Tag | Parser | Output index prefix | Content |
 |-------------|-----|--------|---------------------|---------|
-| `<bi-logs>/app.log` | `ballerina_app_logs` | `bal_logfmt_parser` | `ballerina-application-logs-` | Application logs |
-| `<bi-logs>/metrics.log` | `ballerina_metrics` | `bal_logfmt_parser` | `ballerina-metrics-logs-` | Per-request metrics |
+| `<default-profile-logs>/app.log` | `ballerina_app_logs` | `bal_logfmt_parser` | `ballerina-application-logs-` | Application logs |
+| `<default-profile-logs>/metrics.log` | `ballerina_metrics` | `bal_logfmt_parser` | `ballerina-metrics-logs-` | Per-request metrics |
 
 ### Parser definition
 
@@ -264,7 +264,7 @@ The Lua enrichment is **required** for the ICP Metrics page to display data. Wit
 
 ### fluent-bit.conf
 
-Replace `<bi-logs>` with the actual path to your BI application's `logs/` directory. Use forward slashes on all platforms.
+Replace `<default-profile-logs>` with the actual path to your default profile application's `logs/` directory. Use forward slashes on all platforms.
 
 ```ini
 [SERVICE]
@@ -275,7 +275,7 @@ Replace `<bi-logs>` with the actual path to your BI application's `logs/` direct
 # ── App logs ──
 [INPUT]
     Name         tail
-    Path         <bi-logs>/app.log
+    Path         <default-profile-logs>/app.log
     Parser       bal_logfmt_parser
     Tag          ballerina_app_logs
     Read_from_Head On
@@ -284,7 +284,7 @@ Replace `<bi-logs>` with the actual path to your BI application's `logs/` direct
 # ── Metrics logs ──
 [INPUT]
     Name         tail
-    Path         <bi-logs>/metrics.log
+    Path         <default-profile-logs>/metrics.log
     Parser       bal_logfmt_parser
     Tag          ballerina_metrics
     Read_from_Head On
@@ -395,7 +395,7 @@ Replace `<bi-logs>` with the actual path to your BI application's `logs/` direct
 
 ### Check OpenSearch indices
 
-After the BI runtime has been running for a minute or two:
+After the default profile runtime has been running for a minute or two:
 
 ```bash
 curl -sk -u admin:<password> https://localhost:9200/_cat/indices/ballerina-*?v
@@ -433,7 +433,7 @@ curl http://localhost:8090/<your-endpoint>
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Metrics page shows "No metrics data" | BI runtime has no inbound HTTP requests | Metrics are generated per-request — send traffic first |
+| Metrics page shows "No metrics data" | default profile runtime has no inbound HTTP requests | Metrics are generated per-request — send traffic first |
 | Metrics page shows "No metrics data" | `metricsLogsEnabled` not set | Add `metricsLogsEnabled = true` to `[ballerina.observe]` in `Config.toml` |
 | Metrics page shows "No metrics data" | Metrics log file not configured | Set `logFilePath` in `[ballerinax.metrics.logs]` |
 | Metrics page shows "No metrics data" | Lua enrichment scripts missing from Fluent Bit config | Add the Lua `[FILTER]` blocks (especially `extract_bal_metrics_data`) — see Step 4 |

--- a/en/docs/reference/api/icp.md
+++ b/en/docs/reference/api/icp.md
@@ -127,7 +127,7 @@ After processing the heartbeat, the ICP runs reconciliation and returns any pend
 | `platformName` | string | Platform identifier (default: `"wso2-mi"`) |
 | `platformVersion` | string | Platform/product version |
 | `platformHome` | string | Installation directory |
-| `ballerinaHome` | string | Ballerina home directory (BI runtimes) |
+| `ballerinaHome` | string | Ballerina home directory (default profile runtimes) |
 | `osName` | string | Operating system name |
 | `osVersion` | string | OS version |
 | `osArch` | string | CPU architecture |
@@ -143,9 +143,9 @@ After processing the heartbeat, the ICP runs reconciliation and returns any pend
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `listeners` | array | Active HTTP/HTTPS listeners (BI) |
-| `services` | array | Deployed Ballerina services (BI) |
-| `main` | object | Main Ballerina package info: `packageOrg`, `packageName`, `packageVersion` (BI) |
+| `listeners` | array | Active HTTP/HTTPS listeners (default profile) |
+| `services` | array | Deployed Ballerina services (default profile) |
+| `main` | object | Main Ballerina package info: `packageOrg`, `packageName`, `packageVersion` (default profile) |
 | `apis` | array | REST APIs (MI) |
 | `proxyServices` | array | Proxy services (MI) |
 | `sequences` | array | Sequences (MI) |

--- a/en/docs/reference/api/management.md
+++ b/en/docs/reference/api/management.md
@@ -479,7 +479,7 @@ dataServiceOverviewByComponent(
 
 #### `loggersByRuntime`
 
-Returns loggers for a specific runtime. For MI runtimes, fetches live from the MI Management API. For BI runtimes, reads from the database with reconcile state overlaid.
+Returns loggers for a specific runtime. For MI runtimes, fetches live from the MI Management API. For default profile runtimes, reads from the database with reconcile state overlaid.
 
 ```graphql
 loggersByRuntime(runtimeId: String!): [Logger!]!
@@ -934,7 +934,7 @@ mutation {
 
 #### `updateLogLevel`
 
-Updates the log level for MI loggers (applied immediately via the MI Management API) or BI component loggers (applied via the reconcile engine).
+Updates the log level for MI loggers (applied immediately via the MI Management API) or default profile component loggers (applied via the reconcile engine).
 
 ```graphql
 updateLogLevel(input: UpdateLogLevelInput!): UpdateLogLevelResponse!

--- a/en/docs/reference/icp/manage-integrations.md
+++ b/en/docs/reference/icp/manage-integrations.md
@@ -1,12 +1,12 @@
 ---
 title: Manage Integrations
-description: Create and manage BI integrations (components) in the ICP Console.
+description: Create and manage default profile integrations (components) in the ICP Console.
 ---
 
 # Manage Integrations
 
 Integrations (also called *components*) represent a deployable unit — a Ballerina
-application in the case of BI. Each integration belongs to a project and runs in
+application in the case of default profile. Each integration belongs to a project and runs in
 one or more environments.
 
 ## Create an Integration
@@ -20,7 +20,7 @@ one or more environments.
 | Project          | Auto     | Pre-filled with the current project. Can be changed via dropdown.            |
 | Display Name     | Yes      | Human-readable name (placeholder: *Enter display name here*).               |
 | Name             | Auto     | Slug from Display Name. Click the edit icon to override.                                |
-| Integration Type | Yes      | Dropdown: **BI** (Ballerina Integrator) or **MI** (Micro Integrator). Defaults to BI. |
+| Integration Type | Yes      | Dropdown: **default profile** or **MI** (Micro Integrator). Defaults to default profile. |
 | Description      | No       | Multi-line text area (placeholder: *Enter description here*).               |
 
 3. Click **Create**.
@@ -36,7 +36,7 @@ displays:
 
 - Environment name and runtime count badge (e.g. *"0 runtimes"* or *"1/1 Online"*).
 - Refresh icon.
-- For BI integrations: **Entry Points** tab listing services/APIs, and a
+- For default profile integrations: **Entry Points** tab listing services/APIs, and a
   **Supporting Artifacts** tab (when artifacts are present).
 - **+ Add Runtime** link when no runtimes are registered.
 
@@ -69,7 +69,7 @@ When runtimes are present, a table shows:
 | ----------------- | ----------------------------------- |
 | Runtime Name      | Display name (or `-` if unset)      |
 | Runtime ID        | UUID                                |
-| Type              | BI                                  |
+| Type              | default profile                     |
 | Status            | RUNNING, OFFLINE, etc.              |
 | Version           | Runtime version                     |
 | Platform          | e.g. *Ballerina 2201.13.2 (Swan Lake Update 13)* |

--- a/en/docs/reference/icp/manage-projects.md
+++ b/en/docs/reference/icp/manage-projects.md
@@ -28,8 +28,8 @@ URL pattern: `https://<host>:9445/organizations/default`
 
 | Field            | Required | Description                                                                 |
 | ---------------- | -------- | --------------------------------------------------------------------------- |
-| Display Name     | Yes      | Human-readable name (e.g. `My BI Project`)                                  |
-| Name             | Auto     | URL-safe slug derived from the display name (e.g. `my-bi-project`). Click the edit icon to override. |
+| Display Name     | Yes      | Human-readable name (e.g. `My default profile Project`)                     |
+| Name             | Auto     | URL-safe slug derived from the display name (e.g. `my-default-profile-project`). Click the edit icon to override. |
 | Description      | No       | Free-text description (placeholder: *Enter Description here*)               |
 
 3. The **Create** button enables once Display Name is filled.
@@ -60,7 +60,7 @@ Clicking a project card navigates to the project home. The page shows:
 
 - Project avatar, display name, and description at the top.
 - An **Integrations** section with a searchable table and a **+ Create** button.
-- An **Integration Types** summary card on the right showing the count of integrations (Total, BI, MI).
+- An **Integration Types** summary card on the right showing the count of integrations (Total, default profile, MI).
 - If no integrations exist: *"No integrations found — Create your first integration to get started."*
 
 ### Project Sidebar

--- a/en/docs/reference/icp/manage-runtimes.md
+++ b/en/docs/reference/icp/manage-runtimes.md
@@ -5,7 +5,7 @@ description: View runtimes, generate secrets, and manage runtime connections in 
 
 # Manage Runtimes
 
-Runtimes are BI (or MI) processes that connect to ICP via heartbeats. The
+Runtimes are default profile (or MI) processes that connect to ICP via heartbeats. The
 Runtimes page is available at every level — organization, project, and
 integration — each scoped accordingly.
 
@@ -25,7 +25,7 @@ Runtimes are grouped by environment. Each environment section shows:
 | ----------------- | ----------------------------------------------------- |
 | Runtime Name      | Display name (`-` if not configured)                  |
 | Runtime ID        | UUID assigned on first heartbeat                      |
-| Type              | BI or MI                                              |
+| Type              | default profile or MI                                 |
 | Component         | Integration name this runtime belongs to              |
 | Status            | **RUNNING** (green badge), OFFLINE, etc.              |
 | Version           | Runtime version (or `—` if not reported)              |

--- a/en/docs/reference/reference.md
+++ b/en/docs/reference/reference.md
@@ -61,7 +61,7 @@ Command-line tools reference:
 - **[Access Control](../manage/icp/access-control.md)** — Control who can do what across organizations, projects, and integrations
 - **[Manage Projects](../manage/icp/manage-projects.md)** — Create, edit, and delete projects
 - **[Manage Environments](../manage/icp/manage-environments.md)** — Create, edit, and delete environments
-- **[Manage Integrations](../manage/icp/manage-integrations.md)** — Create and manage BI integrations
+- **[Manage Integrations](../manage/icp/manage-integrations.md)** — Create and manage default profile integrations
 - **[Manage Runtimes](../manage/icp/manage-runtimes.md)** — View runtimes, generate secrets, and manage connections
 - **[Server Configuration](icp/server-configuration.md)** — Server settings and authentication token keys
 - **[Database Configuration](icp/database-configuration.md)** — Main database and credentials database setup


### PR DESCRIPTION
## Summary

- Replaces all uses of the `BI` label with **default profile** across ICP console UI docs and reference pages (manage, deploy-operate, and reference sections)
- API enum values (`componentType`, `runtimeType`) retain `BI` as the actual wire value since only the UI terminology has changed
- Updates mermaid diagram node label in observability setup and renames the `<bi-logs>` placeholder to `<default-profile-logs>`

## Files changed

14 files across `en/docs/manage/icp/`, `en/docs/reference/icp/`, `en/docs/reference/api/`, `en/docs/deploy-operate/observe/`, and `en/docs/reference/reference.md`.

## Test plan

- [ ] Verify ICP console docs render "default profile" in integration type dropdowns, runtime type tables, and observability setup
- [ ] Confirm API reference docs still show `"BI"` as the enum value for `runtimeType` and `componentType`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Integration Control Plane documentation throughout to reference "default profile" terminology instead of "BI" for runtimes, integrations, and related configurations across installation guides, management, observability setup, and API references.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/366)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->