### PR TITLE
Update MongoDB connector docs

### DIFF
--- a/en/docs/connectors/catalog/database/mongodb/actions.md
+++ b/en/docs/connectors/catalog/database/mongodb/actions.md
@@ -1,5 +1,6 @@
 ---
-title: Actions
+connector: true
+connector_name: "mongodb"
 toc_max_heading_level: 4
 ---
 
@@ -13,7 +14,9 @@ The `ballerinax/mongodb` package exposes the following clients:
 | [`Database`](#database) | Represents a MongoDB database. Manage collections and drop the database. |
 | [`Collection`](#collection) | Document CRUD, queries, aggregation pipelines, distinct values, and index management. |
 
-> **Note on error types**: All operations return errors as `mongodb:Error`, a union of `mongodb:DatabaseError`, `mongodb:ApplicationError`, and Ballerina's built-in `error`. `mongodb:DatabaseError` carries an additional `mongoDBExceptionType` detail field for command-level failures.
+:::note Error types
+All operations return errors as `mongodb:Error`, a union of `mongodb:DatabaseError`, `mongodb:ApplicationError`, and Ballerina's built-in `error`. `mongodb:DatabaseError` carries an additional `mongoDBExceptionType` detail field for command-level failures.
+:::
 
 ---
 
@@ -25,8 +28,8 @@ Top-level client for connecting to MongoDB, listing databases, and obtaining Dat
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection` | `ConnectionParameters\|string` | Required | Structured connection parameters or a MongoDB connection string URI. |
-| `options` | `ConnectionProperties?` | `()` | Optional connection properties (read concern, write concern, pool settings, SSL, timeouts). |
+| `connection` | <code>ConnectionParameters&#124;string</code> | Required | Structured connection parameters or a MongoDB connection string URI. |
+| `options` | <code>ConnectionProperties?</code> | `()` | Optional connection properties (read concern, write concern, pool settings, SSL, timeouts). |
 
 ### Initializing the client
 
@@ -81,7 +84,7 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `databaseName` | `string` | Yes | Name of the database to retrieve. |
+| `databaseName` | <code>string</code> | Yes | Name of the database to retrieve. |
 
 Returns: `mongodb:Database|mongodb:Error`
 
@@ -123,7 +126,7 @@ Represents a MongoDB database. Manage collections and drop the database.
 
 ### Configuration
 
-> `Database` has no direct configuration. Instances are obtained via `Client->getDatabase()`.
+`Database` has no direct configuration. Instances are obtained through `Client->getDatabase()`.
 
 ### Initializing the client
 
@@ -178,7 +181,7 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `collectionName` | `string` | Yes | Name of the collection to create. |
+| `collectionName` | <code>string</code> | Yes | Name of the collection to create. |
 
 Returns: `mongodb:Error?`
 
@@ -203,7 +206,7 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `collectionName` | `string` | Yes | Name of the collection to retrieve. |
+| `collectionName` | <code>string</code> | Yes | Name of the collection to retrieve. |
 
 Returns: `mongodb:Collection|mongodb:Error`
 
@@ -247,7 +250,7 @@ Document CRUD, queries, aggregation pipelines, distinct values, and index manage
 
 ### Configuration
 
-> `Collection` has no direct configuration. Instances are obtained via `Database->getCollection()`.
+`Collection` has no direct configuration. Instances are obtained through `Database->getCollection()`.
 
 ### Initializing the client
 
@@ -277,8 +280,8 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `document` | `record {\|anydata...;\|}` | Yes | The document to insert. |
-| `options` | `InsertOneOptions` | No | Insert options (comment, bypassDocumentValidation). |
+| `document` | <code>record &#123;&#124;anydata...;&#124;&#125;</code> | Yes | The document to insert. |
+| `options` | <code>InsertOneOptions</code> | No | Insert options (comment, bypassDocumentValidation). |
 
 Returns: `mongodb:Error?`
 
@@ -307,8 +310,8 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `documents` | `record {\|anydata...;\|}[]` | Yes | Array of documents to insert. |
-| `options` | `InsertManyOptions` | No | Insert options (comment, bypassDocumentValidation, ordered). |
+| `documents` | <code>record &#123;&#124;anydata...;&#124;&#125;[]</code> | Yes | Array of documents to insert. |
+| `options` | <code>InsertManyOptions</code> | No | Insert options (comment, bypassDocumentValidation, ordered). |
 
 Returns: `mongodb:Error?`
 
@@ -339,10 +342,10 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `filter` | `map<json>` | No | Query filter document. Defaults to `{}` (match all). |
-| `findOptions` | `FindOptions` | No | Sort, limit, skip, and batchSize options. |
-| `projection` | `map<json>?` | No | Projection document to include/exclude fields. |
-| `targetType` | `typedesc<record {\|anydata...;\|}>` | No | Expected record type for results (inferred from context). |
+| `filter` | <code>map&lt;json&gt;</code> | No | Query filter document. Defaults to `{}` (match all). |
+| `findOptions` | <code>FindOptions</code> | No | Sort, limit, skip, and batchSize options. |
+| `projection` | <code>map&lt;json&gt;?</code> | No | Projection document to include or exclude fields. |
+| `targetType` | <code>typedesc&lt;record &#123;&#124;anydata...;&#124;&#125;&gt;</code> | No | Expected record type for results (inferred from context). |
 
 Returns: `stream<targetType, error?>|mongodb:Error`
 
@@ -380,10 +383,10 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `filter` | `map<json>` | No | Query filter document. |
-| `findOptions` | `FindOptions` | No | Sort, limit, skip, and batchSize options. |
-| `projection` | `map<json>?` | No | Projection document to include/exclude fields. |
-| `targetType` | `typedesc<record {\|anydata...;\|}>` | No | Expected record type (inferred from context). |
+| `filter` | <code>map&lt;json&gt;</code> | No | Query filter document. |
+| `findOptions` | <code>FindOptions</code> | No | Sort, limit, skip, and batchSize options. |
+| `projection` | <code>map&lt;json&gt;?</code> | No | Projection document to include or exclude fields. |
+| `targetType` | <code>typedesc&lt;record &#123;&#124;anydata...;&#124;&#125;&gt;</code> | No | Expected record type (inferred from context). |
 
 Returns: `targetType|mongodb:Error?`
 
@@ -414,8 +417,8 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `filter` | `map<json>` | No | Query filter document. Defaults to `{}` (count all). |
-| `options` | `CountOptions` | No | Options for limit, skip, maxTimeMS, and hint. |
+| `filter` | <code>map&lt;json&gt;</code> | No | Query filter document. Defaults to `{}` (count all). |
+| `options` | <code>CountOptions</code> | No | Options for limit, skip, maxTimeMS, and hint. |
 
 Returns: `int|mongodb:Error`
 
@@ -446,9 +449,9 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `fieldName` | `string` | Yes | The field name to get distinct values for. |
-| `filter` | `map<json>` | No | Query filter document. Defaults to `{}` (all documents). |
-| `targetType` | `typedesc<anydata>` | No | Type for distinct values (inferred from context). |
+| `fieldName` | <code>string</code> | Yes | The field name to get distinct values for. |
+| `filter` | <code>map&lt;json&gt;</code> | No | Query filter document. Defaults to `{}` (all documents). |
+| `targetType` | <code>typedesc&lt;anydata&gt;</code> | No | Type for distinct values (inferred from context). |
 
 Returns: `stream<targetType, error?>|mongodb:Error`
 
@@ -482,9 +485,9 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `filter` | `map<json>` | Yes | Filter to match the document to update. |
-| `update` | `Update` | Yes | Update operators record (`set`, `unset`, `inc`, `mul`, `rename`, etc.). |
-| `options` | `UpdateOptions` | No | Options for upsert, bypassDocumentValidation, comment, hint, and hintString. |
+| `filter` | <code>map&lt;json&gt;</code> | Yes | Filter to match the document to update. |
+| `update` | <code>Update</code> | Yes | Update operators record (`set`, `unset`, `inc`, `mul`, `rename`, etc.). |
+| `options` | <code>UpdateOptions</code> | No | Options for upsert, bypassDocumentValidation, comment, hint, and hintString. |
 
 Returns: `UpdateResult|mongodb:Error`
 
@@ -503,7 +506,9 @@ Sample response:
 {"matchedCount": 1, "modifiedCount": 1}
 ```
 
-**Note:** The `upsertedId` field appears in the response only when the operation performs an upsert (`upsert: true` is set in `UpdateOptions` and a new document is inserted as a result). For non-upsert calls like the sample above, the field is omitted from the result entirely.
+:::note
+The `upsertedId` field appears in the response only when the operation performs an upsert (`upsert: true` is set in `UpdateOptions` and a new document is inserted as a result). For non-upsert calls like the sample above, the field is omitted from the result entirely.
+:::
 
 </div>
 
@@ -520,9 +525,9 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `filter` | `map<json>` | Yes | Filter to match documents to update. |
-| `update` | `Update` | Yes | Update operators record. |
-| `options` | `UpdateOptions` | No | Options for upsert, bypassDocumentValidation, comment, hint, and hintString. |
+| `filter` | <code>map&lt;json&gt;</code> | Yes | Filter to match documents to update. |
+| `update` | <code>Update</code> | Yes | Update operators record. |
+| `options` | <code>UpdateOptions</code> | No | Options for upsert, bypassDocumentValidation, comment, hint, and hintString. |
 
 Returns: `UpdateResult|mongodb:Error`
 
@@ -541,7 +546,9 @@ Sample response:
 {"matchedCount": 3, "modifiedCount": 3}
 ```
 
-**Note:** The `upsertedId` field appears in the response only when the operation performs an upsert. For non-upsert calls like the sample above, the field is omitted from the result entirely.
+:::note
+The `upsertedId` field appears in the response only when the operation performs an upsert. For non-upsert calls like the sample above, the field is omitted from the result entirely.
+:::
 
 </div>
 
@@ -560,7 +567,7 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `filter` | `map<json>` | Yes | Filter to match the document to delete. |
+| `filter` | <code>map&lt;json&gt;</code> | Yes | Filter to match the document to delete. |
 
 Returns: `DeleteResult|mongodb:Error`
 
@@ -591,7 +598,7 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `filter` | `string\|map<json>` | Yes | Filter for documents to delete. |
+| `filter` | <code>string&#124;map&lt;json&gt;</code> | Yes | Filter for documents to delete. |
 
 Returns: `DeleteResult|mongodb:Error`
 
@@ -624,8 +631,8 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `pipeline` | `map<json>[]` | Yes | Array of aggregation pipeline stage documents. |
-| `targetType` | `typedesc<anydata>` | No | Expected result type (inferred from context). |
+| `pipeline` | <code>map&lt;json&gt;[]</code> | Yes | Array of aggregation pipeline stage documents. |
+| `targetType` | <code>typedesc&lt;anydata&gt;</code> | No | Expected result type (inferred from context). |
 
 Returns: `stream<targetType, error?>|mongodb:Error`
 
@@ -667,8 +674,8 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `keys` | `map<json>` | Yes | Index key specification (field name to direction, e.g. `{"title": 1}` for ascending). |
-| `options` | `CreateIndexOptions` | No | Index options (unique, sparse, name, expireAfterSeconds, etc.). |
+| `keys` | <code>map&lt;json&gt;</code> | Yes | Index key specification (field name to direction, for example `{"title": 1}` for ascending). |
+| `options` | <code>CreateIndexOptions</code> | No | Index options (unique, sparse, name, expireAfterSeconds, etc.). |
 
 Returns: `mongodb:Error?`
 
@@ -720,7 +727,7 @@ Parameters:
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `indexName` | `string` | Yes | Name of the index to drop. |
+| `indexName` | <code>string</code> | Yes | Name of the index to drop. |
 
 Returns: `mongodb:Error?`
 
@@ -805,15 +812,15 @@ Structured connection parameters used in `ConnectionConfig.connection`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `serverAddress` | `ServerAddress\|ServerAddress[]` | `{}` | A single server address, or an array for replica sets / sharded clusters. |
-| `auth` | `BasicAuthCredential \| ScramSha1AuthCredential \| ScramSha256AuthCredential \| X509Credential \| GssApiCredential` | `()` | Optional. Authentication credentials: pick the record that matches your server's configured auth mechanism. See [Authentication credentials](#authentication-credentials) below. |
+| `serverAddress` | <code>ServerAddress&#124;ServerAddress[]</code> | `{}` | A single server address, or an array for replica sets and sharded clusters. |
+| `auth` | <code>BasicAuthCredential&#124;ScramSha1AuthCredential&#124;ScramSha256AuthCredential&#124;X509Credential&#124;GssApiCredential</code> | `()` | Optional. Authentication credentials: pick the record that matches your server's configured auth mechanism. See [Authentication credentials](#authentication-credentials) below. |
 
 ### `ServerAddress`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `host` | `string` | `"localhost"` | MongoDB server hostname or IP. |
-| `port` | `int` | `27017` | MongoDB server port. |
+| `host` | <code>string</code> | `"localhost"` | MongoDB server hostname or IP. |
+| `port` | <code>int</code> | `27017` | MongoDB server port. |
 
 ### Authentication credentials
 
@@ -823,10 +830,10 @@ The `auth` field of `ConnectionParameters` accepts one of five records, each tag
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `authMechanism` | `AUTH_PLAIN` | `AUTH_PLAIN` | Always `"PLAIN"`. Read-only. |
-| `username` | `string` | Required | Username. |
-| `password` | `string` | Required | Password. |
-| `database` | `string` | Required | Authentication source database (typically `"admin"`). |
+| `authMechanism` | <code>AUTH_PLAIN</code> | `AUTH_PLAIN` | Always `"PLAIN"`. Read-only. |
+| `username` | <code>string</code> | Required | Username. |
+| `password` | <code>string</code> | Required | Password. |
+| `database` | <code>string</code> | Required | Authentication source database (typically `"admin"`). |
 
 #### `ScramSha1AuthCredential`: SCRAM-SHA-1
 
@@ -840,16 +847,16 @@ Same field shape as `BasicAuthCredential`. The `authMechanism` is the constant `
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `authMechanism` | `AUTH_MONGODB_X509` | `AUTH_MONGODB_X509` | Always `"MONGODB_X509"`. Read-only. |
-| `username` | `string?` | `()` | Optional username for client-certificate authentication. Omit to use the certificate subject. |
+| `authMechanism` | <code>AUTH_MONGODB_X509</code> | `AUTH_MONGODB_X509` | Always `"MONGODB_X509"`. Read-only. |
+| `username` | <code>string?</code> | `()` | Optional username for client-certificate authentication. Omit to use the certificate subject. |
 
 #### `GssApiCredential`: GSSAPI / Kerberos
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `authMechanism` | `AUTH_GSSAPI` | `AUTH_GSSAPI` | Always `"GSSAPI"`. Read-only. |
-| `username` | `string` | Required | Kerberos principal username. |
-| `serviceName` | `string?` | `()` | Override the default service name (`"mongodb"`). |
+| `authMechanism` | <code>AUTH_GSSAPI</code> | `AUTH_GSSAPI` | Always `"GSSAPI"`. Read-only. |
+| `username` | <code>string</code> | Required | Kerberos principal username. |
+| `serviceName` | <code>string?</code> | `()` | Override the default service name (`"mongodb"`). |
 
 ### `ConnectionProperties`
 
@@ -857,30 +864,30 @@ Optional connection-level settings passed via `ConnectionConfig.options`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `readConcern` | `ReadConcern?` | `()` | Read concern level (see below). |
-| `writeConcern` | `string?` | `()` | Write concern level (e.g. `"majority"`). |
-| `readPreference` | `string?` | `()` | Read preference for replica sets (e.g. `"secondaryPreferred"`). |
-| `replicaSet` | `string?` | `()` | Replica-set name. The driver uses it to validate that the cluster matches. |
-| `sslEnabled` | `boolean` | `false` | Enable SSL/TLS. Set `secureSocket` together with this when a custom trust chain is needed. |
-| `invalidHostNameAllowed` | `boolean` | `false` | Allow invalid hostnames in TLS handshakes. |
-| `secureSocket` | `SecureSocket?` | `()` | TLS keystore/truststore configuration. Required when `sslEnabled` is `true` and you provide custom certificates. |
-| `retryWrites` | `boolean?` | `()` | Retry writes on transient errors. |
-| `socketTimeout` | `int?` | `()` | Socket timeout in milliseconds. |
-| `connectionTimeout` | `int?` | `()` | Connection timeout in milliseconds. |
-| `maxPoolSize` | `int?` | `()` | Maximum connections in the pool. |
-| `maxIdleTime` | `int?` | `()` | Maximum idle time of a pooled connection (milliseconds). |
-| `maxLifeTime` | `int?` | `()` | Maximum lifetime of a pooled connection (milliseconds). |
-| `minPoolSize` | `int?` | `()` | Minimum pool size. |
-| `localThreshold` | `int?` | `()` | Local-threshold latency for server selection (milliseconds). |
-| `heartbeatFrequency` | `int?` | `()` | Frequency of cluster heartbeats (milliseconds). |
+| `readConcern` | <code>ReadConcern?</code> | `()` | Read concern level (see below). |
+| `writeConcern` | <code>string?</code> | `()` | Write concern level (for example `"majority"`). |
+| `readPreference` | <code>string?</code> | `()` | Read preference for replica sets (for example `"secondaryPreferred"`). |
+| `replicaSet` | <code>string?</code> | `()` | Replica-set name. The driver uses it to validate that the cluster matches. |
+| `sslEnabled` | <code>boolean</code> | `false` | Enable SSL/TLS. Set `secureSocket` together with this when a custom trust chain is needed. |
+| `invalidHostNameAllowed` | <code>boolean</code> | `false` | Allow invalid hostnames in TLS handshakes. |
+| `secureSocket` | <code>SecureSocket?</code> | `()` | TLS keystore and truststore configuration. Required when `sslEnabled` is `true` and you provide custom certificates. |
+| `retryWrites` | <code>boolean?</code> | `()` | Retry writes on transient errors. |
+| `socketTimeout` | <code>int?</code> | `()` | Socket timeout in milliseconds. |
+| `connectionTimeout` | <code>int?</code> | `()` | Connection timeout in milliseconds. |
+| `maxPoolSize` | <code>int?</code> | `()` | Maximum connections in the pool. |
+| `maxIdleTime` | <code>int?</code> | `()` | Maximum idle time of a pooled connection (milliseconds). |
+| `maxLifeTime` | <code>int?</code> | `()` | Maximum lifetime of a pooled connection (milliseconds). |
+| `minPoolSize` | <code>int?</code> | `()` | Minimum pool size. |
+| `localThreshold` | <code>int?</code> | `()` | Local-threshold latency for server selection (milliseconds). |
+| `heartbeatFrequency` | <code>int?</code> | `()` | Frequency of cluster heartbeats (milliseconds). |
 
 ### `SecureSocket`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `trustStore` | `crypto:TrustStore` | Required | Truststore (JKS / PKCS12) holding the CA certificates the client trusts. |
-| `keyStore` | `crypto:KeyStore` | Required | Keystore holding the client certificate (used for X.509 auth or mutual TLS). |
-| `protocol` | `string` | Required | TLS protocol name (e.g. `"TLS"`, `"TLSv1.2"`, `"TLSv1.3"`). |
+| `trustStore` | <code>crypto:TrustStore</code> | Required | Truststore (JKS or PKCS12) holding the CA certificates the client trusts. |
+| `keyStore` | <code>crypto:KeyStore</code> | Required | Keystore holding the client certificate (used for X.509 auth or mutual TLS). |
+| `protocol` | <code>string</code> | Required | TLS protocol name (for example `"TLS"`, `"TLSv1.2"`, `"TLSv1.3"`). |
 
 ### `ReadConcern`
 
@@ -898,69 +905,69 @@ A union of the supported read-concern levels:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `comment` | `string?` | `()` | Comment included with the operation in MongoDB logs. |
-| `bypassDocumentValidation` | `boolean` | `false` | Skip server-side schema validation. |
+| `comment` | <code>string?</code> | `()` | Comment included with the operation in MongoDB logs. |
+| `bypassDocumentValidation` | <code>boolean</code> | `false` | Skip server-side schema validation. |
 
 ### `InsertManyOptions`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `comment` | `string?` | `()` | Comment included with the operation. |
-| `bypassDocumentValidation` | `boolean` | `false` | Skip server-side schema validation. |
-| `ordered` | `boolean` | `true` | When `true`, insertion stops at the first error; when `false`, attempts every document and reports per-document failures. |
+| `comment` | <code>string?</code> | `()` | Comment included with the operation. |
+| `bypassDocumentValidation` | <code>boolean</code> | `false` | Skip server-side schema validation. |
+| `ordered` | <code>boolean</code> | `true` | When `true`, insertion stops at the first error. When `false`, the connector attempts every document and reports per-document failures. |
 
 ### `FindOptions`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `sort` | `map<json>` | `{}` | Sort specification (e.g. `{"year": -1}`). |
-| `limit` | `int?` | `()` | Maximum number of documents to return. |
-| `batchSize` | `int?` | `()` | Cursor batch size. |
-| `skip` | `int?` | `()` | Number of documents to skip. |
+| `sort` | <code>map&lt;json&gt;</code> | `{}` | Sort specification (for example `{"year": -1}`). |
+| `limit` | <code>int?</code> | `()` | Maximum number of documents to return. |
+| `batchSize` | <code>int?</code> | `()` | Cursor batch size. |
+| `skip` | <code>int?</code> | `()` | Number of documents to skip. |
 
 ### `CountOptions`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `limit` | `int?` | `()` | Maximum number of documents to count. |
-| `skip` | `int?` | `()` | Number of documents to skip before counting. |
-| `maxTimeMS` | `int?` | `()` | Maximum time the operation can run, in milliseconds. |
-| `hint` | `string?` | `()` | Hint as a JSON string indicating which index to use. |
+| `limit` | <code>int?</code> | `()` | Maximum number of documents to count. |
+| `skip` | <code>int?</code> | `()` | Number of documents to skip before counting. |
+| `maxTimeMS` | <code>int?</code> | `()` | Maximum time the operation can run, in milliseconds. |
+| `hint` | <code>string?</code> | `()` | Hint as a JSON string indicating which index to use. |
 
 ### `CreateIndexOptions`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `background` | `boolean?` | `()` | Build the index in the background (legacy MongoDB). |
-| `unique` | `boolean?` | `()` | Enforce uniqueness on the indexed fields. |
-| `name` | `string?` | `()` | Custom index name. |
-| `sparse` | `boolean?` | `()` | Index only documents where the indexed field exists. |
-| `expireAfterSeconds` | `int?` | `()` | TTL on documents in the collection, creates a TTL index. |
-| `version` | `int?` | `()` | Index version number. |
-| `weights` | `map<json>?` | `()` | Per-field weights for text indexes. |
-| `defaultLanguage` | `string?` | `()` | Default language for text indexes. |
-| `languageOverride` | `string?` | `()` | Field name that overrides the default language per document. |
-| `textVersion` | `int?` | `()` | Text-index version. |
-| `sphereVersion` | `int?` | `()` | 2dsphere-index version. |
-| `bits` | `int?` | `()` | 2d-index geohash precision. |
-| `min` | `float?` | `()` | 2d-index minimum boundary. |
-| `max` | `float?` | `()` | 2d-index maximum boundary. |
-| `partialFilterExpression` | `map<json>` | `{}` | Filter expression for partial indexes. |
-| `hidden` | `boolean?` | `()` | Hide the index from the query planner. |
+| `background` | <code>boolean?</code> | `()` | Build the index in the background (legacy MongoDB). |
+| `unique` | <code>boolean?</code> | `()` | Enforce uniqueness on the indexed fields. |
+| `name` | <code>string?</code> | `()` | Custom index name. |
+| `sparse` | <code>boolean?</code> | `()` | Index only documents where the indexed field exists. |
+| `expireAfterSeconds` | <code>int?</code> | `()` | TTL on documents in the collection. Creates a TTL index. |
+| `version` | <code>int?</code> | `()` | Index version number. |
+| `weights` | <code>map&lt;json&gt;?</code> | `()` | Per-field weights for text indexes. |
+| `defaultLanguage` | <code>string?</code> | `()` | Default language for text indexes. |
+| `languageOverride` | <code>string?</code> | `()` | Field name that overrides the default language per document. |
+| `textVersion` | <code>int?</code> | `()` | Text-index version. |
+| `sphereVersion` | <code>int?</code> | `()` | 2dsphere-index version. |
+| `bits` | <code>int?</code> | `()` | 2d-index geohash precision. |
+| `min` | <code>float?</code> | `()` | 2d-index minimum boundary. |
+| `max` | <code>float?</code> | `()` | 2d-index maximum boundary. |
+| `partialFilterExpression` | <code>map&lt;json&gt;</code> | `{}` | Filter expression for partial indexes. |
+| `hidden` | <code>boolean?</code> | `()` | Hide the index from the query planner. |
 
 ### `UpdateOptions`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `upsert` | `boolean` | `false` | Insert a new document if no match is found. |
-| `bypassDocumentValidation` | `boolean` | `false` | Skip server-side schema validation. |
-| `comment` | `string?` | `()` | Comment included with the operation. |
-| `hint` | `map<json>?` | `()` | Hint as a document indicating which index to use. |
-| `hintString` | `string?` | `()` | Hint as a string indicating which index to use. |
+| `upsert` | <code>boolean</code> | `false` | Insert a new document if no match is found. |
+| `bypassDocumentValidation` | <code>boolean</code> | `false` | Skip server-side schema validation. |
+| `comment` | <code>string?</code> | `()` | Comment included with the operation. |
+| `hint` | <code>map&lt;json&gt;?</code> | `()` | Hint as a document indicating which index to use. |
+| `hintString` | <code>string?</code> | `()` | Hint as a string indicating which index to use. |
 
 ### `Update`
 
-A record where each field corresponds to a MongoDB update operator. The connector adds the leading `$` to each operator name automatically. Write `set`, the wire payload contains `$set`. All fields are optional; the record is **open**, so any additional MongoDB update operator can be passed and will likewise receive the `$` prefix.
+A record where each field corresponds to a MongoDB update operator. The connector adds the leading `$` to each operator name automatically. Write `set`, the wire payload contains `$set`. All fields are optional. The record is open, so any additional MongoDB update operator can be passed and will likewise receive the `$` prefix.
 
 | Field | MongoDB operator | Description |
 |-------|------------------|-------------|
@@ -978,24 +985,24 @@ A record where each field corresponds to a MongoDB update operator. The connecto
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `matchedCount` | `int` | Number of documents matched by the filter. |
-| `modifiedCount` | `int` | Number of documents whose contents actually changed. |
-| `upsertedId` | `string?` | _Optional._ Set only when an upsert occurred and a new `_id` was assigned. Absent from the result otherwise. |
+| `matchedCount` | <code>int</code> | Number of documents matched by the filter. |
+| `modifiedCount` | <code>int</code> | Number of documents whose contents actually changed. |
+| `upsertedId` | <code>string?</code> | Optional. Set only when an upsert occurred and a new `_id` was assigned. Absent from the result otherwise. |
 
 ### `DeleteResult`
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `deletedCount` | `int` | Number of documents deleted. |
-| `acknowledged` | `boolean` | Whether the operation was acknowledged by the server. |
+| `deletedCount` | <code>int</code> | Number of documents deleted. |
+| `acknowledged` | <code>boolean</code> | Whether the operation was acknowledged by the server. |
 
 ### `Index`
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `ns` | `string` | Index namespace (`<database>.<collection>`). |
-| `v` | `int` | Index version. |
-| `name` | `string` | Index name. |
-| `key` | `map<json>` | Index key specification. |
+| `ns` | <code>string</code> | Index namespace (`<database>.<collection>`). |
+| `v` | <code>int</code> | Index version. |
+| `name` | <code>string</code> | Index name. |
+| `key` | <code>map&lt;json&gt;</code> | Index key specification. |
 
 `Index` is an open record. Servers may include additional fields (`unique`, `sparse`, `weights`, etc.) depending on the index type.

--- a/en/docs/connectors/catalog/database/mongodb/actions.md
+++ b/en/docs/connectors/catalog/database/mongodb/actions.md
@@ -967,7 +967,7 @@ A union of the supported read-concern levels:
 
 ### `Update`
 
-A record where each field corresponds to a MongoDB update operator. The connector adds the leading `$` to each operator name automatically. Write `set`, the wire payload contains `$set`. All fields are optional. The record is open, so any additional MongoDB update operator can be passed and will likewise receive the `$` prefix.
+A record where each field corresponds to a MongoDB update operator. The connector adds the leading `$` to each operator name automatically: writing `set` produces `$set` on the wire. All fields are optional. The record is open, so any additional MongoDB update operator can be passed and will likewise receive the `$` prefix.
 
 | Field | MongoDB operator | Description |
 |-------|------------------|-------------|

--- a/en/docs/connectors/catalog/database/mongodb/connector-overview.md
+++ b/en/docs/connectors/catalog/database/mongodb/connector-overview.md
@@ -1,15 +1,18 @@
 ---
-title: "Overview"
+connector: true
+connector_name: "mongodb"
+title: "MongoDB"
+description: "Overview of the ballerinax/mongodb connector for WSO2 Integrator."
 ---
 
 # Overview
 
-MongoDB is a document-oriented NoSQL database used for high-volume data storage and flexible schema design. The Ballerina `ballerinax/mongodb` connector (v5.2.4) provides programmatic access to MongoDB through a three-level client hierarchy (Client → Database → Collection), enabling you to perform CRUD operations, aggregation pipelines, and index management from your Ballerina integration flows.
+MongoDB is a document-oriented NoSQL database used for high-volume data storage and flexible schema design. The `ballerinax/mongodb` connector (v5.2.4) provides programmatic access to MongoDB through a three-level client hierarchy (`Client`, `Database`, and `Collection`), enabling you to perform CRUD operations, aggregation pipelines, and index management from your WSO2 Integrator integrations.
 
 
 ## Key features
 
-- Three-level client model (Client → Database → Collection) mirroring the MongoDB resource hierarchy
+- Three-level client model (`Client`, `Database`, and `Collection`) mirroring the MongoDB resource hierarchy
 - Full CRUD operations on documents with typed record mapping via Ballerina's data binding
 - Aggregation pipeline support including $match, $group, $lookup, $sort, $project, and more
 - Index management: create, list, and drop indexes including unique, sparse, and TTL indexes

--- a/en/docs/connectors/catalog/database/mongodb/example.md
+++ b/en/docs/connectors/catalog/database/mongodb/example.md
@@ -126,7 +126,7 @@ The automation flow canvas opens, showing a **Start** node and an **Error Handle
 
 Try this sample in WSO2 Integration Platform.
 
-[![Push to cloud](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
+[![Deploy to WSO2 Integration Platform](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
 

--- a/en/docs/connectors/catalog/database/mongodb/example.md
+++ b/en/docs/connectors/catalog/database/mongodb/example.md
@@ -1,3 +1,11 @@
+---
+connector: true
+connector_name: "mongodb"
+title: "Example"
+description: "Build an automation that connects to MongoDB and retrieves a database handle using the MongoDB connector."
+keywords: [wso2 integrator, mongodb, connector, example, database]
+---
+
 # Example
 
 ## What you'll build
@@ -23,11 +31,13 @@ flowchart LR
 
 ## Setting up the MongoDB integration
 
-> **New to WSO2 Integrator?** Follow the [Create a New Integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
+:::note
+New to WSO2 Integrator? Follow the [Create a new integration](../../../../develop/create-integrations/create-a-new-integration.md) guide to set up your integration first, then return here to add the connector.
+:::
 
 ## Adding the MongoDB connector
 
-### Step 1: Open the connector palette and search for MongoDB
+### Open the connector palette and search for MongoDB
 
 1. On the main canvas, click **+ Add Connection** to open the connector palette.
 2. Type **MongoDB** in the search box.
@@ -37,7 +47,7 @@ flowchart LR
 
 ## Configuring the MongoDB connection
 
-### Step 2: Fill in the connection parameters
+### Fill in the connection parameters
 
 In the **Configure MongoDB** panel, bind each field to a configurable variable using Expression mode in the **Connection** textbox. For each parameter listed below:
 
@@ -53,23 +63,27 @@ In the **Configure MongoDB** panel, bind each field to a configurable variable u
 
 After creating all five configurables, set **Connection Name** to `mongodbClient`.
 
-> **Alternative connection URI**: If you already have a complete MongoDB connection URI (`mongodb://...` or `mongodb+srv://...`), you can paste it directly into the **Connection** field as a single string instead of binding the individual sub-fields. See the [setup guide](setup-guide.md) for how to obtain that URI.
+:::tip Alternative connection URI
+If you already have a complete MongoDB connection URI (`mongodb://...` or `mongodb+srv://...`), you can paste it directly into the **Connection** field as a single string instead of binding the individual sub-fields. See the [Setup guide](setup-guide.md) for how to obtain that URI.
+:::
 
-> **Authentication mechanism**: The walkthrough above uses **password-based authentication**. The three password records share the `username/password/database` field shape but each has a distinct, read-only `authMechanism`. 
+:::note Authentication mechanism
+The walkthrough above uses password-based authentication. The three password records share the `username`, `password`, and `database` field shape, but each has a distinct, read-only `authMechanism`.
 
-Pick `BasicAuthCredential` for `PLAIN`, `ScramSha1AuthCredential` for SCRAM-SHA-1, or `ScramSha256AuthCredential` for SCRAM-SHA-256 (the default mechanism on modern MongoDB servers). The connector dispatches on the `authMechanism` constant, so the record type you choose is what determines the wire-level mechanism. 
+Pick `BasicAuthCredential` for `PLAIN`, `ScramSha1AuthCredential` for SCRAM-SHA-1, or `ScramSha256AuthCredential` for SCRAM-SHA-256 (the default mechanism on modern MongoDB servers). The connector dispatches on the `authMechanism` constant, so the record type you choose determines the wire-level mechanism.
 
 For X.509 client-certificate or GSSAPI/Kerberos authentication, use `X509Credential` or `GssApiCredential` instead. See [Authentication credentials](actions.md#authentication-credentials) for the field shapes.
+:::
 
 ![MongoDB connection form fully filled with all parameters before saving](/img/connectors/catalog/database/mongodb/mongodb_screenshot_02_connection_config.png)
 
-### Step 3: Save the connection
+### Save the connection
 
 Click **Save Connection** to persist the connection. The `mongodbClient` node appears in the **Connections** section of the left sidebar and on the canvas.
 
 ![MongoDB Connections panel showing mongodbClient entry after saving](/img/connectors/catalog/database/mongodb/mongodb_screenshot_03_connection_saved.png)
 
-### Step 4: Set actual values for your configurables
+### Set actual values for your configurables
 
 1. In the left panel, click **Configurations**.
 2. Set a value for each configurable listed below.
@@ -82,7 +96,7 @@ Click **Save Connection** to persist the connection. The `mongodbClient` node ap
 
 ## Configuring the MongoDB get database operation
 
-### Step 5: Add an automation entry point
+### Add an automation entry point
 
 1. On the main canvas, click **+ Add Artifact**.
 2. Choose **Automation** under the Automation heading.
@@ -90,7 +104,7 @@ Click **Save Connection** to persist the connection. The `mongodbClient` node ap
 
 The automation flow canvas opens, showing a **Start** node and an **Error Handler** node with an empty step slot between them.
 
-### Step 6: Select and configure the get database operation
+### Select and configure the get database operation
 
 1. Click the **+** button between the Start and Error Handler nodes in the flow.
 2. Under **Connections**, expand **mongodbClient** to reveal available operations.
@@ -112,7 +126,7 @@ The automation flow canvas opens, showing a **Start** node and an **Error Handle
 
 Try this sample in WSO2 Integration Platform.
 
-[![Deploy to Devant](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
+[![Push to cloud](https://openindevant.choreoapps.dev/images/DeployDevant-White.svg)](https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
 
 [View source on GitHub](https://github.com/wso2/integration-samples/tree/main/integrator-default-profile/connectors/mongodb_connector_sample)
 

--- a/en/docs/connectors/catalog/database/mongodb/setup-guide.md
+++ b/en/docs/connectors/catalog/database/mongodb/setup-guide.md
@@ -1,6 +1,10 @@
 ---
-title: Setup Guide
+connector: true
+connector_name: "mongodb"
+title: "Setup Guide"
+description: "How to set up and configure the ballerinax/mongodb connector."
 ---
+
 # Setup Guide
 
 This guide walks you through setting up a MongoDB instance and obtaining the connection string required to use the MongoDB connector.
@@ -66,3 +70,8 @@ mongodb://myUser:myPassword@localhost:27017/?authSource=admin
 :::tip
 Store the connection string securely. Use Ballerina's `configurable` feature and a `Config.toml` file to supply it at runtime.
 :::
+
+## Next steps
+
+- [Action reference](actions.md) — Operations, parameters, and sample code for every MongoDB client.
+- [Example](example.md) — Build an automation that connects to MongoDB and retrieves a database handle.

--- a/en/docs/connectors/catalog/database/mongodb/setup-guide.md
+++ b/en/docs/connectors/catalog/database/mongodb/setup-guide.md
@@ -1,10 +1,6 @@
 ---
-connector: true
-connector_name: "mongodb"
-title: "Setup Guide"
-description: "How to set up and configure the ballerinax/mongodb connector."
+title: Setup Guide
 ---
-
 # Setup Guide
 
 This guide walks you through setting up a MongoDB instance and obtaining the connection string required to use the MongoDB connector.
@@ -70,8 +66,3 @@ mongodb://myUser:myPassword@localhost:27017/?authSource=admin
 :::tip
 Store the connection string securely. Use Ballerina's `configurable` feature and a `Config.toml` file to supply it at runtime.
 :::
-
-## Next steps
-
-- [Action reference](actions.md) — Operations, parameters, and sample code for every MongoDB client.
-- [Example](example.md) — Build an automation that connects to MongoDB and retrieves a database handle.


### PR DESCRIPTION
## Purpose

Updates the following pages:
- https://wso2.github.io/docs-integrator/docs/connectors/catalog/database/mongodb/connector-overview
- https://wso2.github.io/docs-integrator/docs/connectors/catalog/database/mongodb/setup-guide
- https://wso2.github.io/docs-integrator/docs/connectors/catalog/database/mongodb/actions
- https://wso2.github.io/docs-integrator/docs/connectors/catalog/database/mongodb/example

This PR makes a few minor updates to the mongodb connector docs adhering to the `content-gen` guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added connector front-matter metadata for MongoDB pages to improve discoverability
  * Standardized type signatures and code markup across actions and supporting types
  * Reformatted notes/callouts into structured note/tip blocks and clarified error/response text
  * Updated example and setup walkthroughs with clearer, renumbered steps and a “Next steps” link
  * Revised overview wording to use consistent client-hierarchy terminology and updated deploy link

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/410)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->