### PR TITLE
Rename navbar logo to "WSO2 Integration Platform"

### DIFF
--- a/en/docusaurus.config.ts
+++ b/en/docusaurus.config.ts
@@ -87,9 +87,9 @@ const config: Config = {
       },
     },
     navbar: {
-      title: 'WSO2 Integrator',
+      title: 'WSO2 Integration Platform',
       logo: {
-        alt: 'WSO2 Integrator Logo',
+        alt: 'WSO2 Integration Platform Logo',
         src: 'img/logo.svg',
         srcDark: 'img/logo-dark.svg',
         href: '/',

--- a/en/src/css/custom.css
+++ b/en/src/css/custom.css
@@ -171,9 +171,28 @@
 }
 
 .navbar__title {
-  font-weight: 700;
+  /* Hide the raw title text — replaced visually by ::before / ::after below
+     so "Integration" renders bold and "Platform" renders lighter. The text
+     remains in the DOM for screen readers and SEO. */
+  font-size: 0;
+  letter-spacing: normal;
+}
+
+.navbar__title::before,
+.navbar__title::after {
   font-size: 1.1rem;
   letter-spacing: -0.01em;
+  color: var(--ifm-navbar-link-color);
+}
+
+.navbar__title::before {
+  content: 'WSO2 Integration\00a0';
+  font-weight: 700;
+}
+
+.navbar__title::after {
+  content: 'Platform';
+  font-weight: 400;
 }
 
 .navbar__link {


### PR DESCRIPTION
Update the navbar title from "WSO2 Integrator" to "WSO2 Integration Platform" and style it with mixed font weights ("Integration" bold, "Platform" regular) via ::before / ::after pseudo-elements so the visual matches the new product branding while the accessible text ("WSO2 Integration Platform") stays intact in the DOM.
<img width="1713" height="869" alt="Screenshot 2026-05-15 at 00 08 45" src="https://github.com/user-attachments/assets/d31625d4-772c-4f59-8cb7-0393f1ae58bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product branding throughout the documentation portal. Navigation elements, page headers, and logo descriptions now display "WSO2 Integration Platform" instead of "WSO2 Integrator", reflecting the updated product name and identity across all user-facing content.

* **Style**
  * Enhanced navbar title styling for improved visual presentation of the updated product branding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/446)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->