### PR TITLE
Add self-hosted deployment options

### DIFF
--- a/en/docs/deploy/self-hosted/docker.md
+++ b/en/docs/deploy/self-hosted/docker.md
@@ -1,0 +1,133 @@
+---
+title: Docker
+description: Build a Docker image from a WSO2 Integrator project using the Ballerina Code to Cloud feature.
+keywords: [wso2 integrator, docker, containerized deployment, code to cloud, bal build, cloud.toml]
+---
+
+# Docker
+
+WSO2 Integrator uses the Ballerina Code to Cloud feature to generate a Docker image directly from your source code. You do not need to write a Dockerfile by hand. The compiler derives the image from your code and the optional `Cloud.toml` configuration file.
+
+:::info Prerequisites
+- [Docker](https://www.docker.com/) installed and running on your build machine
+- A WSO2 Integrator project based on Ballerina
+:::
+
+:::note
+macOS users on Apple Silicon must set the following environment variable before building, because the Ballerina base Docker image does not yet support ARM:
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+This setting applies only to the current terminal session.
+:::
+
+## How Code to Cloud works
+
+When you build a Ballerina project with a cloud target, the compiler extension generates deployment artifacts alongside the executable JAR. The artifacts land in the `target/` directory:
+
+```
+├── Cloud.toml
+├── Ballerina.toml
+├── Config.toml
+└── target/
+    ├── bin/
+    │   └── <module>.jar
+    └── docker/
+        └── Dockerfile
+```
+
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted.
+
+**`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. You must supply it at runtime via a volume mount.
+
+## Step 1: Set the cloud target
+
+Open `Ballerina.toml` and add the cloud build option:
+
+```toml
+[build-options]
+cloud = "docker"
+```
+
+Alternatively, pass the flag inline at build time without modifying `Ballerina.toml`:
+
+```bash
+bal build --cloud=docker
+```
+
+## Step 2: Configure the image
+
+Create a `Cloud.toml` file in the project root. The `[container.image]` section controls the generated image name and tag:
+
+```toml
+[container.image]
+repository = "myorg"
+name = "my-integration"
+tag = "v1.0.0"
+
+[settings]
+buildImage = true
+```
+
+Set `buildImage = false` if you only need the generated Dockerfile without building the image locally.
+
+:::tip
+`Cloud.toml` is optional. If you skip it, the compiler falls back to the package metadata in `Ballerina.toml` (the `org`, `name`, and `version` fields) to name the image and set the tag.
+:::
+
+## Step 3: Create a Config.toml
+
+Create a `Config.toml` with values for any `configurable` variables in your code:
+
+```toml
+# Config.toml - provided at runtime, not packed into the image
+greeting = "Hello"
+```
+
+## Step 4: Build
+
+```bash
+bal build
+```
+
+The output confirms the image was built and shows the `docker run` command:
+
+```
+Compiling source
+        myorg/my-integration:1.0.0
+
+Generating executable
+
+Generating artifacts...
+
+        @kubernetes:Docker                       - complete 2/2
+
+        Execute the below command to run the generated Docker image:
+        docker run -d -p 9090:9090 myorg/my-integration:v1.0.0
+
+        target/bin/my-integration.jar
+```
+
+## Step 5: Run the container
+
+Mount your `Config.toml` into the container at runtime to supply the configurable values:
+
+```bash
+docker run -d \
+  -v /absolute/path/to/Config.toml:/home/ballerina/Config.toml \
+  -p 9090:9090 \
+  myorg/my-integration:v1.0.0
+```
+
+Verify the integration is running:
+
+```bash
+curl http://localhost:9090/helloWorld/sayHello
+```
+
+## What's next
+
+- [Kubernetes](./kubernetes.md) — Generate Kubernetes manifests and deploy to a cluster using Code to Cloud
+- [Red Hat OpenShift](./openshift.md) — Generate OpenShift manifests and deploy using the `oc` CLI

--- a/en/docs/deploy/self-hosted/kubernetes.md
+++ b/en/docs/deploy/self-hosted/kubernetes.md
@@ -1,0 +1,221 @@
+---
+title: Kubernetes
+description: Deploy a WSO2 Integrator project to Kubernetes using the Ballerina Code to Cloud feature.
+keywords: [wso2 integrator, kubernetes, containerized deployment, code to cloud, bal build, cloud.toml, kubectl]
+---
+
+# Kubernetes
+
+WSO2 Integrator uses the Ballerina Code to Cloud feature to generate Kubernetes manifests directly from your source code. The `cloud = "k8s"` build option produces a Docker image and a complete set of Kubernetes YAML files in a single `bal build` invocation.
+
+:::info Prerequisites
+- [Docker](https://www.docker.com/) installed and running on your build machine
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and configured against a Kubernetes cluster
+- A WSO2 Integrator project based on Ballerina
+:::
+
+:::note
+macOS users on Apple Silicon must set the following environment variable before building, because the Ballerina base Docker image does not yet support ARM:
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+This setting applies only to the current terminal session.
+:::
+
+## How Code to Cloud works
+
+When you build with `cloud = "k8s"`, the compiler generates Kubernetes manifests alongside the executable JAR:
+
+```
+├── Cloud.toml
+├── Ballerina.toml
+├── Config.toml
+└── target/
+    ├── bin/
+    │   └── <module>.jar
+    ├── docker/
+    │   └── Dockerfile
+    └── kubernetes/
+        └── <module>-0.0.1.yaml
+```
+
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted.
+
+**`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. Use the `[[cloud.config.files]]` entry in `Cloud.toml` to mount it as a Kubernetes ConfigMap at runtime.
+
+## Step 1: Set the cloud target
+
+Open `Ballerina.toml` and add the cloud build option:
+
+```toml
+[build-options]
+cloud = "k8s"
+```
+
+Alternatively, pass the flag inline at build time without modifying `Ballerina.toml`:
+
+```bash
+bal build --cloud=k8s
+```
+
+## Step 2: Configure the deployment
+
+Create a `Cloud.toml` with container, resource, autoscaling, ConfigMap, and probe settings:
+
+```toml
+[container.image]
+repository = "myorg"
+name = "my-integration"
+tag = "v1.0.0"
+
+[cloud.deployment]
+min_memory = "100Mi"
+max_memory = "256Mi"
+min_cpu = "500m"
+max_cpu = "500m"
+
+[cloud.deployment.autoscaling]
+min_replicas = 2
+max_replicas = 5
+cpu = 60
+
+[[cloud.config.files]]
+file = "./Config.toml"
+
+[cloud.deployment.probes.liveness]
+port = 9091
+path = "/probes/healthz"
+
+[cloud.deployment.probes.readiness]
+port = 9091
+path = "/probes/readyz"
+```
+
+The `[[cloud.config.files]]` entry mounts your `Config.toml` as a Kubernetes ConfigMap, which is the recommended way to supply configuration to Kubernetes workloads.
+
+:::note
+The `[cloud.deployment.probes.liveness]` and `[cloud.deployment.probes.readiness]` sections only apply to long-running service workloads. Omit them if your integration is an Automation. For services, add a dedicated probe listener in your Ballerina code to back these endpoints:
+
+```ballerina
+import ballerina/http;
+
+listener http:Listener probeEndpoint = new (9091);
+
+service /probes on probeEndpoint {
+    resource function get healthz() returns boolean {
+        return true;
+    }
+    resource function get readyz() returns boolean {
+        return true;
+    }
+}
+```
+:::
+
+## Step 3: Build
+
+```bash
+bal build
+```
+
+The compiler generates all Kubernetes manifests and prints the `kubectl apply` command:
+
+```
+Generating artifacts...
+
+        @kubernetes:Service                      - complete 1/2
+        @kubernetes:Service                      - complete 2/2
+        @kubernetes:ConfigMap                    - complete 1/1
+        @kubernetes:Deployment                   - complete 1/1
+        @kubernetes:HPA                          - complete 1/1
+        @kubernetes:Docker                       - complete 2/2
+
+        Execute the below command to deploy the Kubernetes artifacts:
+        kubectl apply -f /path/to/project/target/kubernetes/my-integration
+```
+
+For a service-type workload, the generated manifest includes a `Deployment`, `Service`, `ConfigMap`, and `HorizontalPodAutoscaler`. The  `HorizontalPodAutoscaler` is only generated when `[cloud.deployment.autoscaling]` is configured. 
+
+For Automations, the compiler generates a `Job` or `CronJob` resource instead of a `Deployment`, with no `Service` or `HorizontalPodAutoscaler`.
+
+## Step 4: Push the image
+
+Push the built image to your container registry before applying the manifests:
+
+```bash
+docker push myorg/my-integration:v1.0.0
+```
+
+:::tip
+If you are using Minikube, run `eval $(minikube docker-env)` before `bal build` to build the image directly into the Minikube Docker daemon. You can then skip the push step.
+:::
+
+## Step 5: Deploy
+
+```bash
+kubectl apply -f target/kubernetes/my-integration/
+```
+
+Expected output for a service-type workload:
+
+```
+service/my-integration-svc created
+configmap/config-config-map created
+deployment.apps/my-integration-deployment created
+horizontalpodautoscaler.autoscaling/my-integration-hpa created
+```
+
+:::note
+Automations generate `Job` or `CronJob` resources instead of a `Deployment`, and do not produce a `Service` or `HorizontalPodAutoscaler`.
+:::
+
+## Step 6: Verify
+
+```bash
+kubectl get pods
+kubectl get services
+kubectl logs -f deployment/my-integration-deployment
+```
+
+## Step 7: Expose and test
+
+:::note
+This step applies to service-type workloads that expose an HTTP endpoint. If your integration is an Automation or Event Listener, skip this step.
+:::
+
+Expose the deployment via NodePort to access it in a development cluster:
+
+```bash
+kubectl expose deployment my-integration-deployment \
+  --type=NodePort \
+  --name=my-integration-svc-local
+```
+
+Get the assigned port:
+
+```bash
+kubectl get svc my-integration-svc-local
+```
+
+If you are using Minikube, get the cluster IP:
+
+```bash
+minikube ip
+```
+
+Then call the service:
+
+```bash
+curl http://<cluster-ip>:<node-port>/helloWorld/sayHello
+```
+
+:::tip
+Code to Cloud does not expose every Kubernetes configuration option. For changes beyond what `Cloud.toml` supports, use [Kustomize](https://kustomize.io/) to patch the generated YAML without modifying it directly. This keeps generated files untouched and makes upgrades easier when you rebuild.
+:::
+
+## What's next
+
+- [Docker](./docker.md) — Build a Docker image from your project using Code to Cloud
+- [Red Hat OpenShift](./openshift.md) — Generate OpenShift manifests and deploy using the `oc` CLI

--- a/en/docs/deploy/self-hosted/openshift.md
+++ b/en/docs/deploy/self-hosted/openshift.md
@@ -1,0 +1,213 @@
+---
+title: Red Hat OpenShift
+description: Deploy a WSO2 Integrator project to Red Hat OpenShift using the Ballerina Code to Cloud feature.
+keywords: [wso2 integrator, openshift, red hat, containerized deployment, code to cloud, bal build, cloud.toml, oc]
+---
+
+# Red Hat OpenShift
+
+WSO2 Integrator uses the Ballerina Code to Cloud feature to generate OpenShift manifests directly from your source code. The `cloud = "openshift"` build option produces a Docker image and a complete set of OpenShift YAML files in a single `bal build` invocation. The generated manifests are structurally identical to the Kubernetes output but land in `target/openshift/` and are applied using the `oc` CLI.
+
+:::info Prerequisites
+- [Docker](https://www.docker.com/) installed and running on your build machine
+- [OpenShift CLI (`oc`)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) installed and logged in to your cluster
+- A WSO2 Integrator project based on Ballerina
+:::
+
+:::note
+macOS users on Apple Silicon must set the following environment variable before building, because the Ballerina base Docker image does not yet support ARM:
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+This setting applies only to the current terminal session.
+:::
+
+## How Code to Cloud works
+
+When you build with `cloud = "openshift"`, the compiler generates OpenShift manifests alongside the executable JAR:
+
+```
+├── Cloud.toml
+├── Ballerina.toml
+├── Config.toml
+└── target/
+    ├── bin/
+    │   └── <module>.jar
+    ├── docker/
+    │   └── Dockerfile
+    └── openshift/
+        └── <module>-0.0.1.yaml
+```
+
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted.
+
+**`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. Use the `[[cloud.config.files]]` entry in `Cloud.toml` to mount it as a ConfigMap at runtime.
+
+## Step 1: Set the cloud target
+
+Open `Ballerina.toml` and add the cloud build option:
+
+```toml
+[build-options]
+cloud = "openshift"
+```
+
+Alternatively, pass the flag inline at build time without modifying `Ballerina.toml`:
+
+```bash
+bal build --cloud=openshift
+```
+
+## Step 2: Configure the deployment
+
+Create a `Cloud.toml` with container, resource, autoscaling, ConfigMap, and probe settings:
+
+```toml
+[container.image]
+repository = "myorg"
+name = "my-integration"
+tag = "v1.0.0"
+
+[cloud.deployment]
+min_memory = "100Mi"
+max_memory = "256Mi"
+min_cpu = "500m"
+max_cpu = "500m"
+
+[cloud.deployment.autoscaling]
+min_replicas = 2
+max_replicas = 5
+cpu = 60
+
+[[cloud.config.files]]
+file = "./Config.toml"
+
+[cloud.deployment.probes.liveness]
+port = 9091
+path = "/probes/healthz"
+
+[cloud.deployment.probes.readiness]
+port = 9091
+path = "/probes/readyz"
+```
+
+The `[[cloud.config.files]]` entry mounts your `Config.toml` as a ConfigMap, which is the recommended way to supply configuration to OpenShift workloads.
+
+:::note
+The `[cloud.deployment.probes.liveness]` and `[cloud.deployment.probes.readiness]` sections only apply to long-running service workloads. Omit them if your integration is an Automation. For services, add a dedicated probe listener in your Ballerina code to back these endpoints:
+
+```ballerina
+import ballerina/http;
+
+listener http:Listener probeEndpoint = new (9091);
+
+service /probes on probeEndpoint {
+    resource function get healthz() returns boolean {
+        return true;
+    }
+    resource function get readyz() returns boolean {
+        return true;
+    }
+}
+```
+:::
+
+## Step 3: Build
+
+```bash
+bal build
+```
+
+The compiler generates all OpenShift manifests and prints the `oc apply` command:
+
+```
+Generating artifacts...
+
+        @kubernetes:Service                      - complete 1/2
+        @kubernetes:Service                      - complete 2/2
+        @kubernetes:ConfigMap                    - complete 1/1
+        @kubernetes:Deployment                   - complete 1/1
+        @kubernetes:HPA                          - complete 1/1
+        @kubernetes:Docker                       - complete 2/2
+
+        Execute the below command to deploy the Kubernetes artifacts:
+        oc apply -f /path/to/project/target/openshift/my-integration
+
+        target/bin/my-integration.jar
+```
+
+For a service-type workload, the generated manifest includes a `Deployment`, `Service`, `ConfigMap`, and `HorizontalPodAutoscaler`. The  `HorizontalPodAutoscaler` is only generated when `[cloud.deployment.autoscaling]` is configured. 
+
+For Automations, the compiler generates a `Job` or `CronJob` resource instead of a `Deployment`, with no `Service` or `HorizontalPodAutoscaler`.
+
+## Step 4: Push the image
+
+Push the built image to your container registry before applying the manifests:
+
+```bash
+docker push myorg/my-integration:v1.0.0
+```
+
+## Step 5: Deploy
+
+```bash
+oc apply -f target/openshift/my-integration/
+```
+
+Expected output:
+
+```
+service/my-integration-svc created
+configmap/config-config-map created
+deployment.apps/my-integration-deployment created
+horizontalpodautoscaler.autoscaling/my-integration-hpa created
+```
+
+:::note
+Automations generate `Job` or `CronJob` resources instead of a `Deployment`, and do not produce a `Service` or `HorizontalPodAutoscaler`.
+:::
+
+## Step 6: Verify
+
+```bash
+oc get pods
+oc get services
+oc logs -f deployment/my-integration-deployment
+```
+
+## Step 7: Expose and test
+
+:::note
+This step applies to service-type workloads that expose an HTTP endpoint. If your integration is an Automation or Event Listener, skip this step.
+:::
+
+Expose the deployment via NodePort to access it in a development cluster:
+
+```bash
+oc expose deployment my-integration-deployment \
+  --type=NodePort \
+  --name=my-integration-svc-local
+```
+
+Get the assigned port:
+
+```bash
+oc get svc my-integration-svc-local
+```
+
+Then call the service:
+
+```bash
+curl http://<cluster-ip>:<node-port>/helloWorld/sayHello
+```
+
+:::tip
+Code to Cloud does not expose every OpenShift configuration option. For changes beyond what `Cloud.toml` supports, use [Kustomize](https://kustomize.io/) to patch the generated YAML without modifying it directly. This keeps generated files untouched and makes upgrades easier when you rebuild.
+:::
+
+## What's next
+
+- [Docker](./docker.md) — Build a Docker image from your project using Code to Cloud
+- [Kubernetes](./kubernetes.md) — Generate Kubernetes manifests and deploy to a cluster using Code to Cloud

--- a/en/docs/deploy/self-hosted/run-locally.md
+++ b/en/docs/deploy/self-hosted/run-locally.md
@@ -29,7 +29,7 @@ To run the project on your local machine:
     bal run
     ```
 
-The Ballerina CLI compiles the project and starts the integration runtime. You will see the program output in the terminal. Integrations with listeners keep runnnig until you terminate it by **`CTRL + C`**
+The Ballerina CLI compiles the project and starts the integration runtime. You will see the program output in the terminal. Integrations with listeners keep running until you terminate it by **`CTRL + C`**
 
 ## Run on a VM
 

--- a/en/docs/deploy/self-hosted/run-locally.md
+++ b/en/docs/deploy/self-hosted/run-locally.md
@@ -1,0 +1,75 @@
+---
+title: Run locally
+description: Run a WSO2 Integrator project using the Ballerina CLI, both on your local machine and on a remote VM.
+keywords: [wso2 integrator, bal run, run locally, vm deployment, ballerina cli]
+---
+
+# Run your integration locally
+
+This page explains how to run a WSO2 Integrator project using the Ballerina CLI. You can run it directly on your local machine during development or on a remote virtual machine for a self-hosted deployment.
+
+:::info Prerequisites
+- [Ballerina installed](https://ballerina.io/downloads/) on any machine where you want to run the project
+- A WSO2 Integrator project based on Ballerina
+:::
+
+## Run locally
+
+To run the project on your local machine:
+
+1. Open a terminal and navigate to the project directory.
+
+    ```bash
+    cd my-integration
+    ```
+
+2. Start the project.
+
+    ```bash
+    bal run
+    ```
+
+The Ballerina CLI compiles the project and starts the integration runtime. You will see the program output in the terminal. Integrations with listeners keep runnnig until you terminate it by **`CTRL + C`**
+
+## Run on a VM
+
+To run the project on a remote virtual machine, install the Ballerina distribution on the VM and run the project directly from source using `bal run`.
+
+### Step 1: Push the project to a remote Git repository
+
+From your local machine, push the project to a remote Git repository such as GitHub, GitLab, or Bitbucket.
+
+```bash
+git add .
+git commit -m "Initial integration project"
+git push origin main
+```
+
+### Step 2: Clone the repository on the VM
+
+SSH into the target VM and clone the repository.
+
+```bash
+git clone https://github.com/your-org/my-integration.git
+cd my-integration
+```
+
+### Step 3: Start the integration
+
+Run the project using the Ballerina CLI.
+
+```bash
+bal run
+```
+
+The runtime starts and the integration begins serving traffic on the configured port.
+
+:::note
+Ballerina must be installed on the VM. Download it from [ballerina.io](https://ballerina.io/downloads/). The version on the VM should match the version used during development.
+:::
+
+## What's next
+
+- [Docker](./docker.md) — Build a Docker image from your project using Code to Cloud
+- [Kubernetes](./kubernetes.md) — Generate Kubernetes manifests and deploy to a cluster using Code to Cloud
+- [Red Hat OpenShift](./openshift.md) — Generate OpenShift manifests and deploy using the `oc` CLI

--- a/en/sidebars.ts
+++ b/en/sidebars.ts
@@ -1890,6 +1890,16 @@ const sidebars: SidebarsConfig = {
             'deploy/cloud/import-integration',
           ],
         },
+        {
+          type: 'category',
+          label: 'Self-hosted',
+          items: [
+            'deploy/self-hosted/run-locally',
+            'deploy/self-hosted/docker',
+            'deploy/self-hosted/kubernetes',
+            'deploy/self-hosted/openshift',
+          ],
+        },
       ],
     },
 


### PR DESCRIPTION
$subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment guides for WSO2 Integrator covering Docker, Kubernetes, OpenShift, and local execution using Ballerina's Code to Cloud feature.
  * Guides include prerequisites, step-by-step instructions, and configuration examples for each platform.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/375)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->