### PR TITLE
Fix broken links and anchors across docs

### DIFF
--- a/en/docs/connectors/catalog/communication/intercom/action-reference.md
+++ b/en/docs/connectors/catalog/communication/intercom/action-reference.md
@@ -541,7 +541,7 @@ intercom:Ticket ticket = check intercomClient->/tickets.post({
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `ticketTypeId` | `string` | Yes | ID of the ticket type (see [Setup guide](setup-guide.md#step-6-optional-find-your-ticket-type-id)) |
+| `ticketTypeId` | `string` | Yes | ID of the ticket type (see [Setup guide](setup-guide.md)) |
 | `contacts` | `CreateTicketRequestContacts[]` | Yes | Contacts associated with the ticket |
 | `companyId` | `string` | No | Company to associate with the ticket |
 

--- a/en/docs/develop/copilot/overview.md
+++ b/en/docs/develop/copilot/overview.md
@@ -78,7 +78,7 @@ Type `/` in the Copilot input bar to invoke a command for a specific task.
 | `/doc` | Generate documentation for your integration. |
 | `/openapi` | Import OpenAPI specifications. |
 | `/typecreator` | Create custom types. |
-| `/datamap` | [Generate data mappings](../integration-artifacts/supporting/data-mapper/ai-data-mapper.md). |
+| `/datamap` | [Generate data mappings](../integration-artifacts/supporting/data-mapper/data-mapper.md). |
 | `/natural-programming` | Experimental. Generate code from requirements and check for drift. |
 
 :::note
@@ -89,6 +89,6 @@ Type `/` in the Copilot input bar to invoke a command for a specific task.
 
 - [Getting started](getting-started.md) — Sign in to WSO2 Integrator Copilot.
 - [Generate tests with AI](../test/ai-generated-cases.md) — Use Copilot to generate test cases.
-- [AI data mapper](../integration-artifacts/supporting/data-mapper/ai-data-mapper.md) — Generate data mappings using AI.
+- [AI data mapper](../integration-artifacts/supporting/data-mapper/data-mapper.md) — Generate data mappings using AI.
 - [Try-It tool](../test/built-in-try-it-tool.md) — Test services without leaving the IDE.
 - [AI usage and data handling guidelines](../../reference/ai-usage-and-data-handling-guidelines.md) — How Copilot handles your data.

--- a/en/docs/develop/debugging/troubleshooting.md
+++ b/en/docs/develop/debugging/troubleshooting.md
@@ -357,6 +357,6 @@ When reporting a bug, include everything from [Before you start](#before-you-sta
 
 ## See also
 
-- [Error Codes](/docs/reference/error-codes): Reference for all error codes
+- [Error Codes](/docs/reference/error-code): Reference for all error codes
 - [System Requirements](../../reference/appendix/system-requirements.md): Supported platforms and versions
 - [FAQ](/docs/reference/faq): Frequently asked questions

--- a/en/docs/develop/integration-artifacts/file/ftp-sftp.md
+++ b/en/docs/develop/integration-artifacts/file/ftp-sftp.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # FTP / SFTP
 
-FTP, SFTP, and FTPS [file integrations](/docs/get-started/concepts/core#file-integrations) poll remote file servers for new files and process them as they arrive. Use them for ETL pipelines, batch processing, and B2B integrations where partners exchange data as CSV, XML, JSON, or binary files.
+FTP, SFTP, and FTPS [file integrations](/docs/get-started/concepts/core#file-integration) poll remote file servers for new files and process them as they arrive. Use them for ETL pipelines, batch processing, and B2B integrations where partners exchange data as CSV, XML, JSON, or binary files.
 
 | Protocol | Description | Transport security | Authentication |
 |---|---|---|---|
@@ -712,7 +712,7 @@ service on primaryListener, backupListener {
 </TabItem>
 </Tabs>
 
-For the general concept, see [Services and listeners](/docs/get-started/concepts/core#services-and-listeners).
+For the general concept, see [Services and listeners](/docs/get-started/concepts/core#integration-as-api).
 
 ## Attaching listeners to services
 

--- a/en/docs/develop/tools/integration-tools/asyncapi-tool.md
+++ b/en/docs/develop/tools/integration-tools/asyncapi-tool.md
@@ -233,4 +233,4 @@ bal asyncapi -i service.bal --mode export -o specs/asyncapi.yaml
 
 - [gRPC Tool](grpc-tool.md) -- Generate gRPC services from Protocol Buffer definitions
 - [OpenAPI Tool](openapi-tool.md) -- Generate REST services and clients
-- [Error Handling](/docs/develop/design-logic/error-handling) -- Handle event processing failures gracefully
+- [Error Handling](/docs/develop/understand-ide/editors/flow-diagram-editor/error-handling) -- Handle event processing failures gracefully

--- a/en/docs/develop/tools/integration-tools/graphql-tool.md
+++ b/en/docs/develop/tools/integration-tools/graphql-tool.md
@@ -266,4 +266,4 @@ Client generation from GraphQL schemas is currently supported only through the B
 
 - [AsyncAPI Tool](asyncapi-tool.md) — Generate event-driven services from AsyncAPI specs
 - [OpenAPI Tool](openapi-tool.md) — Generate REST services and clients
-- [Ballerina pro-code](/docs/develop/design-logic/ballerina-pro-code) — Write advanced GraphQL resolver logic
+- [Flow Diagram Editor](/docs/develop/understand-ide/editors/flow-diagram-editor/) — Switch to pro-code to write advanced GraphQL resolver logic

--- a/en/docs/develop/tools/integration-tools/grpc-tool.md
+++ b/en/docs/develop/tools/integration-tools/grpc-tool.md
@@ -360,4 +360,4 @@ bal grpc --input <proto-file> [options]
 
 - [OpenAPI Tool](openapi-tool.md) — Generate REST services and clients
 - [WSDL Tool](wsdl-tool.md) — Generate SOAP clients from WSDL files
-- [Error Handling](/docs/develop/design-logic/error-handling) — Handle gRPC errors and deadlines
+- [Error Handling](/docs/develop/understand-ide/editors/flow-diagram-editor/error-handling) — Handle gRPC errors and deadlines

--- a/en/docs/develop/tools/integration-tools/openapi-tool.md
+++ b/en/docs/develop/tools/integration-tools/openapi-tool.md
@@ -331,4 +331,4 @@ Once your service is built, export its OpenAPI specification and share it with c
 
 - [GraphQL Tool](graphql-tool.md) — Generate GraphQL services from SDL schemas
 - [gRPC Tool](grpc-tool.md) — Generate gRPC services from Protocol Buffer definitions
-- [Visual flow designer](/docs/develop/design-logic/visual-flow-designer) — Build logic visually on top of generated stubs
+- [Flow Diagram editor](/docs/develop/understand-ide/editors/flow-diagram-editor/) — Build logic visually on top of generated stubs

--- a/en/docs/develop/tools/integration-tools/persist-tool.md
+++ b/en/docs/develop/tools/integration-tools/persist-tool.md
@@ -280,4 +280,4 @@ bal persist push --datastore <datastore> --module <module>
 
 - [Scan Tool](../other/scan-tool.md) — Analyze Ballerina code for security and quality issues
 - [Configuration management](/docs/reference/config/configuration-management) — Manage data store credentials with configurable variables
-- [Databases connector guide](/docs/connectors/catalog/database) — Database connectivity options
+- [Connector catalog](/docs/connectors/catalog/) — Browse database connectors and other connectivity options

--- a/en/docs/develop/transform/json.md
+++ b/en/docs/develop/transform/json.md
@@ -258,7 +258,7 @@ public function main() returns error? {
 
 ## Parse JSON arrays
 
-Use `jsondata:parseString()` to parse a JSON array string directly into a typed record array. If you already have a `json` value instead of a string, use `jsondata:parseAsType()` as described in [Convert a JSON value to a typed record](`#convert-a-json-value-to-a-typed-record`).
+Use `jsondata:parseString()` to parse a JSON array string directly into a typed record array. If you already have a `json` value instead of a string, use `jsondata:parseAsType()` as described in [Convert a JSON value to a typed record](#convert-a-json-value-to-a-typed-record).
 
 <Tabs>
 <TabItem value="ui" label="Visual Designer" default>
@@ -445,5 +445,5 @@ Create a `products.json` file in the project directory.
 ## What's next
 
 - [XML Processing](xml.md) - Work with XML data
-- [Type System & Records](type-system.md) - Type-safe data handling
+- [Type System & Records](/docs/reference/language/type-system) - Type-safe data handling
 

--- a/en/docs/develop/understand-ide/editors/datamapper-editor.md
+++ b/en/docs/develop/understand-ide/editors/datamapper-editor.md
@@ -8,7 +8,7 @@ description: Map fields between source and target types visually, without writin
 
 The Data Mapper editor is the visual surface you open for any data mapper in WSO2 Integrator. It shows the source types on the left, the target type on the right, and the mapping canvas between them, so you can wire fields by drawing links or filling expressions instead of hand-writing the conversion function. The data mapper itself is a typed function with one or more inputs and one output, and every change you make in the editor is reflected in the underlying function source.
 
-For end-to-end usage, including how to create a data mapper, work with arrays and nested records, and apply transformations, see [Data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/data-mapper).
+For end-to-end usage, including how to create a data mapper, work with arrays and nested records, and apply transformations, see [Data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/).
 
 ![Data Mapper editor for the transform data mapper](/img/develop/understand-ide/editors/datamapper-editor/overview.png)
 
@@ -16,7 +16,7 @@ For end-to-end usage, including how to create a data mapper, work with arrays an
 
 Select a data mapper under **Data Mappers** in the project explorer, or select the data mapper node from a flow in the [Flow Diagram editor](flow-diagram-editor/flow-diagram-editor.md). The editor opens with the data mapper's inputs on the left, the output on the right, and the mapping canvas between them.
 
-To create a new data mapper before opening the editor, see [Data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/data-mapper).
+To create a new data mapper before opening the editor, see [Data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/).
 
 ## Header
 
@@ -89,7 +89,7 @@ The right side of the editor shows the data mapper's output type with each field
 
 ## What's next
 
-- [Data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/data-mapper): end-to-end guide to creating and using data mappers.
+- [Data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/): end-to-end guide to creating and using data mappers.
 - [Expression editor](expression-editor.md): write a custom expression for a single mapping.
 - [Configure editor](configure-editor.md): change the data mapper's inputs, output, or visibility.
 - [Type editor](type-editor.md): define the record types the data mapper maps between.

--- a/en/docs/develop/understand-ide/editors/service-design-editor.md
+++ b/en/docs/develop/understand-ide/editors/service-design-editor.md
@@ -6,7 +6,7 @@ description: Design HTTP, gRPC, and event-driven service entry points visually.
 
 # Service Design Editor
 
-The Service Design editor, also known as the **service designer**, is the editor you open for any service entry point in WSO2 Integrator. It lists every resource or handler the service exposes and gives you one place to add, edit, remove, try out, and export them. For background on what a service is and how it relates to listeners, see [Services and listeners](/docs/get-started/concepts/core#services-and-listeners).
+The Service Design editor, also known as the **service designer**, is the editor you open for any service entry point in WSO2 Integrator. It lists every resource or handler the service exposes and gives you one place to add, edit, remove, try out, and export them. For background on what a service is and how it relates to listeners, see [Services and listeners](/docs/get-started/concepts/core#integration-as-api).
 
 ![Service Design editor for an HTTP service](/img/develop/understand-ide/editors/service-design-editor/overview.png)
 
@@ -14,7 +14,7 @@ The Service Design editor, also known as the **service designer**, is the editor
 
 Select a service entry point under **Entry points** in the project explorer, or select the service node on the [Integrator view](../views/integration-view.md) design canvas. The editor opens with the resources or handlers the service exposes.
 
-To create a new service before opening the editor, see [Service artifacts](/docs/develop/integration-artifacts/service) and choose the service type ([HTTP](/docs/develop/integration-artifacts/service/http), [gRPC](/docs/develop/integration-artifacts/service/grpc), [TCP](/docs/develop/integration-artifacts/service/tcp), [WebSocket](/docs/develop/integration-artifacts/service/websocket), [WebSub Hub](/docs/develop/integration-artifacts/service/websub-hub)).
+To create a new service before opening the editor, see the [Integration artifacts](/docs/develop/integration-artifacts/) overview and choose the service type ([HTTP](/docs/develop/integration-artifacts/service/http), [gRPC](/docs/develop/integration-artifacts/service/grpc), [TCP](/docs/develop/integration-artifacts/service/tcp), [WebSocket](/docs/develop/integration-artifacts/service/websocket), [WebSub Hub](/docs/develop/integration-artifacts/service/websub-hub)).
 
 ## Header
 
@@ -71,7 +71,7 @@ The **More** menu groups actions that are specific to the service type. For HTTP
 ## What's next
 
 - [Integration artifacts](/docs/develop/integration-artifacts): browse the full set of services, automations, event handlers, and file processors you can build.
-- [Service artifacts](/docs/develop/integration-artifacts/service): configure HTTP, gRPC, and other service types in detail.
+- [HTTP service](/docs/develop/integration-artifacts/service/http): configure HTTP services in detail (see the sidebar for gRPC, TCP, WebSocket, WebSub Hub).
 - [Flow Diagram editor](flow-diagram-editor/flow-diagram-editor.md): edit the logic that runs when a resource or handler is invoked.
 - [Type editor](type-editor.md): define the request and response types used by the service.
-- [Services and listeners](/docs/get-started/concepts/core#services-and-listeners): understand the listener and service model.
+- [Services and listeners](/docs/get-started/concepts/core#integration-as-api): understand the listener and service model.

--- a/en/docs/develop/understand-ide/editors/type-editor.md
+++ b/en/docs/develop/understand-ide/editors/type-editor.md
@@ -9,7 +9,7 @@ keywords: [wso2 integrator, type editor, record, enum, union, array, service cla
 
 The Type editor is the side panel you open whenever you create or change a custom type in WSO2 Integrator. It gives you one form to define records, enums, unions, arrays, and service classes, configure each member or field, and toggle advanced options such as additional fields and read-only types. Every change you save in the editor updates the type's Ballerina source and the type card on the [Type Diagram editor](type-diagram-editor.md).
 
-For an introduction to types and how an integration uses them, see [Key concepts](/docs/get-started/key-concepts). For a canvas-level view of how all the types in your integration relate to each other, see the [Type Diagram editor](type-diagram-editor.md).
+For an introduction to types and how an integration uses them, see [Core Concepts](/docs/get-started/concepts/core). For a canvas-level view of how all the types in your integration relate to each other, see the [Type Diagram editor](type-diagram-editor.md).
 
 ## Open the editor
 
@@ -191,7 +191,7 @@ The editor generates a `Library` record with a `book` array field and a nested r
 Once the records look right, save the form. The new types are added to the integration and become available everywhere a custom type can be used.
 
 :::tip Common next steps after import
-- Use the generated record as a request or response payload in a [service](/docs/develop/integration-artifacts/service).
+- Use the generated record as a request or response payload in a [service](/docs/develop/integration-artifacts/service/http).
 - Map fields from the imported record onto another type in the [Data Mapper editor](datamapper-editor.md).
 - Expose the record from a [GraphQL service](/docs/develop/integration-artifacts/service/graphql) resolver.
 :::

--- a/en/docs/develop/understand-ide/views/integration-view.md
+++ b/en/docs/develop/understand-ide/views/integration-view.md
@@ -91,6 +91,6 @@ Click **Edit** to modify the README directly. You can also click **Generate with
 
 ## What's next
 
-- [Design integration logic](/docs/develop/design-logic/) — Build logic using the visual designer.
+- [Flow Diagram editor](/docs/develop/understand-ide/editors/flow-diagram-editor/) — Build logic using the visual designer.
 - [Integration artifacts](/docs/develop/integration-artifacts) — Learn about artifact types and their configuration.
 - [Deploy to WSO2 Cloud](/docs/deploy/cloud/overview) — Deploy your integration to the cloud.

--- a/en/docs/genai/develop/rag/rag-ingestion.md
+++ b/en/docs/genai/develop/rag/rag-ingestion.md
@@ -190,7 +190,7 @@ The in-memory store is rebuilt on every restart, so re-running the integration r
 - Use **Delete By Filter** before re-ingesting a document to avoid duplicates. Filter by a metadata field like `source` or `version`.
 - Schedule the automation with a trigger (for example, an HTTP call, a cron, or a file-watch event) rather than running it once.
 
-See [Knowledge Bases — delete by filter](../components/knowledge-bases.md#public-actions) for details.
+See [Knowledge Bases — delete by filter](../components/knowledge-bases.md#available-actions) for details.
 
 ---
 

--- a/en/docs/genai/tutorials/building-a-customer-care-agent-mcp.md
+++ b/en/docs/genai/tutorials/building-a-customer-care-agent-mcp.md
@@ -166,7 +166,7 @@ Try the following messages to exercise all three tools:
     }}
 />
 
-For more detail on using the chat panel, see [Testing chat agents](../../develop/test/built-in-try-it-tool#testing-chat-agents).
+For more detail on using the chat panel, see [Try-It experiences](../../develop/test/built-in-try-it-tool#try-it-experiences).
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">

--- a/en/docs/genai/tutorials/building-hr-knowledge-base-rag.md
+++ b/en/docs/genai/tutorials/building-hr-knowledge-base-rag.md
@@ -533,4 +533,4 @@ You now have a fully visual HR RAG pipeline that grounds an LLM in your actual p
 
 - [Vector stores](../develop/components/vector-stores.md) — Swap the in-memory store for a persistent backend (Pinecone, Milvus, Pgvector, Weaviate).
 - [Chunkers](../develop/components/chunkers.md) — Tune chunk size and overlap, or plug in a custom chunker.
-- [The query flow](../develop/rag/overview.md#the-query-flow) — Customize retrieval (top-K, filters, hybrid search).
+- [How RAG works](../develop/rag/overview.md#how-it-works) — Customize retrieval (top-K, filters, hybrid search).

--- a/en/docs/genai/tutorials/it-helpdesk-chatbot.md
+++ b/en/docs/genai/tutorials/it-helpdesk-chatbot.md
@@ -149,7 +149,7 @@ final ai:Agent itHelpDeskAgent = check new (
 
 ### Step 5: Add a tool to the agent
 
-Add the following tool to the agent by following the instructions in [Create custom tool — hand-crafted definitions](genai/develop/agents/tools.md#4-create-custom-tool--hand-crafted-definitions).
+Add the following tool to the agent by following the instructions in [Create custom tool](/docs/genai/develop/agents/tools#4-create-custom-tool).
 
 <Tabs>
 <TabItem value="code" label="Ballerina Code">

--- a/en/docs/get-started/concepts/core.md
+++ b/en/docs/get-started/concepts/core.md
@@ -7,7 +7,7 @@ keywords: [wso2 integrator, core concepts, project, integration, service, listen
 
 # Core Concepts
 
-This page introduces every major building block you work with when designing and building integrations in the WSO2 Integrator IDE. Use it as a vocabulary reference before diving into the [Develop](/docs/develop/integration-artifacts/integration-artifacts) section, where each concept is covered in full detail.
+This page introduces every major building block you work with when designing and building integrations in the WSO2 Integrator IDE. Use it as a vocabulary reference before diving into the [Develop](/docs/develop/integration-artifacts/) section, where each concept is covered in full detail.
 
 ## Organization
 
@@ -142,5 +142,5 @@ ICP runs on your machine and mirrors enough of the production runtime that an in
 ## What's next
 
 - [WSO2 Integration Cloud concepts](integration-cloud-concepts.md) — data planes, environments, and deployment tracks
-- [Integration artifacts](/docs/develop/integration-artifacts/integration-artifacts) — choose the right artifact for your use case
+- [Integration artifacts](/docs/develop/integration-artifacts/) — choose the right artifact for your use case
 - [Introduction](../introduction.md) — platform overview and architecture

--- a/en/docs/get-started/concepts/integration-cloud-concepts.md
+++ b/en/docs/get-started/concepts/integration-cloud-concepts.md
@@ -302,5 +302,5 @@ A new build undergoes a health check before switching traffic from the current b
 ## What's next
 
 - [Core concepts](core.md) — projects, integrations, services, connectors, and more
-- [Deploy and operate](/docs/deploy-operate/overview) — self-hosted deployment options
+- [Deploy](/docs/deploy/overview) — self-hosted deployment options
 - [Introduction](../introduction.md) — platform overview and architecture

--- a/en/docs/get-started/introduction.md
+++ b/en/docs/get-started/introduction.md
@@ -79,4 +79,4 @@ The platform ships with **WSO2 Integrator Copilot** to assist during design and 
 
 - [Concepts](concepts/overview.md) — learn the vocabulary used across the platform
 - [Set up WSO2 Integrator](setup/overview.md) — set up the IDE and create your first integration
-- [Integration artifacts](/docs/develop/integration-artifacts/integration-artifacts) — choose the right artifact for your use case
+- [Integration artifacts](/docs/develop/integration-artifacts/) — choose the right artifact for your use case

--- a/en/docs/guides/migration/coming-from-mulesoft.md
+++ b/en/docs/guides/migration/coming-from-mulesoft.md
@@ -273,7 +273,7 @@ To build a deployable artifact:
 bal build
 ```
 
-See [Deploy & Operate](/docs/deploy-operate/overview) for Docker, Kubernetes, and cloud deployment options.
+See [Deploy](/docs/deploy/overview) for Docker, Kubernetes, and cloud deployment options.
 
 ## Concept and component mapping
 

--- a/en/docs/guides/migration/coming-from-tibco.md
+++ b/en/docs/guides/migration/coming-from-tibco.md
@@ -272,7 +272,7 @@ To build a deployable artifact:
 bal build
 ```
 
-See [Deploy & Operate](/docs/deploy-operate/overview) for Docker, Kubernetes, and cloud deployment options.
+See [Deploy](/docs/deploy/overview) for Docker, Kubernetes, and cloud deployment options.
 
 ## Concept mapping
 

--- a/en/docs/guides/patterns/channel-adapter.md
+++ b/en/docs/guides/patterns/channel-adapter.md
@@ -22,7 +22,7 @@ A connector client adapts an external application API into the integration flow.
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Add the connector client connection for the application channel. See [creating a connection](/docs/develop/design-logic/managing-connections#creating-a-connection); for this example, select the Jira connector as shown in [adding the Jira connector](/docs/connectors/catalog/productivity-collaboration/jira/example#adding-the-jira-connector).
+1. Add the connector client connection for the application channel. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection); for this example, select the Jira connector as shown in [adding the Jira connector](/docs/connectors/catalog/productivity-collaboration/jira/example#adding-the-jira-connector).
 2. Configure the endpoint, authentication values, and other connection properties with project configurables. Use the connector-specific [Jira setup guide](/docs/connectors/catalog/productivity-collaboration/jira/setup-guide) and [Jira connection configuration steps](/docs/connectors/catalog/productivity-collaboration/jira/example#configuring-the-jira-connection).
 3. Add the connector operation that reads from or writes to the application channel. Use the [Jira action reference](/docs/connectors/catalog/productivity-collaboration/jira/actions#projects) to select the project operation for this example.
 4. Map the connector response to the message shape used by the rest of the flow.
@@ -104,14 +104,14 @@ service /projects on projectListener {
 
 ## Broker-backed channel adapter
 
-Use a broker listener when the channel is a messaging broker rather than an application API or HTTP endpoint. The service receives records from the broker, converts each record into the flow payload, and acknowledges or publishes through the connector according to the channel contract. Use the relevant broker guide, such as [Kafka consumers](/docs/develop/integration-artifacts/event/kafka#creating-a-kafka-consumer), [RabbitMQ services](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service), or the [JMS listener](/docs/connectors/catalog/messaging/java.jms/triggers#listener).
+Use a broker listener when the channel is a messaging broker rather than an application API or HTTP endpoint. The service receives records from the broker, converts each record into the flow payload, and acknowledges or publishes through the connector according to the channel contract. Use the relevant broker guide, such as [Kafka consumers](/docs/develop/integration-artifacts/event/kafka#creating-a-kafka-listener), [RabbitMQ services](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service), or the [JMS listener](/docs/connectors/catalog/messaging/java.jms/triggers#listener).
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create the broker listener for the channel. For Kafka, see [creating a Kafka consumer](/docs/develop/integration-artifacts/event/kafka#creating-a-kafka-consumer); for RabbitMQ, see [creating a RabbitMQ service](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service); for JMS, see the [JMS listener](/docs/connectors/catalog/messaging/java.jms/triggers#listener).
-2. Configure the broker endpoint, topic or queue, and credentials with configurables. For Kafka, use [listener configuration](/docs/develop/integration-artifacts/event/kafka#listener-configuration); for RabbitMQ, use [listener configuration](/docs/develop/integration-artifacts/event/rabbitmq#listener-configuration).
-3. Add the message-handling function for the broker event. For Kafka, use [event handler configuration](/docs/develop/integration-artifacts/event/kafka#event-handler-configuration); for RabbitMQ, use [event handlers](/docs/develop/integration-artifacts/event/rabbitmq#event-handlers).
+1. Create the broker listener for the channel. For Kafka, see [creating a Kafka consumer](/docs/develop/integration-artifacts/event/kafka#creating-a-kafka-listener); for RabbitMQ, see [creating a RabbitMQ service](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service); for JMS, see the [JMS listener](/docs/connectors/catalog/messaging/java.jms/triggers#listener).
+2. Configure the broker endpoint, topic or queue, and credentials with configurables. For Kafka, use [service configuration](/docs/develop/integration-artifacts/event/kafka#service-configuration); for RabbitMQ, use [listener configuration](/docs/develop/integration-artifacts/event/rabbitmq#listener-configuration).
+3. Add the message-handling function for the broker event. For Kafka, use [service configuration](/docs/develop/integration-artifacts/event/kafka#service-configuration); for RabbitMQ, use [event handlers](/docs/develop/integration-artifacts/event/rabbitmq#event-handlers).
 4. Convert the broker record to the typed payload used inside the flow.
 
 </TabItem>

--- a/en/docs/guides/patterns/content-based-routing.md
+++ b/en/docs/guides/patterns/content-based-routing.md
@@ -17,15 +17,15 @@ The pattern is implemented at the decision point where the flow has enough messa
 
 ## Pattern-based content routing
 
-Use pattern-based content routing with [match expressions](/docs/develop/design-logic/control-flow#match-expressions) when each recipient maps to a known field value, such as a message type, region, product category, or event name. Keep an explicit default branch so unsupported content is handled in a dedicated fallback path for invalid recipients.
+Use pattern-based content routing with [match expressions](/docs/develop/understand-ide/editors/flow-diagram-editor/control#match) when each recipient maps to a known field value, such as a message type, region, product category, or event name. Keep an explicit default branch so unsupported content is handled in a dedicated fallback path for invalid recipients.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create or open the [HTTP service resource](/docs/develop/integration-artifacts/service/http#creating-an-http-service) that receives the routed message.
-2. Add HTTP client connections for each recipient. See [creating a connection](/docs/develop/design-logic/managing-connections#creating-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
-3. Open the resource flow and [add a step](/docs/develop/design-logic/visual-flow-designer#adding-steps-to-the-flow).
-4. Add a [Match node](/docs/develop/design-logic/control-flow#match-expressions) and set the expression to the routing field, such as `order.itemType`.
+2. Add HTTP client connections for each recipient. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
+3. Open the resource flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+4. Add a [Match node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#match) and set the expression to the routing field, such as `order.itemType`.
 5. Add one branch for each accepted value, such as `"standard"` and `"express"`, and add `_` as the default branch.
 6. In each accepted branch, add the connector call for that recipient and return the route result.
 7. In the default branch, return an error response for unsupported content.
@@ -82,15 +82,15 @@ service /orders on new http:Listener(8080) {
 
 ## Predicate-based content routing
 
-Use predicate-based content routing with [if/else statements](/docs/develop/design-logic/control-flow#ifelse-statements) when the route depends on content rules instead of one stable routing key.
+Use predicate-based content routing with [if/else statements](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) when the route depends on content rules instead of one stable routing key.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create or open the resource or function that contains the routing decision.
-2. Add HTTP client connections for the possible recipients. See [creating a connection](/docs/develop/design-logic/managing-connections#creating-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
+2. Add HTTP client connections for the possible recipients. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
 3. Add a [configurable variable](/docs/reference/config/configuration-management#configurable-variables) for any route rule that should change by environment, such as `bulkThreshold`.
-4. Open the flow and add an [If node](/docs/develop/design-logic/control-flow#ifelse-statements) with a condition such as `order.quantity >= bulkThreshold`.
+4. Open the flow and add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) with a condition such as `order.quantity >= bulkThreshold`.
 5. Add the bulk recipient call inside the **True** branch.
 6. In the **False** branch, add another **If** node with a condition such as `order.priority`.
 7. Add the priority recipient call inside the nested **True** branch and the default recipient call inside the nested **False** branch.

--- a/en/docs/guides/patterns/message-dispatcher.md
+++ b/en/docs/guides/patterns/message-dispatcher.md
@@ -17,14 +17,14 @@ The pattern is implemented at the point where the integration receives a message
 
 ## Stateful round-robin dispatch
 
-Use stateful round-robin dispatch when each incoming message should be sent to the next processor in a fixed set. Store the current processor index in the service, update it with a `lock`, and call the selected processor through an [HTTP client connection](/docs/connectors/catalog/built-in/http/action-reference#client). The `lock` keeps the index update consistent when multiple requests arrive at the same time. For constructs that do not have a full visual representation, use [Ballerina Pro-Code](/docs/develop/design-logic/ballerina-pro-code) or the collapsed code block that appears in the [Visual Flow Designer](/docs/develop/design-logic/visual-flow-designer#bidirectional-sync).
+Use stateful round-robin dispatch when each incoming message should be sent to the next processor in a fixed set. Store the current processor index in the service, update it with a `lock`, and call the selected processor through an [HTTP client connection](/docs/connectors/catalog/built-in/http/action-reference#client). The `lock` keeps the index update consistent when multiple requests arrive at the same time. For constructs that do not have a full visual representation, switch to pro-code through the [Flow Diagram editor](/docs/develop/understand-ide/editors/flow-diagram-editor/#configuring-a-node).
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create an [HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service) for the dispatcher entry point.
 2. Add a `GET` resource, such as `/process`, and define a query parameter that carries the message reference, such as `resourceUrl`. See [resource inputs](/docs/develop/integration-artifacts/service/http#defining-inputs).
-3. Add the outbound processor [HTTP connection](/docs/develop/design-logic/managing-connections#creating-a-connection). Configure its base URL with a [configurable variable](/docs/reference/config/configuration-management#configurable-variables).
+3. Add the outbound processor [HTTP connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection). Configure its base URL with a [configurable variable](/docs/reference/config/configuration-management#configurable-variables).
 4. Add a service-level variable named `nextProcessor` with type `int` and default value `0`.
 5. In the resource flow, add the processor selection logic as a Ballerina code block: read `nextProcessor`, advance it inside a `lock`, and store the selected processor ID.
 6. Add the HTTP connector call that includes the selected processor ID in the request path and passes the message reference as a query parameter.

--- a/en/docs/guides/patterns/message-filter.md
+++ b/en/docs/guides/patterns/message-filter.md
@@ -19,13 +19,13 @@ The pattern is implemented by placing a filtering construct at the point where t
 
 ## Predicate-based filtering
 
-Use predicate-based filtering with [if/else statements](/docs/develop/design-logic/control-flow#ifelse-statements) when each message carries the fields needed for a single boolean decision, such as priority, source, header, or status. The accepted path contains the forwarding or processing action. The rejected path does nothing or handles the rejection separately.
+Use predicate-based filtering with [if/else statements](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) when each message carries the fields needed for a single boolean decision, such as priority, source, header, or status. The accepted path contains the forwarding or processing action. The rejected path does nothing or handles the rejection separately.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Open the flow and [add a step](/docs/develop/design-logic/visual-flow-designer#adding-steps-to-the-flow).
-2. Add an [If node](/docs/develop/design-logic/control-flow#ifelse-statements) at the point where the message has enough data for the decision.
+1. Open the flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+2. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) at the point where the message has enough data for the decision.
 3. Set the condition to `message.priority == HIGH_PRIORITY`.
 4. Add the accepted action inside the matching branch.
 5. Leave the other branch empty when unmatched messages should be discarded.
@@ -71,13 +71,13 @@ service /api/v1 on new http:Listener(8080) {
 
 ## Collection-level filtering
 
-Use collection-level filtering with [query expressions](/docs/develop/design-logic/query-expressions) when the flow already has a group of messages or records and only a subset should continue. Keep the predicate in the `where` clause so the result is the accepted collection.
+Use collection-level filtering with [query expressions](/docs/reference/language/query-expressions) when the flow already has a group of messages or records and only a subset should continue. Keep the predicate in the `where` clause so the result is the accepted collection.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Open the flow and [add a step](/docs/develop/design-logic/visual-flow-designer#adding-steps-to-the-flow).
-2. Add a [Map Data or Declare Variable step](/docs/develop/design-logic/query-expressions#using-query-expressions-in-the-visual-designer).
+1. Open the flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+2. Add a [Map Data or Declare Variable step](/docs/reference/language/query-expressions).
 3. Set the output type to the accepted collection type, such as `Message[]`.
 4. Enter a query expression with a `where` clause for the filter predicate.
 5. Use the resulting collection in the next processing or forwarding step.

--- a/en/docs/guides/patterns/message-mapper.md
+++ b/en/docs/guides/patterns/message-mapper.md
@@ -26,7 +26,7 @@ Use record-to-record mapping when both the domain value and the channel payload 
 2. Create a [reusable data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/access-paths/reusable) with the domain record as the input and the message record as the output.
 3. Open the data mapper canvas and connect matching fields, such as `id` to `orderId`.
 4. Use the expression editor for transformed fields, such as combining names or calculating a total. See [Expression editor](/docs/develop/integration-artifacts/supporting/data-mapper/mapping-capabilities#expression-editor).
-5. Use [array mappings](/docs/develop/integration-artifacts/supporting/data-mapper/array-mappings/array-mappings) when the mapper must convert item collections.
+5. Use [array mappings](/docs/develop/integration-artifacts/supporting/data-mapper/array-mappings/) when the mapper must convert item collections.
 6. Add a **Map Data** step in the flow and pass the mapped record to the next service, resource function, or connector call.
 
 </TabItem>
@@ -89,7 +89,7 @@ function toDomain(OrderMessage message) returns Order {
 
 ## Data-format boundary mapping
 
-Use data-format boundary mapping when the channel sends or receives raw JSON, XML, CSV, or another serialized format. Keep parsing and serialization at the boundary, then call the typed mapper so the main flow works with records instead of raw payloads. For JSON payloads, use [type-safe JSON conversion](/docs/develop/transform/json#type-safe-json-with-ballerinadatajsondata). For XML and CSV payloads, use the corresponding [XML processing](/docs/develop/transform/xml) or [CSV and flat file processing](/docs/develop/transform/csv-flat-file) guide.
+Use data-format boundary mapping when the channel sends or receives raw JSON, XML, CSV, or another serialized format. Keep parsing and serialization at the boundary, then call the typed mapper so the main flow works with records instead of raw payloads. For JSON payloads, use [type-safe JSON conversion](/docs/develop/transform/json#convert-a-json-value-to-a-typed-record). For XML and CSV payloads, use the corresponding [XML processing](/docs/develop/transform/xml) or [CSV and flat file processing](/docs/develop/transform/csv-flat-file) guide.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>

--- a/en/docs/guides/patterns/message.md
+++ b/en/docs/guides/patterns/message.md
@@ -24,7 +24,7 @@ Use a typed message envelope when the integration needs a stable application-lev
 
 1. Create a new integration in WSO2 Integrator.
 2. Add the header, body, and envelope records in [Types](/docs/develop/integration-artifacts/supporting/types).
-3. Open the flow and [add a step](/docs/develop/design-logic/visual-flow-designer#adding-steps-to-the-flow).
+3. Open the flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
 4. Add a **Declare Variable** or **Map Data** step to construct the envelope.
 5. Pass the envelope to the connector call, return it from the resource function, or map it into another boundary-specific message.
 
@@ -71,7 +71,7 @@ Use channel boundary binding when the message arrives through, or leaves through
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Add and configure the required connector under **Connections**. For brokered messages, select the relevant connector, such as the [NATS connector](/docs/connectors/catalog/messaging/nats/connector-overview), from the [messaging connector catalog](/docs/connectors/catalog/messaging/messaging).
+1. Add and configure the required connector under **Connections**. For brokered messages, select the relevant connector, such as the [NATS connector](/docs/connectors/catalog/messaging/nats/connector-overview), from the [messaging connector catalog](/docs/connectors/catalog/).
 2. Add the listener or entry point for the inbound channel. For HTTP, start by [creating an HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service).
 3. Bind the request payload as the body and bind transport metadata, such as headers, as message headers.
 4. Add a **Map Data** step to create the typed message envelope from the inbound payload and metadata.

--- a/en/docs/guides/patterns/polling-consumer.md
+++ b/en/docs/guides/patterns/polling-consumer.md
@@ -17,17 +17,17 @@ The pattern is implemented at the point where the flow controls the receive call
 
 ## Loop-driven polling
 
-Use loop-driven polling with [while loops](/docs/develop/design-logic/control-flow#while-loops) when the integration should keep checking a channel or endpoint while it controls the maximum attempts and wait interval. The receive or status-check call stays inside the loop, and the flow exits when it receives a message that is ready to process.
+Use loop-driven polling with [while loops](/docs/develop/understand-ide/editors/flow-diagram-editor/control#while) when the integration should keep checking a channel or endpoint while it controls the maximum attempts and wait interval. The receive or status-check call stays inside the loop, and the flow exits when it receives a message that is ready to process.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create or open the [HTTP service resource](/docs/develop/integration-artifacts/service/http#creating-an-http-service) that starts the polling flow.
-2. Add an HTTP client connection for the source that the flow must poll. See [creating a connection](/docs/develop/design-logic/managing-connections#creating-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
+2. Add an HTTP client connection for the source that the flow must poll. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
 3. Add [configurable variables](/docs/reference/config/configuration-management#configurable-variables) for values such as `maxAttempts` and `pollDelaySeconds`.
-4. Add a [While node](/docs/develop/design-logic/control-flow#while-loops) that runs while the attempt count is less than `maxAttempts`.
+4. Add a [While node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#while) that runs while the attempt count is less than `maxAttempts`.
 5. Inside the loop, add the HTTP client operation that asks for the current message or status.
-6. Add an [If node](/docs/develop/design-logic/control-flow#ifelse-statements) that returns the message when it is ready. Otherwise, wait for the configured delay and continue the loop.
+6. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) that returns the message when it is ready. Otherwise, wait for the configured delay and continue the loop.
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">
@@ -79,10 +79,10 @@ Use scheduled broker polling when each automation run should pull at most one me
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create a [scheduled automation](/docs/develop/integration-artifacts/automation/automation#creating-an-automation) for the polling interval.
+1. Create a [scheduled automation](/docs/develop/integration-artifacts/automation#creating-an-automation) for the polling interval.
 2. Add the `java.jms` **JMS MessageConsumer** connection and bind the broker settings to configurable variables. See the [JMS consumer example](/docs/connectors/catalog/messaging/java.jms/example#adding-the-javajms-connector).
 3. Add the **Receive** operation from the JMS consumer connection and set the timeout value for the polling window.
-4. Add an [If node](/docs/develop/design-logic/control-flow#ifelse-statements) that checks whether the received value is a message.
+4. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) that checks whether the received value is a message.
 5. Add the processing steps inside the branch that received a message.
 6. Acknowledge the message only after the processing steps finish successfully.
 

--- a/en/docs/guides/patterns/selective-consumer.md
+++ b/en/docs/guides/patterns/selective-consumer.md
@@ -65,14 +65,14 @@ service "priority-order-consumer" on orderListener {
 
 ## Flow-level selection
 
-Use flow-level selection with [if/else statements](/docs/develop/design-logic/control-flow#ifelse-statements) when the consumer must inspect the delivered payload, call another system, or apply rules that cannot be expressed as a broker selector. The service still reads from the shared channel, but the accepted branch contains the processing logic and the unmatched branch is ignored or handled separately.
+Use flow-level selection with [if/else statements](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) when the consumer must inspect the delivered payload, call another system, or apply rules that cannot be expressed as a broker selector. The service still reads from the shared channel, but the accepted branch contains the processing logic and the unmatched branch is ignored or handled separately.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create or open the consumer service that receives messages from the shared channel.
-2. Open the message handler flow and [add a step](/docs/develop/design-logic/visual-flow-designer#adding-steps-to-the-flow).
-3. Add an [If node](/docs/develop/design-logic/control-flow#ifelse-statements) at the point where the flow has the payload fields needed for selection.
+2. Open the message handler flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+3. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) at the point where the flow has the payload fields needed for selection.
 4. Set the condition to the consumer criteria, such as `order.priority == "high" && order.region == "west"`.
 5. Add the processing steps inside the **True** branch.
 6. Leave the **False** branch empty when unmatched messages should be ignored, or add separate handling for rejected messages.

--- a/en/docs/manage/icp/observability-setup.md
+++ b/en/docs/manage/icp/observability-setup.md
@@ -15,7 +15,7 @@ For MI runtimes, see [MI observability setup](mi-profile/observability-setup-mi.
 
 :::info Prerequisites
 
-- ICP server running with OpenSearch connection configured in `deployment.toml`. Use `https://` if OpenSearch is running with TLS (including the demo setup). See [Install ICP](install-icp.md#opensearch-observability).
+- ICP server running with OpenSearch connection configured in `deployment.toml`. Use `https://` if OpenSearch is running with TLS (including the demo setup). See [Install ICP](install-icp.md).
 - Integration connected to ICP with heartbeats working. See [Connect an integration to ICP](connect-runtime.md).
 - Fluent Bit installed on the machine running the default profile runtime. See the [Fluent Bit installation page](https://docs.fluentbit.io/manual/installation/downloads).
 

--- a/en/docs/reference/api/ballerina-documentation.md
+++ b/en/docs/reference/api/ballerina-documentation.md
@@ -136,5 +136,5 @@ The WSO2 Integrator VS Code extension provides inline API documentation:
 
 ## See also
 
-- [Protocols Reference](../protocols) — Supported protocols and modules
+- [Supported Protocols](../supported-protocols) — Supported protocols and modules
 - [Connectors overview](../../connectors/overview) — Connector guides and configuration

--- a/en/docs/reference/config/configuration-management.md
+++ b/en/docs/reference/config/configuration-management.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 Integration projects typically run across multiple environments — development, staging, and production — each with different endpoints, credentials, and feature flags. WSO2 Integrator uses Ballerina's built-in configuration system to keep these settings out of source code and supply them at runtime.
 
 :::note
-This guide is the deeper reference for the configuration model. For the fundamentals of using configurable variables, see [Configurations](../integration-artifacts/supporting/configurations.md).
+This guide is the deeper reference for the configuration model. For the fundamentals of using configurable variables, see [Configurations](/docs/develop/integration-artifacts/supporting/configurations).
 :::
 
 ## Configurable variables
@@ -284,6 +284,6 @@ Never commit secret-bearing configuration files to version control. For producti
 
 ## What's next
 
-- [Configurations](../integration-artifacts/supporting/configurations.md) — Declare configurable variables and supply values through the visual designer.
+- [Configurations](/docs/develop/integration-artifacts/supporting/configurations) — Declare configurable variables and supply values through the visual designer.
 - [Secrets and encryption](../../deploy-operate/secure/secrets-encryption.md) — Securely supply credentials and protect data in transit and at rest.
-- [Connections](managing-connections.md) — Use configurable variables to parameterize connections.
+- [Connections](/docs/develop/integration-artifacts/supporting/connections) — Use configurable variables to parameterize connections.

--- a/en/docs/reference/error-code.md
+++ b/en/docs/reference/error-code.md
@@ -114,5 +114,5 @@ function callApi() returns json|error {
 
 ## What's Next
 
-- [Error Handling Guide](/docs/develop/design-logic/error-handling) -- Error handling patterns and best practices
+- [Error Handling Guide](/docs/develop/understand-ide/editors/flow-diagram-editor/error-handling) -- Error handling patterns and best practices
 - [Troubleshooting](/docs/develop/debugging/troubleshooting) -- Resolve common development issues

--- a/en/docs/reference/faq.md
+++ b/en/docs/reference/faq.md
@@ -94,7 +94,7 @@ Yes. WSO2 Integrator includes first-class support for AI agents, retrieval-augme
 
 ### Which LLM and vector store providers are supported?
 
-WSO2 Integrator ships connectors for major LLM providers and vector stores. See the [Connectors catalog](/docs/connectors/catalog/ai-ml/ai-machine-learning) for the current list.
+WSO2 Integrator ships connectors for major LLM providers and vector stores. See the [Connectors catalog](/docs/connectors/catalog/) for the current list.
 
 ## Deploy and operate
 
@@ -151,7 +151,7 @@ The ICP is a monitoring and management dashboard for deployed integrations. It p
 - Artifact discovery (services, listeners, connectors)
 - Integration lifecycle management (activate, deactivate, restart)
 
-See the [ICP API Reference](/docs/reference/api/icp-api) for programmatic access.
+See the [ICP API Reference](/docs/reference/api/icp) for programmatic access.
 
 ## Migration
 
@@ -159,7 +159,7 @@ See the [ICP API Reference](/docs/reference/api/icp-api) for programmatic access
 
 ### Can I migrate from MuleSoft or TIBCO?
 
-Yes. WSO2 provides migration guides and tooling to help transition from other integration platforms. See [Coming from MuleSoft](/docs/tutorials/migration/coming-from-mulesoft) and [Coming from TIBCO](/docs/tutorials/migration/coming-from-tibco) for platform-specific guidance. For migrating third-party integrations programmatically, see [Migrate third-party integrations](/docs/develop/create-integrations/migrate-third-party-integrations).
+Yes. WSO2 provides migration guides and tooling to help transition from other integration platforms. See [Coming from MuleSoft](/docs/guides/migration/coming-from-mulesoft) and [Coming from TIBCO](/docs/guides/migration/coming-from-tibco) for platform-specific guidance. For migrating third-party integrations programmatically, see [Migrate third-party integrations](/docs/develop/create-integrations/migrate-third-party-integrations).
 
 ### Can I run WSO2 MI and WSO2 Integrator side by side?
 

--- a/en/docs/reference/language/concurrency.md
+++ b/en/docs/reference/language/concurrency.md
@@ -343,4 +343,4 @@ function processMessages(kafka:Consumer consumer, int workerId) returns error? {
 ## See also
 
 - [Error Handling](error-handling.md) -- Error handling patterns
-- [Ballerina by Example](/docs/reference/by-example) -- Runnable concurrency examples
+- [Ballerina by Example](/docs/reference/ballerina-by-example) -- Runnable concurrency examples

--- a/en/docs/reference/language/error-handling.md
+++ b/en/docs/reference/language/error-handling.md
@@ -359,4 +359,4 @@ function validateOrder(Order order) returns error? {
 ## See also
 
 - [Concurrency](concurrency.md) -- Workers, transactions, and error handling in concurrent code
-- [Ballerina by Example](/docs/reference/by-example) -- Runnable error handling examples
+- [Ballerina by Example](/docs/reference/ballerina-by-example) -- Runnable error handling examples


### PR DESCRIPTION
Re-target 50 broken links and 13 broken anchors flagged by the Docusaurus build:

- Re-map removed develop/design-logic/* references to their new homes under understand-ide/editors/flow-diagram-editor/* and reference/language/* (along with renamed anchors: ifelse-statements → if, match-expressions → match, while-loops → while).
- Use category-index URLs (e.g. integration-artifacts/, data-mapper/, flow-diagram-editor/) where a doc backs a sidebar category.
- Fix renamed reference paths (error-codes → error-code, by-example → ballerina-by-example, protocols → supported-protocols, icp-api → icp, deploy-operate/overview → deploy/overview, tutorials/migration → guides/migration, key-concepts → concepts/core).
- Fix wrong relative paths in configuration-management.md and ballerina-documentation.md.
- Fix stray backticks in a json.md anchor link.
- Re-point copilot/overview.md from the deleted ai-data-mapper.md to data-mapper.md.
- Correct anchor names against the actual headings (kafka, knowledge-bases, agents/tools, rag/overview, json).
- Drop two anchors with no current target (intercom setup-guide step 6, install-icp opensearch-observability) and leave a generic page link so the broken anchor doesn't break the build.
