### PR TITLE
Split TOML reference docs by role

### DIFF
--- a/en/docs/deploy/self-hosted/docker.md
+++ b/en/docs/deploy/self-hosted/docker.md
@@ -38,7 +38,7 @@ When you build a Ballerina project with a cloud target, the compiler extension g
         └── Dockerfile
 ```
 
-**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted.
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](../../reference/project/cloudtoml-reference.md) for the full field list.
 
 **`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. You must supply it at runtime via a volume mount.
 

--- a/en/docs/deploy/self-hosted/docker.md
+++ b/en/docs/deploy/self-hosted/docker.md
@@ -38,7 +38,7 @@ When you build a Ballerina project with a cloud target, the compiler extension g
         └── Dockerfile
 ```
 
-**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](../../reference/project/cloudtoml-reference.md) for the full field list.
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](/docs/reference/project/cloudtoml-reference) for the full field list.
 
 **`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. You must supply it at runtime via a volume mount.
 

--- a/en/docs/deploy/self-hosted/kubernetes.md
+++ b/en/docs/deploy/self-hosted/kubernetes.md
@@ -41,7 +41,7 @@ When you build with `cloud = "k8s"`, the compiler generates Kubernetes manifests
         └── <module>-0.0.1.yaml
 ```
 
-**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](../../reference/project/cloudtoml-reference.md) for the full field list.
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](/docs/reference/project/cloudtoml-reference) for the full field list.
 
 **`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. Use the `[[cloud.config.files]]` entry in `Cloud.toml` to mount it as a Kubernetes ConfigMap at runtime.
 

--- a/en/docs/deploy/self-hosted/kubernetes.md
+++ b/en/docs/deploy/self-hosted/kubernetes.md
@@ -41,7 +41,7 @@ When you build with `cloud = "k8s"`, the compiler generates Kubernetes manifests
         └── <module>-0.0.1.yaml
 ```
 
-**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted.
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](../../reference/project/cloudtoml-reference.md) for the full field list.
 
 **`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. Use the `[[cloud.config.files]]` entry in `Cloud.toml` to mount it as a Kubernetes ConfigMap at runtime.
 

--- a/en/docs/deploy/self-hosted/openshift.md
+++ b/en/docs/deploy/self-hosted/openshift.md
@@ -41,7 +41,7 @@ When you build with `cloud = "openshift"`, the compiler generates OpenShift mani
         └── <module>-0.0.1.yaml
 ```
 
-**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted.
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](../../reference/project/cloudtoml-reference.md) for the full field list.
 
 **`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. Use the `[[cloud.config.files]]` entry in `Cloud.toml` to mount it as a ConfigMap at runtime.
 

--- a/en/docs/deploy/self-hosted/openshift.md
+++ b/en/docs/deploy/self-hosted/openshift.md
@@ -41,7 +41,7 @@ When you build with `cloud = "openshift"`, the compiler generates OpenShift mani
         └── <module>-0.0.1.yaml
 ```
 
-**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](../../reference/project/cloudtoml-reference.md) for the full field list.
+**`Cloud.toml`** overrides defaults that the compiler infers from your code. Every field is optional. The compiler provides sensible defaults when the file is absent or when a field is omitted. See the [Cloud.toml reference](/docs/reference/project/cloudtoml-reference) for the full field list.
 
 **`Config.toml`** is intentionally excluded from the container image because it can contain sensitive values. Use the `[[cloud.config.files]]` entry in `Cloud.toml` to mount it as a ConfigMap at runtime.
 

--- a/en/docs/reference/config/configtoml-reference.md
+++ b/en/docs/reference/config/configtoml-reference.md
@@ -9,7 +9,7 @@ keywords: [wso2 integrator, ballerina, config.toml, configurable, runtime config
 `Config.toml` provides runtime values for `configurable` variables declared in Ballerina source code. Place it in the project root (alongside `Ballerina.toml`), or specify one or more config files via the `BAL_CONFIG_FILES` environment variable. Ballerina uses TOML syntax with module-qualified keys to map configuration values to their corresponding `configurable` declarations.
 
 :::note
-This page is the TOML encoding reference for `Config.toml`. For the basics of using configurable variables, see [Configurations](../../develop/integration-artifacts/supporting/configurations.md). For the complete configuration reference, see [Configuration management](configuration-management.md).
+This page is the TOML encoding reference for `Config.toml`. For the basics of using configurable variables, see [Configurations](/docs/develop/integration-artifacts/supporting/configurations). For the complete configuration reference, see [Configuration management](/docs/reference/config/configuration-management).
 :::
 
 ## Module-qualified names
@@ -253,5 +253,5 @@ department = "Marketing"
 
 ## What's next
 
-- [Configuration management](configuration-management.md) — the broader runtime-config story: value sources, precedence, environment variables, and per-environment files.
+- [Configuration management](/docs/reference/config/configuration-management) — the broader runtime-config story: value sources, precedence, environment variables, and per-environment files.
 - [Cloud.toml reference](/docs/reference/project/cloudtoml-reference) — mount Config.toml into deployments via `[[cloud.config.files]]`.

--- a/en/docs/reference/config/configtoml-reference.md
+++ b/en/docs/reference/config/configtoml-reference.md
@@ -253,6 +253,5 @@ department = "Marketing"
 
 ## What's next
 
-- [Ballerina.toml reference](ballerinatoml-reference.md) — configure package metadata, build options, and dependencies
-- [Cloud.toml reference](cloudtoml-reference.md) — configure Kubernetes and Docker deployment descriptors
-- [Configuration management](configuration-management.md) — set configuration values, override Config.toml via environment variables, and target per-environment configuration
+- [Configuration management](configuration-management.md) — the broader runtime-config story: value sources, precedence, environment variables, and per-environment files.
+- [Cloud.toml reference](../project/cloudtoml-reference.md) — mount Config.toml into deployments via `[[cloud.config.files]]`.

--- a/en/docs/reference/config/configtoml-reference.md
+++ b/en/docs/reference/config/configtoml-reference.md
@@ -254,4 +254,4 @@ department = "Marketing"
 ## What's next
 
 - [Configuration management](configuration-management.md) — the broader runtime-config story: value sources, precedence, environment variables, and per-environment files.
-- [Cloud.toml reference](../project/cloudtoml-reference.md) — mount Config.toml into deployments via `[[cloud.config.files]]`.
+- [Cloud.toml reference](/docs/reference/project/cloudtoml-reference) — mount Config.toml into deployments via `[[cloud.config.files]]`.

--- a/en/docs/reference/config/configuration-management.md
+++ b/en/docs/reference/config/configuration-management.md
@@ -156,7 +156,7 @@ Command-line arguments support only basic primitive types (`boolean`, `int`, `fl
 
 `Config.toml` is the primary configuration file. Place it in the project root directory (alongside `Ballerina.toml`). The runtime reads it automatically at startup. Values you enter through the Visual Designer's Config Editor are written to this same file.
 
