### PR TITLE
Fix broken links in genai section

### DIFF
--- a/en/docs/genai/develop/agents/creating-an-agent.md
+++ b/en/docs/genai/develop/agents/creating-an-agent.md
@@ -99,11 +99,11 @@ service /blogReviewer on chatAgentListener {
 
 After generation, you are directed to the integration canvas where you can configure the following aspects of the agent:
 
-- [Agent behavior, including role, instructions, query, and input/output bindings](/genai/develop/agents/creating-an-agent.md#configure-agent-behavior)
-- [Model provider](/genai/develop/components/model-providers.md)
-- [Tool integration](/genai/develop/agents/tools.md)
-- [Memory configuration](/genai/develop/agents/memory.md)
-- [Observability and tracing](/genai/develop/agents/observability.md)
+- [Agent behavior, including role, instructions, query, and input/output bindings](creating-an-agent.md#configure-agent-behavior)
+- [Model provider](../components/model-providers.md)
+- [Tool integration](tools.md)
+- [Memory configuration](memory.md)
+- [Observability and tracing](observability.md)
 
 ## Configure agent behavior
 

--- a/en/docs/genai/develop/agents/overview.md
+++ b/en/docs/genai/develop/agents/overview.md
@@ -38,9 +38,9 @@ The **AI Agent** block provides a centralized configuration interface for defini
 The **AI Agent** block allows you to configure the following components of the agent:
 
 - **System prompt and agent behavior**: Click the **AI Agent** block to open the configuration panel, where you can configure the agent role, instructions, query input, and response mapping.
-- **Memory configuration**: Use the **Add Memory** option to configure conversational or persistent memory for the agent. For more information, see [Memory](genai/develop/agents/memory.md).
-- **Tools**: Use the **+** button on the AI Agent block to add tools and integrations that the agent can invoke during execution. For more information, see [Tools](genai/develop/agents/tools.md).
-- **Model Provider Configuration**: Click the attached model provider node (for example, `wso2ModelProvider`) to configure the LLM provider and model settings used by the agent. For more information, see [Model Providers](genai/develop/components/model-providers.md).
+- **Memory configuration**: Use the **Add Memory** option to configure conversational or persistent memory for the agent. For more information, see [Memory](memory.md).
+- **Tools**: Use the **+** button on the AI Agent block to add tools and integrations that the agent can invoke during execution. For more information, see [Tools](tools.md).
+- **Model Provider Configuration**: Click the attached model provider node (for example, `wso2ModelProvider`) to configure the LLM provider and model settings used by the agent. For more information, see [Model Providers](../components/model-providers.md).
 
 ## Try it and run
 

--- a/en/docs/genai/develop/agents/tools.md
+++ b/en/docs/genai/develop/agents/tools.md
@@ -85,7 +85,7 @@ The dialog provides the following options for selecting a function:
 
 | Group | Description |
 |---|---|
-| **Within Project** | Functions defined within your own project, including [natural functions](/docs/genai/develop/natural-functions/overview), can be added as tools with a single click. |
+| **Within Project** | Functions defined within your own project, including [natural functions](../natural-functions/overview.md), can be added as tools with a single click. |
 | **Standard Library** | A curated set of commonly used Ballerina utility functions organized by module. |
 | ↳ **`io`** | `fileReadJson`, `fileReadString`, `fileWriteJson`, `fileWriteString`, `print`, `println` |
 | ↳ **`log`** | `printDebug`, `printError`, `printInfo`, `printWarn` |
@@ -111,12 +111,12 @@ The dialog provides the following configuration for selecting a tool:
 | **Server URL** | The MCP endpoint URL, for example `http://localhost:9090/mcp` or `https://mcp.example.com`. |
 | **Requires Authentication** | Enable this option if the server requires authentication, then configure the required authentication settings. |
 | **Tools to Include** | Select `All` to expose every tool advertised by the server, or choose a specific subset of tools by name. |
-| **Advanced Configurations** | Additional [HTTP client configurations](/docs/connectors/catalog/built-in/http/action-reference#client). |
+| **Advanced Configurations** | Additional [HTTP client configurations](../../../connectors/catalog/built-in/http/action-reference.md#client). |
 | **Result** | The name of the variable used to store the result returned by the MCP tool invocation. |
 
 After saving, every tool exposed by the MCP server — or every tool selected in **Tools to Include** — becomes available to the agent. These tools appear alongside local function tools and are used transparently from the agent’s perspective.
 
-> **Tip:** A WSO2 Integrator project can also consume its own MCP service. See [Exposing a Service as MCP](/docs/genai/develop/mcp/exposing-as-mcp).
+> **Tip:** A WSO2 Integrator project can also consume its own MCP service. See [Exposing a Service as MCP](../mcp/exposing-as-mcp.md).
 
 ## 4. Create custom tool
 

--- a/en/docs/genai/develop/components/chunkers.md
+++ b/en/docs/genai/develop/components/chunkers.md
@@ -162,7 +162,7 @@ The Devant Chunker is added from the same **Select Chunker** picker. Its create 
 | **Maximum Overlap Size in Characters** | `50` | Any non-negative integer | Overlap characters between adjacent chunks. |
 | **Chunking Strategy** | `RECURSIVE` | `RECURSIVE`, `PARAGRAPH`, `SENTENCE`, `CHARACTER` | The chunking strategy WSO2 Integration Platform uses. |
 
-Plus the [Standard HTTP Advanced Configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations).
+Plus the [Standard HTTP Advanced Configurations](model-providers.md#standard-http-advanced-configurations).
 
 > Only binary documents are accepted. The document's metadata must include a file name so WSO2 Integration Platform can detect the source format.
 
@@ -183,7 +183,7 @@ The defaults (`200` / `40`) are tuned for prose. Code-heavy or table-heavy conte
 
 ## What's next
 
-- [Embedding Providers](/docs/genai/develop/components/embedding-providers) - Configure the model that converts chunks into vectors.
-- [Vector Stores](/docs/genai/develop/components/vector-stores) - Set up the store that indexes and retrieves those vectors.
-- [Knowledge Bases](/docs/genai/develop/components/knowledge-bases) - Combine a chunker, embedding provider, and vector store into a single ingest-and-retrieve component.
-- [RAG](/docs/genai/develop/rag/overview) - End-to-end walkthrough of the ingestion and query flows.
+- [Embedding Providers](embedding-providers.md) - Configure the model that converts chunks into vectors.
+- [Vector Stores](vector-stores.md) - Set up the store that indexes and retrieves those vectors.
+- [Knowledge Bases](knowledge-bases.md) - Combine a chunker, embedding provider, and vector store into a single ingest-and-retrieve component.
+- [RAG](../rag/overview.md) - End-to-end walkthrough of the ingestion and query flows.

--- a/en/docs/genai/develop/components/embedding-providers.md
+++ b/en/docs/genai/develop/components/embedding-providers.md
@@ -39,7 +39,7 @@ In the **Create Vector Knowledge Base** form, click **+ Create New Embedding Mod
 | **OpenRouter** | [`ballerinax/ai.openrouter`](https://central.ballerina.io/ballerinax/ai.openrouter/latest) | Yes | None |
 
 :::info
-The HTTP-level advanced configurations on every external embedding provider use the same set of fields as model providers. For the full reference, see [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations).
+The HTTP-level advanced configurations on every external embedding provider use the same set of fields as model providers. For the full reference, see [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations).
 :::
 
 ## Default WSO2 embedding provider
@@ -75,7 +75,7 @@ The model name is implicit in the **deployment** on Azure. There is no **Model T
 
 ![Azure OpenAI Create Embedding Provider form with Advanced Configurations expanded showing Cache Configuration, Circuit Breaker Configuration, Compression AUTO, Forwarded 'disable', HTTP1 Settings, HTTP2 Settings.](/img/genai/develop/components/embedding-providers/04-azure-advanced.png)
 
-For standard HTTP configurations, see [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations).
+For standard HTTP configurations, see [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations).
 
 ## Google Vertex
 
@@ -87,7 +87,7 @@ Official website: [Vertex AI embeddings documentation](https://cloud.google.com/
 
 | Field | Required | Default | Available values |
 |---|---|---|---|
-| **Auth** | Yes | — | OAuth2 refresh-token record, a service-account record, or a path to a service-account JSON file. See [Vertex auth options](/docs/genai/develop/components/model-providers#vertex-auth-options) on the Model Providers page. |
+| **Auth** | Yes | — | OAuth2 refresh-token record, a service-account record, or a path to a service-account JSON file. See [Vertex auth options](model-providers.md#vertex-auth-options) on the Model Providers page. |
 | **Project ID** | Yes | — | Your Google Cloud project ID. |
 
 ### Advanced configurations
@@ -100,7 +100,7 @@ Official website: [Vertex AI embeddings documentation](https://cloud.google.com/
 | **Model Type** | `text-embedding-005` | `text-embedding-005`, `text-embedding-004`, `textembedding-gecko-multilingual@001`, `textembedding-gecko@001`. | Vertex embedding model. |
 | **Service URL** | `""` (auto-derived) | URL string | Override the regional endpoint. Defaults to `https://\{location\}-aiplatform.googleapis.com`. |
 
-For standard HTTP configurations, see [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations).
+For standard HTTP configurations, see [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations).
 
 ## OpenAI
 
@@ -123,7 +123,7 @@ Official website: [OpenAI Embeddings documentation](https://platform.openai.com/
 |---|---|---|---|
 | **Service URL** | `https://api.openai.com/v1` | URL string | OpenAI API base URL. |
 
-For standard HTTP configurations, see [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations).
+For standard HTTP configurations, see [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations).
 
 ## OpenRouter
 
@@ -150,7 +150,7 @@ Official website: [openrouter.ai](https://openrouter.ai/).
 | **Site URL** | `()` | URL string or empty | Optional site URL sent as `HTTP-Referer`. |
 | **Site Name** | `()` | String or empty | Optional site name sent as `X-OpenRouter-Title`. |
 
-For standard HTTP configurations, see [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations).
+For standard HTTP configurations, see [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations).
 
 :::warning
 OpenRouter's embedding endpoint accepts text-only chunks. Image or audio chunks raise an error.
@@ -170,7 +170,7 @@ The provider selected at ingest time must remain consistent for the lifetime of 
 
 ## What's next
 
-- [Vector Stores](/docs/genai/develop/components/vector-stores) — Where the embeddings live.
-- [Knowledge Bases](/docs/genai/develop/components/knowledge-bases) — The object that ties an embedding provider, a vector store, and a chunker together.
-- [Chunkers](/docs/genai/develop/components/chunkers) — Split documents into chunks before embedding for ingestion into a vector store.
-- [RAG](/docs/genai/develop/rag/overview) — WSO2 Integrator walkthrough for ingestion and query flows.
+- [Vector Stores](vector-stores.md) — Where the embeddings live.
+- [Knowledge Bases](knowledge-bases.md) — The object that ties an embedding provider, a vector store, and a chunker together.
+- [Chunkers](chunkers.md) — Split documents into chunks before embedding for ingestion into a vector store.
+- [RAG](../rag/overview.md) — WSO2 Integrator walkthrough for ingestion and query flows.

--- a/en/docs/genai/develop/components/knowledge-bases.md
+++ b/en/docs/genai/develop/components/knowledge-bases.md
@@ -9,7 +9,7 @@ keywords: [wso2 integrator, knowledge base, rag, vector knowledge base, azure ai
 
 A **Knowledge Base** is a managed store of documents that your integration can index and query. It provides a consistent interface for adding content, retrieving the most relevant chunks for a given query, and removing stale content — regardless of the underlying storage technology.
 
-In WSO2 Integrator, a Knowledge Base is the single object the RAG ingest, retrieve, and delete-by-filter nodes talk to. It uses three pluggable parts (a [Vector Store](/docs/genai/develop/components/vector-stores), an [Embedding Provider](/docs/genai/develop/components/embedding-providers), and a [Chunker](/docs/genai/develop/components/chunkers)) and exposes a small surface for indexing chunks and retrieving the most relevant ones.
+In WSO2 Integrator, a Knowledge Base is the single object the RAG ingest, retrieve, and delete-by-filter nodes talk to. It uses three pluggable parts (a [Vector Store](vector-stores.md), an [Embedding Provider](embedding-providers.md), and a [Chunker](chunkers.md)) and exposes a small surface for indexing chunks and retrieving the most relevant ones.
 
 ## Available actions
 
@@ -40,7 +40,7 @@ Click **+ Add Knowledge Base** and the **Select Knowledge Base** picker opens:
 
 | Knowledge Base | Module | Storage |
 |---|---|---|
-| **Vector Knowledge Base** | `ballerina/ai` | Any [Vector Store](/docs/genai/develop/components/vector-stores) |
+| **Vector Knowledge Base** | `ballerina/ai` | Any [Vector Store](vector-stores.md) |
 | **Azure AI Search Knowledge Base** | [`ballerinax/ai.azure`](https://central.ballerina.io/ballerinax/ai.azure/latest) | Azure AI Search index |
 
 ---
@@ -55,9 +55,9 @@ The default implementation. You combine a Vector Store, an Embedding Provider, a
 
 | Field | Required | Default | Available values |
 |---|---|---|---|
-| **Vector Store** | Yes | — | Any saved [Vector Store](/docs/genai/develop/components/vector-stores) connection. Click **+ Create New Vector Store** to make one inline. |
-| **Embedding Model** | Yes | — | Any saved [Embedding Provider](/docs/genai/develop/components/embedding-providers) connection. **Use the same provider on ingest and retrieve.** Embeddings from different providers are not interchangeable. |
-| **Chunker** | No | `ai:AUTO` | `ai:AUTO` (chunker chosen automatically based on document type), `ai:DISABLE` (no chunking; each document becomes one chunk), or any saved [Chunker](/docs/genai/develop/components/chunkers) connection. |
+| **Vector Store** | Yes | — | Any saved [Vector Store](vector-stores.md) connection. Click **+ Create New Vector Store** to make one inline. |
+| **Embedding Model** | Yes | — | Any saved [Embedding Provider](embedding-providers.md) connection. **Use the same provider on ingest and retrieve.** Embeddings from different providers are not interchangeable. |
+| **Chunker** | No | `ai:AUTO` | `ai:AUTO` (chunker chosen automatically based on document type), `ai:DISABLE` (no chunking; each document becomes one chunk), or any saved [Chunker](chunkers.md) connection. |
 
 There are no Advanced Configurations on the Vector Knowledge Base itself. Every knob lives on the underlying Vector Store, Embedding Provider, or Chunker connection.
 
@@ -80,8 +80,8 @@ Official website: [Azure AI Search](https://azure.microsoft.com/services/search/
 | **Service URL** | Yes | — | Service URL of your Azure AI Search instance. |
 | **API Key** | Yes | — | API key for authenticating with the Azure AI Search service. |
 | **Index** | Yes | — | The name of an existing search index, or a `search:SearchIndex` definition (a record describing the index schema). When creating a new index, ensure it contains one key field of type string. |
-| **Embedding Model** | No | `()` | Any saved [Embedding Provider](/docs/genai/develop/components/embedding-providers) connection. Used for query and ingest if provided. Leave empty to rely on Azure AI Search's integrated vectorization. |
-| **Chunker** | No | `ai:AUTO` | `ai:AUTO`, `ai:DISABLE`, or any saved [Chunker](/docs/genai/develop/components/chunkers) connection. |
+| **Embedding Model** | No | `()` | Any saved [Embedding Provider](embedding-providers.md) connection. Used for query and ingest if provided. Leave empty to rely on Azure AI Search's integrated vectorization. |
+| **Chunker** | No | `ai:AUTO` | `ai:AUTO`, `ai:DISABLE`, or any saved [Chunker](chunkers.md) connection. |
 
 ### Advanced configurations
 
@@ -92,8 +92,8 @@ Official website: [Azure AI Search](https://azure.microsoft.com/services/search/
 | **Verbose** | `false` | `true`, `false` | Whether to enable verbose logging during ingest and retrieve. Useful when debugging. |
 | **API Version** | `2025-09-01` | Azure AI Search API version string | The Azure AI Search REST API version to use. |
 | **Content Field Name** | `"content"` | String | The name of the field in the index that contains the main chunk content. |
-| **Search Client Connection Config** | `{}` | Record | Connection configuration for the Azure AI Search service client. Required only when `Index` is provided as a `search:SearchIndex` definition (i.e. when the connector creates the index for you). See [Standard HTTP Advanced Configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations) for available knobs. |
-| **Index Client Connection Config** | `{}` | Record | Connection configuration for the Azure AI Search index client. See [Standard HTTP Advanced Configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations) for available knobs. |
+| **Search Client Connection Config** | `{}` | Record | Connection configuration for the Azure AI Search service client. Required only when `Index` is provided as a `search:SearchIndex` definition (i.e. when the connector creates the index for you). See [Standard HTTP Advanced Configurations](model-providers.md#standard-http-advanced-configurations) for available knobs. |
+| **Index Client Connection Config** | `{}` | Record | Connection configuration for the Azure AI Search index client. See [Standard HTTP Advanced Configurations](model-providers.md#standard-http-advanced-configurations) for available knobs. |
 | **Semantic Configuration Name** | `()` | String or empty | The name of the semantic configuration to use for semantic search. Leave empty for plain vector / keyword search. |
 
 > The connector analyzes the index schema on init: it identifies the **key field**, every **vector field**, and verifies the content field exists. If you use Azure AI Search's integrated vectorization, you don't need to provide an Embedding Model.
@@ -110,6 +110,6 @@ Official website: [Azure AI Search](https://azure.microsoft.com/services/search/
 
 ## What's next
 
-- [Chunkers](/docs/genai/develop/components/chunkers) — How documents are split before ingest.
-- [Direct LLM Calls](/docs/genai/develop/direct-llm/overview) — One-shot generate calls without an agent loop.
-- [Natural Functions](/docs/genai/develop/natural-functions/overview) — Ballerina functions whose body is plain English, evaluated at runtime by an LLM.
+- [Chunkers](chunkers.md) — How documents are split before ingest.
+- [Direct LLM Calls](../direct-llm/overview.md) — One-shot generate calls without an agent loop.
+- [Natural Functions](../natural-functions/overview.md) — Ballerina functions whose body is plain English, evaluated at runtime by an LLM.

--- a/en/docs/genai/develop/components/model-providers.md
+++ b/en/docs/genai/develop/components/model-providers.md
@@ -44,7 +44,7 @@ Scroll to see the remaining options:
 
 | Provider | Module | API key required? | Has embedding provider? |
 |---|---|---|---|
-| **Default WSO2** | `ballerina/ai` | No (signed-in via WSO2) | Yes. See [Default WSO2 Embedding Provider](/docs/genai/develop/components/embedding-providers#default-wso2-embedding-provider) |
+| **Default WSO2** | `ballerina/ai` | No (signed-in via WSO2) | Yes. See [Default WSO2 Embedding Provider](embedding-providers.md#default-wso2-embedding-provider) |
 | **Anthropic** | [`ballerinax/ai.anthropic`](https://central.ballerina.io/ballerinax/ai.anthropic/latest) | Yes | No |
 | **Azure OpenAI** | [`ballerinax/ai.azure`](https://central.ballerina.io/ballerinax/ai.azure/latest) | Yes | Yes |
 | **DeepSeek** | [`ballerinax/ai.deepseek`](https://central.ballerina.io/ballerinax/ai.deepseek/latest) | Yes | No |
@@ -152,7 +152,7 @@ Official website: [Azure OpenAI Service](https://azure.microsoft.com/services/co
 Plus the [Standard HTTP advanced configurations](#standard-http-advanced-configurations).
 
 :::info
-The Azure package also ships an **Embedding Provider** and the **Azure AI Search Knowledge Base**. See [Azure OpenAI](/docs/genai/develop/components/embedding-providers#azure-openai) and [Azure AI Search](/docs/genai/develop/components/knowledge-bases#azure-ai-search-knowledge-base).
+The Azure package also ships an **Embedding Provider** and the **Azure AI Search Knowledge Base**. See [Azure OpenAI](embedding-providers.md#azure-openai) and [Azure AI Search](knowledge-bases.md#azure-ai-search-knowledge-base).
 :::
 
 ## DeepSeek
@@ -220,7 +220,7 @@ Plus the [Standard HTTP advanced configurations](#standard-http-advanced-configu
 | **Service account JSON path** | A file path string | Easiest - point at the downloaded service-account JSON file from the Google Cloud console. The connector reads `client_email` and `private_key` automatically and refreshes the token. |
 
 :::info
-Vertex also ships an **Embedding Provider**. See [Google Vertex](/docs/genai/develop/components/embedding-providers#google-vertex).
+Vertex also ships an **Embedding Provider**. See [Google Vertex](embedding-providers.md#google-vertex).
 :::
 
 ## Mistral
@@ -320,7 +320,7 @@ Official website: [platform.openai.com](https://platform.openai.com/).
 Plus the [Standard HTTP advanced configurations](#standard-http-advanced-configurations) (Timeout, Retry, Circuit Breaker, Proxy, etc.).
 
 :::info
-The OpenAI package also ships an **Embedding Provider**. See [OpenAI](/docs/genai/develop/components/embedding-providers#openai).
+The OpenAI package also ships an **Embedding Provider**. See [OpenAI](embedding-providers.md#openai).
 :::
 
 ## OpenRouter
@@ -353,7 +353,7 @@ Official website: [openrouter.ai](https://openrouter.ai/).
 Plus the [Standard HTTP advanced configurations](#standard-http-advanced-configurations).
 
 :::info
-The OpenRouter package also ships an **Embedding Provider**. See [OpenRouter](/docs/genai/develop/components/embedding-providers#openrouter).
+The OpenRouter package also ships an **Embedding Provider**. See [OpenRouter](embedding-providers.md#openrouter).
 :::
 
 ## Model provider connections
@@ -391,7 +391,7 @@ Editing a connection follows the same pattern for every component type. Embeddin
 
 ## What's next
 
-- [Embedding providers](/docs/genai/develop/components/embedding-providers) — Vector embeddings for RAG. The OpenAI, Azure, Vertex, OpenRouter, and Default WSO2 packages also ship embedding providers.
-- [Vector stores](/docs/genai/develop/components/vector-stores.md) — Persist and query embeddings using Pinecone, Weaviate, Qdrant, pgvector, and other backends.
-- [Knowledge bases](/docs/genai/develop/components/knowledge-bases.md) — Managed retrieval sources, including Azure AI Search, that plug directly into RAG flows.
-- [Chunkers](/docs/genai/develop/components/chunkers.md) — Split documents into chunks before embedding for ingestion into a vector store.
+- [Embedding providers](embedding-providers.md) — Vector embeddings for RAG. The OpenAI, Azure, Vertex, OpenRouter, and Default WSO2 packages also ship embedding providers.
+- [Vector stores](vector-stores.md) — Persist and query embeddings using Pinecone, Weaviate, Qdrant, pgvector, and other backends.
+- [Knowledge bases](knowledge-bases.md) — Managed retrieval sources, including Azure AI Search, that plug directly into RAG flows.
+- [Chunkers](chunkers.md) — Split documents into chunks before embedding for ingestion into a vector store.

--- a/en/docs/genai/develop/components/vector-stores.md
+++ b/en/docs/genai/develop/components/vector-stores.md
@@ -11,7 +11,7 @@ A vector database stores vector embeddings and enables similarity search over th
 
 A **Vector Store** is WSO2 Integrator's abstraction over these databases, exposing a common interface for every supported backend.
 
-It is the storage half of a [Knowledge Base](/docs/genai/develop/components/knowledge-bases). The [Embedding Provider](/docs/genai/develop/components/embedding-providers) produces the vectors, and the Vector Store abstracts where and how they are persisted and retrieved at query time.
+It is the storage half of a [Knowledge Base](knowledge-bases.md). The [Embedding Provider](embedding-providers.md) produces the vectors, and the Vector Store abstracts where and how they are persisted and retrieved at query time.
 
 ## Available actions
 
@@ -128,7 +128,7 @@ Official website: [Milvus documentation](https://milvus.io/docs).
 
 | Field | Default | Available values | What it controls |
 |---|---|---|---|
-| **HTTP Configuration** | `{}` | Record | Standard HTTP knobs. Same fields as [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations). |
+| **HTTP Configuration** | `{}` | Record | Standard HTTP knobs. Same fields as [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations). |
 
 :::info
 The connector loads the collection into memory automatically before each search. Milvus converts IDs to integers for the primary key field.
@@ -189,7 +189,7 @@ Official website: [Pinecone documentation](https://docs.pinecone.io).
 | Field | Default | Available values | What it controls |
 |---|---|---|---|
 | **Pinecone Configuration** | `{}` | Record (`namespace`, `filters`, `sparseVector`) | Pinecone-specific settings. **Namespace** isolates vectors for multi-tenancy. **Filters** sets default metadata filters applied on every query. **Sparse Vector** is needed for hybrid search. |
-| **HTTP Configuration** | `{}` | Record | Standard HTTP knobs. Same fields as [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations). |
+| **HTTP Configuration** | `{}` | Record | Standard HTTP knobs. Same fields as [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations). |
 | **Query Mode** | `ai:DENSE` | `ai:DENSE`, `ai:SPARSE`, `ai:HYBRID` | Search mode. |
 
 :::info
@@ -218,7 +218,7 @@ Official website: [Weaviate documentation](https://weaviate.io/developers/weavia
 
 | Field | Default | Available values | What it controls |
 |---|---|---|---|
-| **HTTP Configuration** | `{}` | Record | Standard HTTP knobs. Same fields as [Standard HTTP advanced configurations](/docs/genai/develop/components/model-providers#standard-http-advanced-configurations). |
+| **HTTP Configuration** | `{}` | Record | Standard HTTP knobs. Same fields as [Standard HTTP advanced configurations](model-providers.md#standard-http-advanced-configurations). |
 
 :::info
 This connector supports dense vectors only. Weaviate maps the `certainty` score to the `similarityScore` field in the response.
@@ -238,6 +238,6 @@ Selection is based on operational concerns (where your data already lives, what 
 
 ## What's next
 
-- [Knowledge Bases](/docs/genai/develop/components/knowledge-bases) — Combine a vector store with an embedding provider and a chunker.
-- [Chunkers](/docs/genai/develop/components/chunkers) — Split documents into chunks before embedding for ingestion into a vector store.
-- [RAG](/docs/genai/develop/rag/overview) — Visual designer walkthrough for RAG ingestion and query in WSO2 Integrator.
+- [Knowledge Bases](knowledge-bases.md) — Combine a vector store with an embedding provider and a chunker.
+- [Chunkers](chunkers.md) — Split documents into chunks before embedding for ingestion into a vector store.
+- [RAG](../rag/overview.md) — Visual designer walkthrough for RAG ingestion and query in WSO2 Integrator.

--- a/en/docs/genai/develop/direct-llm/overview.md
+++ b/en/docs/genai/develop/direct-llm/overview.md
@@ -12,17 +12,17 @@ A **direct LLM call** is the simplest way to use AI in WSO2 Integrator. You add 
 This page is a single, end-to-end reference for everything you need to make that call work in WSO2 Integrator: adding a model provider, dropping a `generate` node, writing the prompt, and binding the response to a Ballerina type.
 
 :::tip Looking for a hands-on walkthrough?
-See the **[Email Generator with Direct LLM](/docs/genai/tutorials/email-generator-direct-llm)** tutorial. It builds a `POST /emails/generate` service end-to-end using everything described on this page.
+See the **[Email Generator with Direct LLM](../../tutorials/email-generator-direct-llm.md)** tutorial. It builds a `POST /emails/generate` service end-to-end using everything described on this page.
 :::
 
 ## When to use direct LLM calls
 
 | Use direct LLM when… | Look elsewhere when… |
 |---|---|
-| You need a single-shot LLM call inside a flow. | You want a typed function with an English body. Use [Natural Functions](/docs/genai/develop/natural-functions/overview). |
-| You want full control over the prompt at the point of use. | The same prompt is reused all over the codebase. Wrap it in a [natural function](/docs/genai/develop/natural-functions/overview) instead. |
-| The LLM doesn't need to call any tools or remember earlier turns. | The task needs tool calls, multi-step reasoning, or conversation history. Use an [AI Agent](/docs/genai/develop/agents/overview). |
-| You need to ground answers in your own documents. | Add [RAG](/docs/genai/develop/rag/overview) and pass the retrieved context into the prompt. |
+| You need a single-shot LLM call inside a flow. | You want a typed function with an English body. Use [Natural Functions](../natural-functions/overview.md). |
+| You want full control over the prompt at the point of use. | The same prompt is reused all over the codebase. Wrap it in a [natural function](../natural-functions/overview.md) instead. |
+| The LLM doesn't need to call any tools or remember earlier turns. | The task needs tool calls, multi-step reasoning, or conversation history. Use an [AI Agent](../agents/overview.md). |
+| You need to ground answers in your own documents. | Add [RAG](../rag/overview.md) and pass the retrieved context into the prompt. |
 
 ## How a direct LLM call looks in a flow
 
@@ -32,14 +32,14 @@ A typical flow with a direct LLM call has a `generate` node sitting between your
 
 To build this you do three things, in order:
 
-1. **Pick a Model Provider connection.** You can use the **Default WSO2 Model Provider**, or see **[Model Providers](/docs/genai/develop/components/model-providers)** for other providers (OpenAI, Anthropic, Azure OpenAI, etc.).
+1. **Pick a Model Provider connection.** You can use the **Default WSO2 Model Provider**, or see **[Model Providers](../components/model-providers.md)** for other providers (OpenAI, Anthropic, Azure OpenAI, etc.).
 2. [**Add the Generate Node**](#the-generate-node), the call itself.
 3. [**Write the prompt**](#the-prompt-editor) and pick the expected type.
 
 The rest of this page walks each step in order.
 
 :::info
-If your project does not have a model provider yet, head over to [Model Providers](/docs/genai/develop/components/model-providers) first. The fastest one is the **Default WSO2 Model Provider**. No API key required, just a one-time WSO2 sign-in.
+If your project does not have a model provider yet, head over to [Model Providers](../components/model-providers.md) first. The fastest one is the **Default WSO2 Model Provider**. No API key required, just a one-time WSO2 sign-in.
 :::
 
 ---
@@ -68,7 +68,7 @@ When the form opens, three fields are all you need: the **Prompt**, the **Result
 
 The **Expected Type** field is what makes the response come back as a typed value. A `string`, an `int`, a record, an array. Not a blob of text you have to parse yourself. The runtime derives a JSON schema from the type, asks the model to fill it, parses the response back, and hands the typed value to the next node. **You don't need to write any schema instructions in the prompt.** The type drives that automatically.
 
-There are no per-call overrides on the `generate` node. Anything you'd tune (temperature, max tokens, and so on) lives on the model provider connection and applies to every call that uses it. See [Model Providers](/docs/genai/develop/components/model-providers) for the full list of advanced configurations per provider.
+There are no per-call overrides on the `generate` node. Anything you'd tune (temperature, max tokens, and so on) lives on the model provider connection and applies to every call that uses it. See [Model Providers](../components/model-providers.md) for the full list of advanced configurations per provider.
 
 ### After saving
 
@@ -96,8 +96,8 @@ The **Insert** menu is the bridge between the prompt and the rest of your projec
 
 ## What's next
 
-- **[Email Generator with Direct LLM (Tutorial)](/docs/genai/tutorials/email-generator-direct-llm)** — build a complete `POST /emails/generate` service from scratch using everything on this page.
-- **[Model Providers](/docs/genai/develop/components/model-providers)** — switch the LLM provider for production; tune temperature, max tokens, retries.
-- **[Natural Functions](/docs/genai/develop/natural-functions/overview)** — when the same prompt is used in many places, package it as a typed function.
-- **[RAG](/docs/genai/develop/rag/overview)** — ground the model's answers in your own documents.
-- **[AI Agents](/docs/genai/develop/agents/overview)** — if the task needs tools or multi-turn reasoning.
+- **[Email Generator with Direct LLM (Tutorial)](../../tutorials/email-generator-direct-llm.md)** — build a complete `POST /emails/generate` service from scratch using everything on this page.
+- **[Model Providers](../components/model-providers.md)** — switch the LLM provider for production; tune temperature, max tokens, retries.
+- **[Natural Functions](../natural-functions/overview.md)** — when the same prompt is used in many places, package it as a typed function.
+- **[RAG](../rag/overview.md)** — ground the model's answers in your own documents.
+- **[AI Agents](../agents/overview.md)** — if the task needs tools or multi-turn reasoning.

--- a/en/docs/genai/develop/mcp/consuming-mcp-from-agent.md
+++ b/en/docs/genai/develop/mcp/consuming-mcp-from-agent.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Consuming MCP from an Agent
 
-An [AI Agent](/docs/genai/develop/agents/overview) in WSO2 Integrator can use any MCP server as a tool source. Add the server once; the agent picks up every tool the server advertises (or only the ones you select) and treats them exactly like local function tools.
+An [AI Agent](../agents/overview.md) in WSO2 Integrator can use any MCP server as a tool source. Add the server once; the agent picks up every tool the server advertises (or only the ones you select) and treats them exactly like local function tools.
 
 ## Adding an MCP server to an agent
 
@@ -193,5 +193,5 @@ Local tools and MCP tools are completely interchangeable from the agent's perspe
 ## What's Next
 
 - **[Exposing a Service as MCP](exposing-as-mcp.md)** — the other side of MCP.
-- **[Tools (in AI Agents)](/docs/genai/develop/agents/tools)** — back to the Add Tool dialog.
-- **[Creating an Agent](/docs/genai/develop/agents/creating-an-agent)** — the agent that consumes the MCP tools.
+- **[Tools (in AI Agents)](../agents/tools.md)** — back to the Add Tool dialog.
+- **[Creating an Agent](../agents/creating-an-agent.md)** — the agent that consumes the MCP tools.

--- a/en/docs/genai/develop/mcp/exposing-as-mcp.md
+++ b/en/docs/genai/develop/mcp/exposing-as-mcp.md
@@ -489,5 +489,5 @@ Once your service is running, MCP clients connect by URL.
 ## What's next
 
 - **[Consuming MCP from an Agent](consuming-mcp-from-agent.md)** — the other half of the MCP picture.
-- **[Tools (in AI Agents)](/docs/genai/develop/agents/tools)** — local-tool reference; the same description-quality rules apply.
+- **[Tools (in AI Agents)](../agents/tools.md)** — local-tool reference; the same description-quality rules apply.
 - **[HTTP service](../../../develop/integration-artifacts/service/http.md)** — for the HTTP-level options exposed through `httpConfig`.

--- a/en/docs/genai/develop/natural-functions/overview.md
+++ b/en/docs/genai/develop/natural-functions/overview.md
@@ -10,7 +10,7 @@ A **natural function** is a function whose body is written in **English** instea
 
 This page is a single, end-to-end reference covering the form that creates the function, the Prompt node, the return type, and how to call it from a flow.
 
-> **Looking for a hands-on walkthrough?** See the **[Customer Review Analyzer with Natural Function](/docs/genai/tutorials/review-summarizer-natural-function)** tutorial. It builds the example shown on this page from an empty project to a working `POST /api/v1/analyze` endpoint.
+> **Looking for a hands-on walkthrough?** See the **[Customer Review Analyzer with Natural Function](../../tutorials/review-summarizer-natural-function.md)** tutorial. It builds the example shown on this page from an empty project to a working `POST /api/v1/analyze` endpoint.
 
 :::caution Experimental feature
 Natural functions are an experimental feature. Enable experimental features in WSO2 Integrator before using them: open **Settings**, expand **Extensions**, select the **Ballerina** extension, and tick **Experimental: Enable Experimental Feature**.
@@ -108,7 +108,7 @@ When you create a natural function, WSO2 Integrator automatically binds it to th
 
 If a provider already exists in the project, pick it from the dropdown and click **Save**. If not, click **+ Create New Model Provider** and pick from the catalogue (OpenAI, Anthropic, Azure OpenAI, Default WSO2, …).
 
-Adding a provider, the per-provider form fields, the supported models, and the advanced HTTP knobs are all documented in **[AI Connections and Stores: Model Providers](/docs/genai/develop/components/model-providers)**. Every natural function, direct LLM call, RAG `generate` node, and AI Agent in the project shares the same provider connections.
+Adding a provider, the per-provider form fields, the supported models, and the advanced HTTP knobs are all documented in **[AI Connections and Stores: Model Providers](../components/model-providers.md)**. Every natural function, direct LLM call, RAG `generate` node, and AI Agent in the project shares the same provider connections.
 
 ---
 
@@ -191,13 +191,13 @@ Once the function exists, calling it from a flow is one step.
 
 Natural functions are first-class functions, so they can call each other from inside any flow. Open a function flow, select **+ Add Node > Statement > Call Function**, and pick the natural function from the picker. Two-step prompts (extract first, then transform) are often cleaner than one giant prompt; each step has its own type and can be tested in isolation.
 
-A natural function can also be wired up as an [agent tool](/docs/genai/develop/agents/tools): the agent decides *whether* to call it, and the natural function's own model handles the call with a tighter prompt and stricter return type.
+A natural function can also be wired up as an [agent tool](../agents/tools.md): the agent decides *whether* to call it, and the natural function's own model handles the call with a tighter prompt and stricter return type.
 
 ---
 
 ## What's Next
 
-- **[Customer Review Analyzer with Natural Function (Tutorial)](/docs/genai/tutorials/review-summarizer-natural-function)** — end-to-end tutorial that builds a `POST /api/v1/analyze` service using everything on this page.
-- **[Model Providers](/docs/genai/develop/components/model-providers)** — switch providers, tune temperature, max tokens, and retries for the Prompt node's connection.
-- **[Direct LLM Calls](/docs/genai/develop/direct-llm/overview)** — when you only need a single in-flow call without packaging it as a function.
-- **[AI Agents](/docs/genai/develop/agents/overview)** — when natural functions become tools an agent can choose to call.
+- **[Customer Review Analyzer with Natural Function (Tutorial)](../../tutorials/review-summarizer-natural-function.md)** — end-to-end tutorial that builds a `POST /api/v1/analyze` service using everything on this page.
+- **[Model Providers](../components/model-providers.md)** — switch providers, tune temperature, max tokens, and retries for the Prompt node's connection.
+- **[Direct LLM Calls](../direct-llm/overview.md)** — when you only need a single in-flow call without packaging it as a function.
+- **[AI Agents](../agents/overview.md)** — when natural functions become tools an agent can choose to call.

--- a/en/docs/genai/getting-started/build-a-hotel-finder-agent.md
+++ b/en/docs/genai/getting-started/build-a-hotel-finder-agent.md
@@ -58,7 +58,7 @@ import TabItem from '@theme/TabItem';
 
 By default, the agent is created with the WSO2 model provider. If you have not [signed in to WSO2 Integrator Copilot](../../develop/copilot/getting-started.md) yet, sign in when prompted. No third-party API key is required.
 
-To use a different LLM instead, see [Model providers](/docs/genai/develop/components/model-providers) for the full list of supported providers (OpenAI, Anthropic, Azure OpenAI, and others).
+To use a different LLM instead, see [Model providers](../develop/components/model-providers.md) for the full list of supported providers (OpenAI, Anthropic, Azure OpenAI, and others).
 
 :::
 
@@ -162,7 +162,7 @@ The tool's visual flow opens. Add the logic:
 
    :::note
 
-   This uses hardcoded sample data. In a real scenario, you would call an external hotel API, query a database, or connect an [MCP tool](/docs/genai/develop/agents/tools).
+   This uses hardcoded sample data. In a real scenario, you would call an external hotel API, query a database, or connect an [MCP tool](../develop/agents/tools.md).
 
    :::
 
@@ -268,7 +268,7 @@ In the tool's visual flow, select **+** and select **Return** under **Control**.
 
 :::note
 
-This returns hardcoded sample data. In a real scenario, you would query a booking system, call an availability API, or connect an [MCP tool](/docs/genai/develop/agents/tools).
+This returns hardcoded sample data. In a real scenario, you would query a booking system, call an availability API, or connect an [MCP tool](../develop/agents/tools.md).
 
 :::
 
@@ -348,7 +348,7 @@ Create a file named `agents.bal`. Each tool is an `isolated` function annotated 
 
 :::note
 
-Both tools use hardcoded sample data. In a real scenario, you would call external APIs, query a database, or connect [MCP tools](/docs/genai/develop/agents/tools).
+Both tools use hardcoded sample data. In a real scenario, you would call external APIs, query a database, or connect [MCP tools](../develop/agents/tools.md).
 
 :::
 
@@ -458,6 +458,6 @@ This example demonstrates two patterns you will reuse in production agents:
 
 ## What's next
 
-- [Creating an agent](/docs/genai/develop/agents/creating-an-agent) — Full reference for agent configuration
-- [Tools](/docs/genai/develop/agents/tools) — Advanced tool patterns, including connection-backed tools and MCP servers
-- [Memory](/docs/genai/develop/agents/memory) — Custom memory strategies beyond the default session store
+- [Creating an agent](../develop/agents/creating-an-agent.md) — Full reference for agent configuration
+- [Tools](../develop/agents/tools.md) — Advanced tool patterns, including connection-backed tools and MCP servers
+- [Memory](../develop/agents/memory.md) — Custom memory strategies beyond the default session store

--- a/en/docs/genai/getting-started/build-a-sentiment-analyzer.md
+++ b/en/docs/genai/getting-started/build-a-sentiment-analyzer.md
@@ -204,5 +204,5 @@ This is what differentiates a direct LLM call from a raw chat completion: you wr
 ## What's next
 
 - [Build a Hotel Finder Agent](build-a-hotel-finder-agent.md) — Add custom tools and session-scoped memory
-- [What is an AI Agent?](/docs/genai/develop/agents/overview) — Understand the agent architecture
-- [What are Tools?](/docs/genai/develop/agents/tools) — Learn tool design patterns
+- [What is an AI Agent?](../develop/agents/overview.md) — Understand the agent architecture
+- [What are Tools?](../develop/agents/tools.md) — Learn tool design patterns

--- a/en/docs/genai/tutorials/building-a-customer-care-agent-mcp.md
+++ b/en/docs/genai/tutorials/building-a-customer-care-agent-mcp.md
@@ -166,7 +166,7 @@ Try the following messages to exercise all three tools:
     }}
 />
 
-For more detail on using the chat panel, see [Try-It experiences](../../develop/test/built-in-try-it-tool#try-it-experiences).
+For more detail on using the chat panel, see [Try-It experiences](../../develop/test/built-in-try-it-tool.md#try-it-experiences).
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">
@@ -250,7 +250,7 @@ To run and test the agent, follow the same steps in the **Visual Designer** tab 
 
 ## What's next
 
-- [Exposing a service as an MCP server](../develop/mcp/exposing-as-mcp) — Build your own MCP server like the one used in this tutorial
-- [Consuming MCP from an agent](../develop/mcp/consuming-mcp-from-agent) — Deeper reference for `ai:McpToolKit` options
-- [Adding memory to an agent](../develop/agents/memory) — Persist conversation history across sessions
-- [AI agent observability](../develop/agents/observability) — Trace tool calls and monitor agent performance
+- [Exposing a service as an MCP server](../develop/mcp/exposing-as-mcp.md) — Build your own MCP server like the one used in this tutorial
+- [Consuming MCP from an agent](../develop/mcp/consuming-mcp-from-agent.md) — Deeper reference for `ai:McpToolKit` options
+- [Adding memory to an agent](../develop/agents/memory.md) — Persist conversation history across sessions
+- [AI agent observability](../develop/agents/observability.md) — Trace tool calls and monitor agent performance

--- a/en/docs/genai/tutorials/email-generator-direct-llm.md
+++ b/en/docs/genai/tutorials/email-generator-direct-llm.md
@@ -6,14 +6,14 @@ description: Step-by-step tutorial — build an HTTP service that generates prof
 
 # Email Generator with Direct LLM
 
-This tutorial walks through building an **HTTP service that generates professional emails using an LLM**. It's a complete, end-to-end scenario that exercises the [Direct LLM Calls](/docs/genai/develop/direct-llm/overview) feature surface.
+This tutorial walks through building an **HTTP service that generates professional emails using an LLM**. It's a complete, end-to-end scenario that exercises the [Direct LLM Calls](../develop/direct-llm/overview.md) feature surface.
 
 By the end you will have a `POST /emails/generate` endpoint that takes recipient details and a meeting intent, and returns a fully written, structured email, subject and body, produced by an LLM.
 
 ## What you'll build
 
 1. **Create the HTTP service** with typed request and response payloads.
-2. **Add a [model provider](/docs/genai/develop/components/model-providers)** as the connection to the LLM.
+2. **Add a [model provider](../develop/components/model-providers.md)** as the connection to the LLM.
 3. **Add a `generate` node** with a prompt that writes the email.
 4. **Bind the response** to the structured response type.
 5. **Run and test** the service end to end.
@@ -98,7 +98,7 @@ Click **Default Model Provider (WSO2)**. In the configuration form:
 
 ![Model Provider configuration with name emailGenerator.](/img/genai/develop/direct-llm/07-model-provider-config.png)
 
-> **Tip:** The Default WSO2 Model Provider does not require an API key. For a different provider see [AI Connections and Stores → Model Providers](/docs/genai/develop/components/model-providers).
+> **Tip:** The Default WSO2 Model Provider does not require an API key. For a different provider see [AI Connections and Stores → Model Providers](../develop/components/model-providers.md).
 
 ---
 
@@ -203,5 +203,5 @@ The LLM produced a complete, professionally written email — subject and body �
 
 ## What's next
 
-- **[Direct LLM Calls reference](/docs/genai/develop/direct-llm/overview)** -- the single-page feature reference covering the `generate` node, prompt editor, and typed responses.
-- **[Model Providers](/docs/genai/develop/components/model-providers)** -- switch the LLM provider for production (init params, supported models, advanced HTTP configs for OpenAI, Azure, Anthropic, Vertex, Mistral, DeepSeek, Ollama, OpenRouter).
+- **[Direct LLM Calls reference](../develop/direct-llm/overview.md)** -- the single-page feature reference covering the `generate` node, prompt editor, and typed responses.
+- **[Model Providers](../develop/components/model-providers.md)** -- switch the LLM provider for production (init params, supported models, advanced HTTP configs for OpenAI, Azure, Anthropic, Vertex, Mistral, DeepSeek, Ollama, OpenRouter).

--- a/en/docs/genai/tutorials/it-helpdesk-chatbot.md
+++ b/en/docs/genai/tutorials/it-helpdesk-chatbot.md
@@ -30,9 +30,9 @@ In this tutorial, you will learn how to:
 
 Before getting started, ensure that the following requirements are met:
 
-- Install the [WSO2 Integrator VS Code extension](/docs/get-started/setup/local-setup)
+- Install the [WSO2 Integrator VS Code extension](../../get-started/setup/local-setup.md)
 - Set up an MSSQL database for agent memory persistence
-- Have a basic understanding of memory configuration concepts. For more information, refer to [Memory](/docs/genai/develop/agents/memory)
+- Have a basic understanding of memory configuration concepts. For more information, refer to [Memory](../develop/agents/memory.md)
 
 ## Architecture
 
@@ -69,7 +69,7 @@ In this section, you will create the integration project and configure the AI ag
 
 ### Step 1: Create the integration project
 
-Create a new integration project by following the instructions in [Create a project](develop/create-integrations/create-a-project.md).
+Create a new integration project by following the instructions in [Create a project](../../develop/create-integrations/create-a-project.md).
 
 ### Step 2: Define the data type
 
@@ -110,7 +110,7 @@ final KbArticle[] & readonly kbArticles = [
 </Tabs>
 ### Step 3: Create the AI agent
 
-Create the AI agent named `itHelpDeskAgent` by following the instructions in [Creating an Agent](genai/develop/agents/creating-an-agent.md).
+Create the AI agent named `itHelpDeskAgent` by following the instructions in [Creating an Agent](../develop/agents/creating-an-agent.md).
 
 ### Step 4: Update the system prompt
 
@@ -149,7 +149,7 @@ final ai:Agent itHelpDeskAgent = check new (
 
 ### Step 5: Add a tool to the agent
 
-Add the following tool to the agent by following the instructions in [Create custom tool](/docs/genai/develop/agents/tools#4-create-custom-tool).
+Add the following tool to the agent by following the instructions in [Create custom tool](../develop/agents/tools.md#4-create-custom-tool).
 
 <Tabs>
 <TabItem value="code" label="Ballerina Code">
@@ -177,7 +177,7 @@ isolated function searchKnowledgeBase(string query) returns string {
 
 ### Step 6: Add persistent memory to the agent
 
-Add persistent memory by following the instructions in [Memory](genai/develop/agents/memory.md).
+Add persistent memory by following the instructions in [Memory](../develop/agents/memory.md).
 
 <Tabs>
 <TabItem value="ui" label="Visual Designer" default>

--- a/en/docs/genai/tutorials/review-summarizer-natural-function.md
+++ b/en/docs/genai/tutorials/review-summarizer-natural-function.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 # Customer Review Analyzer with Natural Function
 
-This tutorial walks through building an **HTTP service that uses a Natural Function to analyze a customer review** and return structured feedback. It is the end-to-end scenario for the [Natural Functions](/docs/genai/develop/natural-functions/overview) feature.
+This tutorial walks through building an **HTTP service that uses a Natural Function to analyze a customer review** and return structured feedback. It is the end-to-end scenario for the [Natural Functions](../develop/natural-functions/overview.md) feature.
 
 By the end you will have a `POST /api/v1/analyze` endpoint that takes a single customer review and returns a typed `ReviewResponse` containing the overall sentiment, a concise summary, per-topic sentiment, a churn-risk flag, and a suggested follow-up action. All of it is produced by an LLM, using a Natural Function as the body.
 
@@ -110,7 +110,7 @@ Click **Import**. WSO2 Integrator infers and registers three types under the **T
 
 `ReviewResponse` is selected automatically as the function's return type.
 
-> Why these field names matter: the runtime turns the record (and its nested types) into a JSON schema and sends it to the LLM. Field names, types, and any descriptions you add become part of the contract the model is constrained to. See [Typed Return Inference](/docs/genai/develop/natural-functions/overview#typed-return-inference) for the details.
+> Why these field names matter: the runtime turns the record (and its nested types) into a JSON schema and sends it to the LLM. Field names, types, and any descriptions you add become part of the contract the model is constrained to. See [Typed Return Inference](../develop/natural-functions/overview.md#typed-return-inference) for the details.
 
 ### Step 1.4: Create the function
 
@@ -296,5 +296,5 @@ The LLM analyzed the review, identified the overall sentiment, extracted per-top
 
 ## What's next
 
-- **[Natural Functions reference](/docs/genai/develop/natural-functions/overview)** — the single-page reference covering the form, the Prompt node, typed return inference, and calling from a flow.
+- **[Natural Functions reference](../develop/natural-functions/overview.md)** — the single-page reference covering the form, the Prompt node, typed return inference, and calling from a flow.
 - **[Email Generator with Direct LLM](email-generator-direct-llm.md)** — a similar tutorial built around direct LLM calls.


### PR DESCRIPTION
## Purpose
The links in the whats next section in some of the genai pages were broken due to the root URL change (Previous URLs had two docs like `https://wso2.com/integration-platform/docs/docs/genai/..`). Docusaurus recommends using relative file paths for links [1] as they are more resilient to path changes.

This PR updates all links in the genai section to use relative file paths with .md extensions.

[1] - https://docusaurus.io/docs/markdown-features/links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation cross-references throughout GenAI documentation (agents, components, tutorials, and guides) to use relative path format across multiple pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->