### PR TITLE
Fix having two docs in url and more broken links

### DIFF
--- a/en/docusaurus.config.ts
+++ b/en/docusaurus.config.ts
@@ -11,11 +11,12 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://integrator.docs.wso2.com',
+  url: 'https://wso2.com',
   baseUrl: process.env.BASE_URL || '/',
 
   organizationName: 'wso2',
   projectName: 'docs-integrator',
+  trailingSlash: true,
 
   onBrokenLinks: 'warn',
 
@@ -46,7 +47,7 @@ const config: Config = {
         language: ['en'],
         highlightSearchTermsOnTargetPage: true,
         explicitSearchResultPath: true,
-        docsRouteBasePath: '/docs',
+        docsRouteBasePath: '/',
         indexBlog: false,
         indexPages: true,
         searchBarShortcutHint: false,
@@ -59,6 +60,7 @@ const config: Config = {
       'classic',
       {
         docs: {
+          routeBasePath: '/',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/wso2/docs-integrator/tree/main/en/',
           showLastUpdateTime: true,
@@ -82,7 +84,7 @@ const config: Config = {
         // Collapse sibling categories whenever a category expands. With
         // `useAutoExpandActiveCategory`, this means navigating to a page
         // collapses every other top-level category and only leaves the
-        // current path expanded.
+        // current path expanded.        
         autoCollapseCategories: true,
       },
     },
@@ -108,28 +110,28 @@ const config: Config = {
         {
           title: 'Get started',
           items: [
-            { label: 'Overview', to: '/docs/get-started/introduction' },
-            { label: 'Install', to: '/docs/get-started/setup/local-setup' },
-            { label: 'Quick starts', to: '/docs/get-started/build-automation' },
+            { label: 'Overview', to: '/get-started/introduction' },
+            { label: 'Install', to: '/get-started/setup/local-setup' },
+            { label: 'Quick starts', to: '/get-started/build-automation' },
           ],
         },
         {
           title: 'Develop',
           items: [
-            { label: 'Integration artifacts', to: '/docs/develop/integration-artifacts' },
-            { label: 'Transform', to: '/docs/develop/integration-artifacts/supporting/data-mapper/' },
-            { label: 'Test', to: '/docs/develop/test/built-in-try-it-tool' },
-            { label: 'Connectors', to: '/docs/connectors/overview' },
-            { label: 'AI Integrations', to: '/docs/genai/overview' },
+            { label: 'Integration artifacts', to: '/develop/integration-artifacts' },
+            { label: 'Transform', to: '/develop/integration-artifacts/supporting/data-mapper/' },
+            { label: 'Test', to: '/develop/test/built-in-try-it-tool' },
+            { label: 'Connectors', to: '/connectors/overview' },
+            { label: 'AI Integrations', to: '/genai/overview' },
           ],
         },
         {
           title: 'Deploy',
           items: [
-            { label: 'Docker and Kubernetes', to: '/docs/deploy/self-hosted/kubernetes' },
-            { label: 'CI/CD', to: '/docs/deploy-operate/cicd/github-actions' },
-            { label: 'Observe', to: '/docs/deploy-operate/observe/observability-overview' },
-            { label: 'Secure', to: '/docs/deploy-operate/secure/authentication' },
+            { label: 'Docker and Kubernetes', to: '/deploy/self-hosted/kubernetes' },
+            { label: 'CI/CD', to: '/deploy-operate/cicd/github-actions' },
+            { label: 'Observe', to: '/deploy-operate/observe/observability-overview' },
+            { label: 'Secure', to: '/deploy-operate/secure/authentication' },
           ],
         },
         {

--- a/en/src/pages/index.tsx
+++ b/en/src/pages/index.tsx
@@ -189,7 +189,7 @@ const quickLinks = [
   { label: 'Build an Automation', to: '/get-started/build-automation' },
   { label: 'Build an AI Agent', to: '/get-started/build-ai-agent' },
   { label: 'Build an API Integration', to: '/get-started/build-api-integration' },
-  { label: 'Connector catalog', to: '/connectors' },
+  { label: 'Connector catalog', to: '/connectors/overview' },
 ];
 
 /* ------------------------------------------------------------------ */

--- a/en/src/pages/index.tsx
+++ b/en/src/pages/index.tsx
@@ -111,7 +111,7 @@ const sections: SectionCard[] = [
   {
     title: 'Get started',
     description: 'Install, set up, and build your first integration in under 10 minutes.',
-    link: '/docs/get-started/introduction',
+    link: '/get-started/introduction',
     icon: <IconGetStarted />,
     iconBg: '#ECFDF5',
     iconBgDark: 'rgba(5, 150, 105, 0.15)',
@@ -120,7 +120,7 @@ const sections: SectionCard[] = [
   {
     title: 'Develop',
     description: 'Build services, transform data, and test integrations on your machine.',
-    link: '/docs/develop/overview',
+    link: '/develop/overview',
     icon: <IconDevelop />,
     iconBg: '#EFF6FF',
     iconBgDark: 'rgba(37, 99, 235, 0.15)',
@@ -129,7 +129,7 @@ const sections: SectionCard[] = [
   {
     title: 'Connectors',
     description: 'Browse 400+ pre-built connectors for SaaS, databases, messaging, and AI.',
-    link: '/docs/connectors/overview',
+    link: '/connectors/overview',
     icon: <IconConnectors />,
     iconBg: '#F0EDFF',
     iconBgDark: 'rgba(124, 58, 237, 0.15)',
@@ -138,7 +138,7 @@ const sections: SectionCard[] = [
   {
     title: 'AI Integrations',
     description: 'Build AI-powered integrations with agents, RAG, and MCP servers.',
-    link: '/docs/genai/overview',
+    link: '/genai/overview',
     icon: <IconGenAI />,
     iconBg: '#FDF4FF',
     iconBgDark: 'rgba(168, 85, 247, 0.15)',
@@ -147,7 +147,7 @@ const sections: SectionCard[] = [
   {
     title: 'Guides',
     description: 'End-to-end tutorials and integration patterns.',
-    link: '/docs/guides/overview',
+    link: '/guides/overview',
     icon: <IconTutorials />,
     iconBg: '#FFF8EB',
     iconBgDark: 'rgba(217, 119, 6, 0.15)',
@@ -156,7 +156,7 @@ const sections: SectionCard[] = [
   {
     title: 'Deploy',
     description: 'Docker, Kubernetes, CI/CD, observability, and production security.',
-    link: '/docs/deploy/overview',
+    link: '/deploy/overview',
     icon: <IconDeploy />,
     iconBg: '#ECFEFF',
     iconBgDark: 'rgba(8, 145, 178, 0.15)',
@@ -165,7 +165,7 @@ const sections: SectionCard[] = [
   {
     title: 'Manage',
     description: 'Centralized control and observability via the Integration Control Plane (ICP).',
-    link: '/docs/manage/overview',
+    link: '/manage/overview',
     icon: <IconManage />,
     iconBg: '#EEF2FF',
     iconBgDark: 'rgba(79, 70, 229, 0.15)',
@@ -174,7 +174,7 @@ const sections: SectionCard[] = [
   {
     title: 'Reference',
     description: 'Language reference, configuration keys, CLI commands, and error codes.',
-    link: '/docs/reference/overview',
+    link: '/reference/overview',
     icon: <IconReference />,
     iconBg: '#F1F5F9',
     iconBgDark: 'rgba(100, 116, 139, 0.15)',
@@ -186,10 +186,10 @@ const sections: SectionCard[] = [
 /*  Quick-links shown when the search input is focused but empty       */
 /* ------------------------------------------------------------------ */
 const quickLinks = [
-  { label: 'Build an Automation', to: '/docs/get-started/build-automation' },
-  { label: 'Build an AI Agent', to: '/docs/get-started/build-ai-agent' },
-  { label: 'Build an API Integration', to: '/docs/get-started/build-api-integration' },
-  { label: 'Connector catalog', to: '/docs/connectors' },
+  { label: 'Build an Automation', to: '/get-started/build-automation' },
+  { label: 'Build an AI Agent', to: '/get-started/build-ai-agent' },
+  { label: 'Build an API Integration', to: '/get-started/build-api-integration' },
+  { label: 'Connector catalog', to: '/connectors' },
 ];
 
 /* ------------------------------------------------------------------ */
@@ -311,7 +311,7 @@ function HomepageHeader(): ReactNode {
         <div className={styles.buttons}>
           <Link
             className={styles.heroBtn}
-            to="/docs/get-started/build-automation">
+            to="/get-started/build-automation">
             Build your first integration
             <svg
               width="16"
@@ -374,7 +374,7 @@ function WhatsNew(): ReactNode {
     <section className={styles.whatsNew}>
       <div className="container">
         <Link
-          to="/docs/reference/release-notes"
+          to="/reference/release-notes"
           className={styles.whatsNewLink}>
           <span className={styles.whatsNewBadge}>New</span>
           Check out the latest release notes


### PR DESCRIPTION
## Purpose
Current live url has `docs/docs` this PR fixed it and broken links introduced by the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined site navigation structure with cleaner URL paths for better user experience
  * Reorganized documentation accessibility under improved routing hierarchy
  * Updated all internal navigation links across the site for consistency
  * Set site domain to `https://wso2.com` with optimized configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/460)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->