-For TOML syntax, type-by-type encoding, and module-qualified key conventions, see the [Config.toml reference](configtoml-reference.md).
+For TOML syntax, type-by-type encoding, and module-qualified key conventions, see the [Config.toml reference](/docs/reference/config/configtoml-reference).
 
 ### Environment variables
 
@@ -280,10 +280,10 @@ BAL_CONFIG_FILES=config/dev.toml bal run
 BAL_CONFIG_FILES=config/prod.toml bal run
 ```
 
-Never commit secret-bearing configuration files to version control. For production credential handling, secret managers, and TLS configuration, see [Secrets and encryption](../../deploy-operate/secure/secrets-encryption.md).
+Never commit secret-bearing configuration files to version control. For production credential handling, secret managers, and TLS configuration, see [Secrets and encryption](/docs/deploy-operate/secure/secrets-encryption).
 
 ## What's next
 
 - [Configurations](/docs/develop/integration-artifacts/supporting/configurations) — Declare configurable variables and supply values through the visual designer.
-- [Secrets and encryption](../../deploy-operate/secure/secrets-encryption.md) — Securely supply credentials and protect data in transit and at rest.
+- [Secrets and encryption](/docs/deploy-operate/secure/secrets-encryption) — Securely supply credentials and protect data in transit and at rest.
 - [Connections](/docs/develop/integration-artifacts/supporting/connections) — Use configurable variables to parameterize connections.

--- a/en/docs/reference/project/ballerinatoml-reference.md
+++ b/en/docs/reference/project/ballerinatoml-reference.md
@@ -230,5 +230,5 @@ options.mode = "client"
 ## What's next
 
 - [Run locally](/docs/deploy/self-hosted/run-locally) — build and run the package you just configured.
-- [Cloud.toml reference](cloudtoml-reference.md) — add Kubernetes and Docker deployment descriptors when you deploy.
+- [Cloud.toml reference](/docs/reference/project/cloudtoml-reference) — add Kubernetes and Docker deployment descriptors when you deploy.
 - [Configuration management](/docs/reference/config/configuration-management) — supply runtime values, override via environment variables, and target per-environment configuration.

--- a/en/docs/reference/project/ballerinatoml-reference.md
+++ b/en/docs/reference/project/ballerinatoml-reference.md
@@ -229,6 +229,6 @@ options.mode = "client"
 
 ## What's next
 
-- [Config.toml reference](configtoml-reference.md) — configure runtime values, secrets, and module settings
-- [Cloud.toml reference](cloudtoml-reference.md) — configure Kubernetes and Docker deployment descriptors
-- [Configuration management](configuration-management.md) — supply runtime values, override via environment variables, and target per-environment configuration
+- [Run locally](/docs/deploy/self-hosted/run-locally) — build and run the package you just configured.
+- [Cloud.toml reference](cloudtoml-reference.md) — add Kubernetes and Docker deployment descriptors when you deploy.
+- [Configuration management](/docs/reference/config/configuration-management) — supply runtime values, override via environment variables, and target per-environment configuration.

--- a/en/docs/reference/project/cloudtoml-reference.md
+++ b/en/docs/reference/project/cloudtoml-reference.md
@@ -213,6 +213,6 @@ file = "./Secret.toml"
 
 ## What's next
 
-- [Ballerina.toml reference](ballerinatoml-reference.md) — set the `cloud` build option and configure package metadata
-- [Config.toml reference](configtoml-reference.md) — supply runtime configuration values mounted via `[[cloud.config.files]]`
-- [Configuration management](configuration-management.md) — supply runtime values, override via environment variables, and target per-environment configuration
+- [Docker](/docs/deploy/self-hosted/docker) — build and run the container image produced from Cloud.toml.
+- [Kubernetes](/docs/deploy/self-hosted/kubernetes) — deploy the generated artifacts to a Kubernetes cluster.
+- [Config.toml reference](../config/configtoml-reference.md) — define the runtime values you mount via `[[cloud.config.files]]`.

--- a/en/docs/reference/project/cloudtoml-reference.md
+++ b/en/docs/reference/project/cloudtoml-reference.md
@@ -215,4 +215,4 @@ file = "./Secret.toml"
 
 - [Docker](/docs/deploy/self-hosted/docker) — build and run the container image produced from Cloud.toml.
 - [Kubernetes](/docs/deploy/self-hosted/kubernetes) — deploy the generated artifacts to a Kubernetes cluster.
-- [Config.toml reference](../config/configtoml-reference.md) — define the runtime values you mount via `[[cloud.config.files]]`.
+- [Config.toml reference](/docs/reference/config/configtoml-reference) — define the runtime values you mount via `[[cloud.config.files]]`.

--- a/en/docs/reference/reference.md
+++ b/en/docs/reference/reference.md
@@ -27,9 +27,9 @@ Project and deployment configuration files:
 | File                                                         | Purpose                           |
 | ------------------------------------------------------------ | --------------------------------- |
 | **[Configuration management](config/configuration-management.md)**    | Configurable variables, value sources, and environment variables |
-| **[Ballerina.toml](config/ballerinatoml-reference.md)**               | Project metadata and dependencies |
+| **[Ballerina.toml](project/ballerinatoml-reference.md)**              | Project metadata and dependencies |
 | **[Config.toml](config/configtoml-reference.md)**                     | Runtime configuration values      |
-| **[Cloud.toml](config/cloudtoml-reference.md)**                       | Cloud deployment settings         |
+| **[Cloud.toml](project/cloudtoml-reference.md)**                      | Cloud deployment settings         |
 
 
 ## APIs

--- a/en/sidebars.ts
+++ b/en/sidebars.ts
@@ -2169,9 +2169,16 @@ const sidebars: SidebarsConfig = {
           label: 'Configuration',
           items: [
             'reference/config/configuration-management',
-            'reference/config/ballerinatoml-reference',
             'reference/config/configtoml-reference',
-            'reference/config/cloudtoml-reference',
+          ],
+        },
+        // Project
+        {
+          type: 'category',
+          label: 'Project',
+          items: [
+            'reference/project/ballerinatoml-reference',
+            'reference/project/cloudtoml-reference',
           ],
         },
         // ICP Configuration


### PR DESCRIPTION
## Purpose

  - Move `Ballerina.toml` and `Cloud.toml` references out of `Reference > Configuration` into a new `Reference > Project` sibling category. The previous grouping conflated runtime configuration (`Config.toml`, `configuration-management`) with package-root descriptors (`Ballerina.toml`, `Cloud.toml`) — these are different concerns and readers look them up differently.
  - Rewrite the "What's next" section on each TOML reference to match the reader's actual next step under the new IA. Cloud.toml now points forward to Docker and Kubernetes; Ballerina.toml points to `run-locally`; Config.toml points to `configuration-management`.
  - Fix a pre-existing broken `[Connections](managing-connections.md)` link in `configuration-management.md`.
  - Cross-link `docker.md`, `kubernetes.md`, and `openshift.md` to the relocated Cloud.toml reference at the first descriptive mention of the file.
  - Normalize the cross-section links introduced in this PR to absolute paths without `.md` (e.g.
  `/docs/reference/project/cloudtoml-reference`), matching the dominant pattern used elsewhere for cross-section navigation.
 
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that all `Cloud.toml` configuration fields are optional, with compiler-inferred defaults.
  * Improved cross-references and navigation between deployment and configuration documentation pages.
  * Reorganized documentation structure for better discoverability of configuration references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/448)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->