### PR TITLE
Replace BI with default profile in ICP docs

### DIFF
--- a/en/docs/deploy-operate/observe/integration-control-plane-icp.md
+++ b/en/docs/deploy-operate/observe/integration-control-plane-icp.md
@@ -26,7 +26,7 @@ Key capabilities:
 
 ### Configuring the integration node with ICP
 
-ICP allows you to connect default profile and MI runtimes to the ICP server for centralized management and monitoring.
+ICP allows you to connect Ballerina and MI runtimes to the ICP server for centralized management and monitoring.
 This guide will walk you through the steps to connect your integration runtime to the ICP server.
 
 1. Navigate to the home view of WSO2 Integrator.

--- a/en/docs/manage/icp/connect-runtime.md
+++ b/en/docs/manage/icp/connect-runtime.md
@@ -32,7 +32,7 @@ or when the component does not exist in ICP yet.
 1. Navigate to **Runtimes** in the sidebar.
 2. Find the target environment card (e.g. *dev*) and click **Add Runtime**.
 3. Click **Generate Secret**.
-4. The **default profile** tab is selected by default. Copy the `Config.toml` snippet shown.
+4. The **default** tab is selected by default. Copy the `Config.toml` snippet shown.
 
 > The secret is displayed only once. Copy it before closing the dialog.
 
@@ -115,20 +115,20 @@ Full heartbeat acknowledged by ICP server
 
 The runtime now appears under **Runtimes** in the ICP console with status **RUNNING**.
 
-## Multiple default profile Nodes
+## Multiple modes
 
-Each default profile node needs a unique `runtime` value but can share the same `project`,
+Each node needs a unique `runtime` value but can share the same `project`,
 `integration`, `environment`, and `secret`. All nodes appear as separate runtimes
 under the same component in ICP.
 
 ```toml
 # Node 1
 [wso2.icp.runtime.bridge]
-runtime = "default-profile-node-1"
+runtime = "ballerina-runtime-node-1"
 
 # Node 2
 [wso2.icp.runtime.bridge]
-runtime = "default-profile-node-2"
+runtime = "ballerina-runtime-node-2"
 ```
 
 ## Troubleshooting
@@ -136,7 +136,7 @@ runtime = "default-profile-node-2"
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `Full heartbeat rejected` | Wrong or revoked secret | Generate a new secret in the console |
-| Runtime shows but status is not RUNNING | Heartbeats stopped | Check the default profile process is alive and network is reachable |
+| Runtime shows but status is not RUNNING | Heartbeats stopped | Check the runtime node process is alive and network is reachable |
 | `PKIX path building failed` | Self-signed ICP certificate | Set `enableSSL = false` (non-production) or provide the CA via `cert` |
 
 ## Next Step

--- a/en/docs/manage/icp/connect-runtime.md
+++ b/en/docs/manage/icp/connect-runtime.md
@@ -115,7 +115,7 @@ Full heartbeat acknowledged by ICP server
 
 The runtime now appears under **Runtimes** in the ICP console with status **RUNNING**.
 
-## Multiple modes
+## Multiple runtime nodes
 
 Each node needs a unique `runtime` value but can share the same `project`,
 `integration`, `environment`, and `secret`. All nodes appear as separate runtimes

--- a/en/docs/manage/icp/icp-console-overview.md
+++ b/en/docs/manage/icp/icp-console-overview.md
@@ -61,17 +61,17 @@ To add another (e.g. *staging*), see
 
 Full details: [Manage Projects](manage-projects.md).
 
-### 3. Create a default profile Integration
+### 3. Create an Integration
 
 1. Inside the project, click **+ Create**.
-2. Enter a **Display Name**. Integration Type defaults to **default profile**.
+2. Enter a **Display Name**. Integration Type defaults to **default**. 
 3. Click **Create**.
 
 Full details: [Manage Integrations](manage-integrations.md).
 
 ### 4. Connect a Runtime
 
-1. Generate a secret and configure your default profile runtime — see [Connect an Integration to ICP](connect-runtime.md).
+1. Generate a secret and configure your runtime — see [Connect an Integration to ICP](connect-runtime.md).
 2. Start the runtime. It appears in the Runtimes table with status **RUNNING**.
 
 Full details: [Manage Runtimes](manage-runtimes.md).


### PR DESCRIPTION
## Summary
- Replaced references to \"BI\" with \"default profile\" across ICP documentation
- Updated 14 files covering ICP console, connect-runtime, install, manage-integrations, manage-projects, manage-runtimes, observability setup, and API reference docs

## Test plan
- [ ] Verify updated terminology is consistent across all ICP doc pages
- [ ] Check that no remaining \"BI\" references exist where \"default profile\" should be used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ICP documentation with clarified terminology for configuring Ballerina and MI runtime integration and centralized management
  * Revised ICP Console Quick Start instructions for creating standard integrations and connecting runtime nodes with improved UI labeling
  * Enhanced runtime node documentation including updated configuration examples, naming conventions, and refined troubleshooting guidance for multi-node deployments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/394)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->