### PR TITLE
Fix broken internal links in guides

### DIFF
--- a/en/docs/guides/migration/coming-from-mulesoft.md
+++ b/en/docs/guides/migration/coming-from-mulesoft.md
@@ -235,7 +235,7 @@ Open `migration_report.html` and work through any non-migratable items. If you o
 
 1. **Unsupported Mule elements**: Implement the equivalent Ballerina logic manually. Refer to the [concept and component mapping table](#concept-and-component-mapping) below.
 2. **DataWeave transformations**: Simple field mappings can be redone with the Visual Data Mapper. Complex transformations should be rewritten as Ballerina query expressions.
-3. **Custom connectors**: Check [Connectors](/docs/connectors/overview) for a Ballerina equivalent, or call the service's REST API directly using `http:Client`.
+3. **Custom connectors**: Check [Connectors](/connectors/overview) for a Ballerina equivalent, or call the service's REST API directly using `http:Client`.
 
 ### Configure credentials
 
@@ -273,7 +273,7 @@ To build a deployable artifact:
 bal build
 ```
 
-See [Deploy](/docs/deploy/overview) for Docker, Kubernetes, and cloud deployment options.
+See [Deploy](/deploy/overview) for Docker, Kubernetes, and cloud deployment options.
 
 ## Concept and component mapping
 
@@ -450,7 +450,7 @@ For each MuleSoft connector:
 - **File/FTP**: Use `ballerina/ftp`, `ballerina/io`
 - **JMS**: Use `ballerinax/java.jms` or migrate to Kafka
 - **Email**: Use `ballerina/email`
-- Check the [Connectors](/docs/connectors/overview) page for the full list.
+- Check the [Connectors](/connectors/overview) page for the full list.
 
 ### 4. Flow control constructs
 

--- a/en/docs/guides/migration/coming-from-tibco.md
+++ b/en/docs/guides/migration/coming-from-tibco.md
@@ -272,7 +272,7 @@ To build a deployable artifact:
 bal build
 ```
 
-See [Deploy](/docs/deploy/overview) for Docker, Kubernetes, and cloud deployment options.
+See [Deploy](/deploy/overview) for Docker, Kubernetes, and cloud deployment options.
 
 ## Concept mapping
 
@@ -402,7 +402,7 @@ For each TIBCO connection resource:
 - **JMS Connection**: Use `ballerinax/kafka` or `ballerinax/rabbitmq`
 - **WSDL/SOAP service**: Run `bal wsdl` to generate a type-safe Ballerina client
 - **File Connection**: Use `ballerina/file`, `ballerina/io`, or `ballerina/ftp`
-- Check the [Connectors](/docs/connectors/overview) page for the full list.
+- Check the [Connectors](/connectors/overview) page for the full list.
 
 ### 4. Activity constructs
 
@@ -427,7 +427,7 @@ The tool maps TIBCO's built-in activities to their Ballerina equivalents:
 - **Shared Variables scope**: TIBCO Shared Variables are global and mutable. In Ballerina, use `configurable` variables (read from `Config.toml`) for static config, or a database/cache for runtime-mutable shared state.
 - **Checkpoint vs. transaction**: TIBCO Checkpoints define recovery points in a process. In Ballerina, use `transaction` blocks for rollback boundaries. True process-level checkpointing requires external state storage.
 - **Mapper Activity output format**: The TIBCO Mapper Activity works on XML data. The migration tool converts these to Ballerina record types, but review complex mappings (especially those with namespace-qualified XML) as they may need adjustments.
-- **Palette connectors**: Not all TIBCO Palette connectors have direct equivalents on Ballerina Central. Check the [Connectors](/docs/connectors/overview) page; for connectors without a match, use the generic `http:Client` or implement a custom Ballerina client.
+- **Palette connectors**: Not all TIBCO Palette connectors have direct equivalents on Ballerina Central. Check the [Connectors](/connectors/overview) page; for connectors without a match, use the generic `http:Client` or implement a custom Ballerina client.
 - **Sub-process calling conventions**: TIBCO sub-processes can be called synchronously or asynchronously. In Ballerina, use a regular function call for synchronous and `start` for fire-and-forget.
 
 ## Before/After examples

--- a/en/docs/guides/patterns/channel-adapter.md
+++ b/en/docs/guides/patterns/channel-adapter.md
@@ -22,9 +22,9 @@ A connector client adapts an external application API into the integration flow.
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Add the connector client connection for the application channel. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection); for this example, select the Jira connector as shown in [adding the Jira connector](/docs/connectors/catalog/productivity-collaboration/jira/example#adding-the-jira-connector).
-2. Configure the endpoint, authentication values, and other connection properties with project configurables. Use the connector-specific [Jira setup guide](/docs/connectors/catalog/productivity-collaboration/jira/setup-guide) and [Jira connection configuration steps](/docs/connectors/catalog/productivity-collaboration/jira/example#configuring-the-jira-connection).
-3. Add the connector operation that reads from or writes to the application channel. Use the [Jira action reference](/docs/connectors/catalog/productivity-collaboration/jira/actions#projects) to select the project operation for this example.
+1. Add the connector client connection for the application channel. See [adding a connection](/develop/integration-artifacts/supporting/connections#adding-a-connection); for this example, select the Jira connector as shown in [adding the Jira connector](/connectors/catalog/productivity-collaboration/jira/example#adding-the-jira-connector).
+2. Configure the endpoint, authentication values, and other connection properties with project configurables. Use the connector-specific [Jira setup guide](/connectors/catalog/productivity-collaboration/jira/setup-guide) and [Jira connection configuration steps](/connectors/catalog/productivity-collaboration/jira/example#configuring-the-jira-connection).
+3. Add the connector operation that reads from or writes to the application channel. Use the [Jira action reference](/connectors/catalog/productivity-collaboration/jira/actions#projects) to select the project operation for this example.
 4. Map the connector response to the message shape used by the rest of the flow.
 
 </TabItem>
@@ -61,14 +61,14 @@ public function readProject(string projectKey) returns jira:Project|error {
 
 ## HTTP service as inbound channel adapter
 
-An HTTP service adapts an inbound HTTP channel into an integration flow. Define the service resource as the adapter entry point, receive a typed request payload, and return the typed response expected by the caller. See [creating an HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service) for the service setup flow.
+An HTTP service adapts an inbound HTTP channel into an integration flow. Define the service resource as the adapter entry point, receive a typed request payload, and return the typed response expected by the caller. See [creating an HTTP service](/develop/integration-artifacts/service/http#creating-an-http-service) for the service setup flow.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create an HTTP service for the inbound channel. See [creating an HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service).
-2. Add the resource that represents the inbound adapter operation. Use [resource inputs](/docs/develop/integration-artifacts/service/http#defining-inputs) to define the request payload or parameters.
-3. Define the response payload type for the resource with [response schemas](/docs/develop/integration-artifacts/service/http#defining-response-schemas).
+1. Create an HTTP service for the inbound channel. See [creating an HTTP service](/develop/integration-artifacts/service/http#creating-an-http-service).
+2. Add the resource that represents the inbound adapter operation. Use [resource inputs](/develop/integration-artifacts/service/http#defining-inputs) to define the request payload or parameters.
+3. Define the response payload type for the resource with [response schemas](/develop/integration-artifacts/service/http#defining-response-schemas).
 4. Add the flow logic that transforms or forwards the received message.
 
 </TabItem>
@@ -104,14 +104,14 @@ service /projects on projectListener {
 
 ## Broker-backed channel adapter
 
-Use a broker listener when the channel is a messaging broker rather than an application API or HTTP endpoint. The service receives records from the broker, converts each record into the flow payload, and acknowledges or publishes through the connector according to the channel contract. Use the relevant broker guide, such as [Kafka consumers](/docs/develop/integration-artifacts/event/kafka#creating-a-kafka-listener), [RabbitMQ services](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service), or the [JMS listener](/docs/connectors/catalog/messaging/java.jms/triggers#listener).
+Use a broker listener when the channel is a messaging broker rather than an application API or HTTP endpoint. The service receives records from the broker, converts each record into the flow payload, and acknowledges or publishes through the connector according to the channel contract. Use the relevant broker guide, such as [Kafka consumers](/develop/integration-artifacts/event/kafka#creating-a-kafka-listener), [RabbitMQ services](/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service), or the [JMS listener](/connectors/catalog/messaging/java.jms/triggers#listener).
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create the broker listener for the channel. For Kafka, see [creating a Kafka consumer](/docs/develop/integration-artifacts/event/kafka#creating-a-kafka-listener); for RabbitMQ, see [creating a RabbitMQ service](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service); for JMS, see the [JMS listener](/docs/connectors/catalog/messaging/java.jms/triggers#listener).
-2. Configure the broker endpoint, topic or queue, and credentials with configurables. For Kafka, use [service configuration](/docs/develop/integration-artifacts/event/kafka#service-configuration); for RabbitMQ, use [listener configuration](/docs/develop/integration-artifacts/event/rabbitmq#listener-configuration).
-3. Add the message-handling function for the broker event. For Kafka, use [service configuration](/docs/develop/integration-artifacts/event/kafka#service-configuration); for RabbitMQ, use [event handlers](/docs/develop/integration-artifacts/event/rabbitmq#event-handlers).
+1. Create the broker listener for the channel. For Kafka, see [creating a Kafka consumer](/develop/integration-artifacts/event/kafka#creating-a-kafka-listener); for RabbitMQ, see [creating a RabbitMQ service](/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service); for JMS, see the [JMS listener](/connectors/catalog/messaging/java.jms/triggers#listener).
+2. Configure the broker endpoint, topic or queue, and credentials with configurables. For Kafka, use [service configuration](/develop/integration-artifacts/event/kafka#service-configuration); for RabbitMQ, use [listener configuration](/develop/integration-artifacts/event/rabbitmq#listener-configuration).
+3. Add the message-handling function for the broker event. For Kafka, use [service configuration](/develop/integration-artifacts/event/kafka#service-configuration); for RabbitMQ, use [event handlers](/develop/integration-artifacts/event/rabbitmq#event-handlers).
 4. Convert the broker record to the typed payload used inside the flow.
 
 </TabItem>

--- a/en/docs/guides/patterns/content-based-routing.md
+++ b/en/docs/guides/patterns/content-based-routing.md
@@ -17,15 +17,15 @@ The pattern is implemented at the decision point where the flow has enough messa
 
 ## Pattern-based content routing
 
-Use pattern-based content routing with [match expressions](/docs/develop/understand-ide/editors/flow-diagram-editor/control#match) when each recipient maps to a known field value, such as a message type, region, product category, or event name. Keep an explicit default branch so unsupported content is handled in a dedicated fallback path for invalid recipients.
+Use pattern-based content routing with [match expressions](/develop/understand-ide/editors/flow-diagram-editor/control#match) when each recipient maps to a known field value, such as a message type, region, product category, or event name. Keep an explicit default branch so unsupported content is handled in a dedicated fallback path for invalid recipients.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create or open the [HTTP service resource](/docs/develop/integration-artifacts/service/http#creating-an-http-service) that receives the routed message.
-2. Add HTTP client connections for each recipient. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
-3. Open the resource flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
-4. Add a [Match node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#match) and set the expression to the routing field, such as `order.itemType`.
+1. Create or open the [HTTP service resource](/develop/integration-artifacts/service/http#creating-an-http-service) that receives the routed message.
+2. Add HTTP client connections for each recipient. See [adding a connection](/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/connectors/catalog/built-in/http/action-reference#client).
+3. Open the resource flow and [add a step](/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+4. Add a [Match node](/develop/understand-ide/editors/flow-diagram-editor/control#match) and set the expression to the routing field, such as `order.itemType`.
 5. Add one branch for each accepted value, such as `"standard"` and `"express"`, and add `_` as the default branch.
 6. In each accepted branch, add the connector call for that recipient and return the route result.
 7. In the default branch, return an error response for unsupported content.
@@ -82,15 +82,15 @@ service /orders on new http:Listener(8080) {
 
 ## Predicate-based content routing
 
-Use predicate-based content routing with [if/else statements](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) when the route depends on content rules instead of one stable routing key.
+Use predicate-based content routing with [if/else statements](/develop/understand-ide/editors/flow-diagram-editor/control#if) when the route depends on content rules instead of one stable routing key.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create or open the resource or function that contains the routing decision.
-2. Add HTTP client connections for the possible recipients. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
-3. Add a [configurable variable](/docs/reference/config/configuration-management#configurable-variables) for any route rule that should change by environment, such as `bulkThreshold`.
-4. Open the flow and add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) with a condition such as `order.quantity >= bulkThreshold`.
+2. Add HTTP client connections for the possible recipients. See [adding a connection](/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/connectors/catalog/built-in/http/action-reference#client).
+3. Add a [configurable variable](/reference/config/configuration-management#configurable-variables) for any route rule that should change by environment, such as `bulkThreshold`.
+4. Open the flow and add an [If node](/develop/understand-ide/editors/flow-diagram-editor/control#if) with a condition such as `order.quantity >= bulkThreshold`.
 5. Add the bulk recipient call inside the **True** branch.
 6. In the **False** branch, add another **If** node with a condition such as `order.priority`.
 7. Add the priority recipient call inside the nested **True** branch and the default recipient call inside the nested **False** branch.

--- a/en/docs/guides/patterns/message-dispatcher.md
+++ b/en/docs/guides/patterns/message-dispatcher.md
@@ -17,14 +17,14 @@ The pattern is implemented at the point where the integration receives a message
 
 ## Stateful round-robin dispatch
 
-Use stateful round-robin dispatch when each incoming message should be sent to the next processor in a fixed set. Store the current processor index in the service, update it with a `lock`, and call the selected processor through an [HTTP client connection](/docs/connectors/catalog/built-in/http/action-reference#client). The `lock` keeps the index update consistent when multiple requests arrive at the same time. For constructs that do not have a full visual representation, switch to pro-code through the [Flow Diagram editor](/docs/develop/understand-ide/editors/flow-diagram-editor/#configuring-a-node).
+Use stateful round-robin dispatch when each incoming message should be sent to the next processor in a fixed set. Store the current processor index in the service, update it with a `lock`, and call the selected processor through an [HTTP client connection](/connectors/catalog/built-in/http/action-reference#client). The `lock` keeps the index update consistent when multiple requests arrive at the same time. For constructs that do not have a full visual representation, switch to pro-code through the [Flow Diagram editor](/develop/understand-ide/editors/flow-diagram-editor/#configuring-a-node).
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create an [HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service) for the dispatcher entry point.
-2. Add a `GET` resource, such as `/process`, and define a query parameter that carries the message reference, such as `resourceUrl`. See [resource inputs](/docs/develop/integration-artifacts/service/http#defining-inputs).
-3. Add the outbound processor [HTTP connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection). Configure its base URL with a [configurable variable](/docs/reference/config/configuration-management#configurable-variables).
+1. Create an [HTTP service](/develop/integration-artifacts/service/http#creating-an-http-service) for the dispatcher entry point.
+2. Add a `GET` resource, such as `/process`, and define a query parameter that carries the message reference, such as `resourceUrl`. See [resource inputs](/develop/integration-artifacts/service/http#defining-inputs).
+3. Add the outbound processor [HTTP connection](/develop/integration-artifacts/supporting/connections#adding-a-connection). Configure its base URL with a [configurable variable](/reference/config/configuration-management#configurable-variables).
 4. Add a service-level variable named `nextProcessor` with type `int` and default value `0`.
 5. In the resource flow, add the processor selection logic as a Ballerina code block: read `nextProcessor`, advance it inside a `lock`, and store the selected processor ID.
 6. Add the HTTP connector call that includes the selected processor ID in the request path and passes the message reference as a query parameter.

--- a/en/docs/guides/patterns/message-filter.md
+++ b/en/docs/guides/patterns/message-filter.md
@@ -19,13 +19,13 @@ The pattern is implemented by placing a filtering construct at the point where t
 
 ## Predicate-based filtering
 
-Use predicate-based filtering with [if/else statements](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) when each message carries the fields needed for a single boolean decision, such as priority, source, header, or status. The accepted path contains the forwarding or processing action. The rejected path does nothing or handles the rejection separately.
+Use predicate-based filtering with [if/else statements](/develop/understand-ide/editors/flow-diagram-editor/control#if) when each message carries the fields needed for a single boolean decision, such as priority, source, header, or status. The accepted path contains the forwarding or processing action. The rejected path does nothing or handles the rejection separately.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Open the flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
-2. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) at the point where the message has enough data for the decision.
+1. Open the flow and [add a step](/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+2. Add an [If node](/develop/understand-ide/editors/flow-diagram-editor/control#if) at the point where the message has enough data for the decision.
 3. Set the condition to `message.priority == HIGH_PRIORITY`.
 4. Add the accepted action inside the matching branch.
 5. Leave the other branch empty when unmatched messages should be discarded.
@@ -71,13 +71,13 @@ service /api/v1 on new http:Listener(8080) {
 
 ## Collection-level filtering
 
-Use collection-level filtering with [query expressions](/docs/reference/language/query-expressions) when the flow already has a group of messages or records and only a subset should continue. Keep the predicate in the `where` clause so the result is the accepted collection.
+Use collection-level filtering with [query expressions](/reference/language/query-expressions) when the flow already has a group of messages or records and only a subset should continue. Keep the predicate in the `where` clause so the result is the accepted collection.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Open the flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
-2. Add a [Map Data or Declare Variable step](/docs/reference/language/query-expressions).
+1. Open the flow and [add a step](/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+2. Add a [Map Data or Declare Variable step](/reference/language/query-expressions).
 3. Set the output type to the accepted collection type, such as `Message[]`.
 4. Enter a query expression with a `where` clause for the filter predicate.
 5. Use the resulting collection in the next processing or forwarding step.
@@ -117,12 +117,12 @@ function filterHighPriorityMessages(Message[] messages) returns Message[] {
 
 ## Boundary-level filtering
 
-Use boundary-level filtering when the input artifact can reject or route messages before custom flow logic runs. For HTTP-facing inputs, use a [request interceptor](/docs/connectors/catalog/built-in/http/trigger-reference#interceptors) when the decision can be made from request metadata before the resource executes. Other inputs can use their own handler, listener, or subscription selection points.
+Use boundary-level filtering when the input artifact can reject or route messages before custom flow logic runs. For HTTP-facing inputs, use a [request interceptor](/connectors/catalog/built-in/http/trigger-reference#interceptors) when the decision can be made from request metadata before the resource executes. Other inputs can use their own handler, listener, or subscription selection points.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Add the source artifact, such as an [HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service).
+1. Add the source artifact, such as an [HTTP service](/develop/integration-artifacts/service/http#creating-an-http-service).
 2. Add a request interceptor for the service boundary.
 3. Read the request metadata needed for the filter, such as a priority header.
 4. Return a response for messages that should stop at the boundary.
@@ -179,12 +179,12 @@ service /events on eventListener {
 
 ## Broker-side delivery filtering
 
-Use broker-side delivery filtering when RabbitMQ can reduce what reaches the flow before consumption. Route matching messages into a dedicated queue with a direct exchange and binding key, then configure the RabbitMQ trigger to consume only that queue. Use [RabbitMQ exchange bindings](/docs/connectors/catalog/messaging/rabbitmq/actions#exchange-management) to bind the accepted-message queue to the exchange with the accepted routing key.
+Use broker-side delivery filtering when RabbitMQ can reduce what reaches the flow before consumption. Route matching messages into a dedicated queue with a direct exchange and binding key, then configure the RabbitMQ trigger to consume only that queue. Use [RabbitMQ exchange bindings](/connectors/catalog/messaging/rabbitmq/actions#exchange-management) to bind the accepted-message queue to the exchange with the accepted routing key.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Add the [RabbitMQ event integration](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service).
+1. Add the [RabbitMQ event integration](/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service).
 2. Configure the RabbitMQ trigger connection with the broker host and port.
 3. Set **Queue Name** to the queue that receives accepted messages, such as `high-priority-orders`.
 4. Create the RabbitMQ broker resources with connector actions or broker administration: declare a direct exchange, declare the accepted-message queue, and bind the queue to the exchange with the accepted routing key.

--- a/en/docs/guides/patterns/message-mapper.md
+++ b/en/docs/guides/patterns/message-mapper.md
@@ -17,16 +17,16 @@ The pattern is implemented between the message boundary and the domain processin
 
 ## Record-to-record mapping
 
-Use record-to-record mapping when both the domain value and the channel payload can be represented as typed records. Create separate record types for the domain model and the message format, then keep the mapping in a [reusable data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/access-paths/reusable) or a dedicated mapper function. Use [mapping capabilities](/docs/develop/integration-artifacts/supporting/data-mapper/mapping-capabilities) for field connections, expressions, and custom transformation logic.
+Use record-to-record mapping when both the domain value and the channel payload can be represented as typed records. Create separate record types for the domain model and the message format, then keep the mapping in a [reusable data mapper](/develop/integration-artifacts/supporting/data-mapper/access-paths/reusable) or a dedicated mapper function. Use [mapping capabilities](/develop/integration-artifacts/supporting/data-mapper/mapping-capabilities) for field connections, expressions, and custom transformation logic.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Define separate record types for the domain value and the channel message. See [Types](/docs/develop/integration-artifacts/supporting/types).
-2. Create a [reusable data mapper](/docs/develop/integration-artifacts/supporting/data-mapper/access-paths/reusable) with the domain record as the input and the message record as the output.
+1. Define separate record types for the domain value and the channel message. See [Types](/develop/integration-artifacts/supporting/types).
+2. Create a [reusable data mapper](/develop/integration-artifacts/supporting/data-mapper/access-paths/reusable) with the domain record as the input and the message record as the output.
 3. Open the data mapper canvas and connect matching fields, such as `id` to `orderId`.
-4. Use the expression editor for transformed fields, such as combining names or calculating a total. See [Expression editor](/docs/develop/integration-artifacts/supporting/data-mapper/mapping-capabilities#expression-editor).
-5. Use [array mappings](/docs/develop/integration-artifacts/supporting/data-mapper/array-mappings/) when the mapper must convert item collections.
+4. Use the expression editor for transformed fields, such as combining names or calculating a total. See [Expression editor](/develop/integration-artifacts/supporting/data-mapper/mapping-capabilities#expression-editor).
+5. Use [array mappings](/develop/integration-artifacts/supporting/data-mapper/array-mappings/) when the mapper must convert item collections.
 6. Add a **Map Data** step in the flow and pass the mapped record to the next service, resource function, or connector call.
 
 </TabItem>
@@ -89,7 +89,7 @@ function toDomain(OrderMessage message) returns Order {
 
 ## Data-format boundary mapping
 
-Use data-format boundary mapping when the channel sends or receives raw JSON, XML, CSV, or another serialized format. Keep parsing and serialization at the boundary, then call the typed mapper so the main flow works with records instead of raw payloads. For JSON payloads, use [type-safe JSON conversion](/docs/develop/transform/json#convert-a-json-value-to-a-typed-record). For XML and CSV payloads, use the corresponding [XML processing](/docs/develop/transform/xml) or [CSV and flat file processing](/docs/develop/transform/csv-flat-file) guide.
+Use data-format boundary mapping when the channel sends or receives raw JSON, XML, CSV, or another serialized format. Keep parsing and serialization at the boundary, then call the typed mapper so the main flow works with records instead of raw payloads. For JSON payloads, use [type-safe JSON conversion](/develop/transform/json#convert-a-json-value-to-a-typed-record). For XML and CSV payloads, use the corresponding [XML processing](/develop/transform/xml) or [CSV and flat file processing](/develop/transform/csv-flat-file) guide.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>

--- a/en/docs/guides/patterns/message.md
+++ b/en/docs/guides/patterns/message.md
@@ -23,8 +23,8 @@ Use a typed message envelope when the integration needs a stable application-lev
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create a new integration in WSO2 Integrator.
-2. Add the header, body, and envelope records in [Types](/docs/develop/integration-artifacts/supporting/types).
-3. Open the flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+2. Add the header, body, and envelope records in [Types](/develop/integration-artifacts/supporting/types).
+3. Open the flow and [add a step](/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
 4. Add a **Declare Variable** or **Map Data** step to construct the envelope.
 5. Pass the envelope to the connector call, return it from the resource function, or map it into another boundary-specific message.
 
@@ -71,8 +71,8 @@ Use channel boundary binding when the message arrives through, or leaves through
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Add and configure the required connector under **Connections**. For brokered messages, select the relevant connector, such as the [NATS connector](/docs/connectors/catalog/messaging/nats/connector-overview), from the [messaging connector catalog](/docs/connectors/catalog/).
-2. Add the listener or entry point for the inbound channel. For HTTP, start by [creating an HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service).
+1. Add and configure the required connector under **Connections**. For brokered messages, select the relevant connector, such as the [NATS connector](/connectors/catalog/messaging/nats/connector-overview), from the [messaging connector catalog](/connectors/catalog/).
+2. Add the listener or entry point for the inbound channel. For HTTP, start by [creating an HTTP service](/develop/integration-artifacts/service/http#creating-an-http-service).
 3. Bind the request payload as the body and bind transport metadata, such as headers, as message headers.
 4. Add a **Map Data** step to create the typed message envelope from the inbound payload and metadata.
 5. Publish the envelope through the connector, forward it to another channel, or return it from the resource function.

--- a/en/docs/guides/patterns/polling-consumer.md
+++ b/en/docs/guides/patterns/polling-consumer.md
@@ -17,17 +17,17 @@ The pattern is implemented at the point where the flow controls the receive call
 
 ## Loop-driven polling
 
-Use loop-driven polling with [while loops](/docs/develop/understand-ide/editors/flow-diagram-editor/control#while) when the integration should keep checking a channel or endpoint while it controls the maximum attempts and wait interval. The receive or status-check call stays inside the loop, and the flow exits when it receives a message that is ready to process.
+Use loop-driven polling with [while loops](/develop/understand-ide/editors/flow-diagram-editor/control#while) when the integration should keep checking a channel or endpoint while it controls the maximum attempts and wait interval. The receive or status-check call stays inside the loop, and the flow exits when it receives a message that is ready to process.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create or open the [HTTP service resource](/docs/develop/integration-artifacts/service/http#creating-an-http-service) that starts the polling flow.
-2. Add an HTTP client connection for the source that the flow must poll. See [adding a connection](/docs/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/docs/connectors/catalog/built-in/http/action-reference#client).
-3. Add [configurable variables](/docs/reference/config/configuration-management#configurable-variables) for values such as `maxAttempts` and `pollDelaySeconds`.
-4. Add a [While node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#while) that runs while the attempt count is less than `maxAttempts`.
+1. Create or open the [HTTP service resource](/develop/integration-artifacts/service/http#creating-an-http-service) that starts the polling flow.
+2. Add an HTTP client connection for the source that the flow must poll. See [adding a connection](/develop/integration-artifacts/supporting/connections#adding-a-connection) and the [HTTP client reference](/connectors/catalog/built-in/http/action-reference#client).
+3. Add [configurable variables](/reference/config/configuration-management#configurable-variables) for values such as `maxAttempts` and `pollDelaySeconds`.
+4. Add a [While node](/develop/understand-ide/editors/flow-diagram-editor/control#while) that runs while the attempt count is less than `maxAttempts`.
 5. Inside the loop, add the HTTP client operation that asks for the current message or status.
-6. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) that returns the message when it is ready. Otherwise, wait for the configured delay and continue the loop.
+6. Add an [If node](/develop/understand-ide/editors/flow-diagram-editor/control#if) that returns the message when it is ready. Otherwise, wait for the configured delay and continue the loop.
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">
@@ -74,15 +74,15 @@ service /messages on new http:Listener(8080) {
 
 ## Scheduled broker polling
 
-Use scheduled broker polling when each automation run should pull at most one message from a broker and then stop. This keeps the schedule outside the receive logic while the flow still controls when it asks the broker for the next message. For JMS-backed channels, use the [JMS Message Consumer actions](/docs/connectors/catalog/messaging/java.jms/actions#message-consumer) with `receive` or `receiveNoWait`.
+Use scheduled broker polling when each automation run should pull at most one message from a broker and then stop. This keeps the schedule outside the receive logic while the flow still controls when it asks the broker for the next message. For JMS-backed channels, use the [JMS Message Consumer actions](/connectors/catalog/messaging/java.jms/actions#message-consumer) with `receive` or `receiveNoWait`.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create a [scheduled automation](/docs/develop/integration-artifacts/automation#creating-an-automation) for the polling interval.
-2. Add the `java.jms` **JMS MessageConsumer** connection and bind the broker settings to configurable variables. See the [JMS consumer example](/docs/connectors/catalog/messaging/java.jms/example#adding-the-javajms-connector).
+1. Create a [scheduled automation](/develop/integration-artifacts/automation#creating-an-automation) for the polling interval.
+2. Add the `java.jms` **JMS MessageConsumer** connection and bind the broker settings to configurable variables. See the [JMS consumer example](/connectors/catalog/messaging/java.jms/example#adding-the-javajms-connector).
 3. Add the **Receive** operation from the JMS consumer connection and set the timeout value for the polling window.
-4. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) that checks whether the received value is a message.
+4. Add an [If node](/develop/understand-ide/editors/flow-diagram-editor/control#if) that checks whether the received value is a message.
 5. Add the processing steps inside the branch that received a message.
 6. Acknowledge the message only after the processing steps finish successfully.
 

--- a/en/docs/guides/patterns/selective-consumer.md
+++ b/en/docs/guides/patterns/selective-consumer.md
@@ -17,13 +17,13 @@ The pattern is implemented at the consumer boundary or immediately inside the co
 
 ## Broker-side selection
 
-Use broker-side selection when the broker can evaluate the criteria before the message reaches the service. For JMS-backed channels, configure a [JMS listener service](/docs/connectors/catalog/messaging/java.jms/triggers#service) with `messageSelector` so the service receives only messages whose headers or properties match the selector expression.
+Use broker-side selection when the broker can evaluate the criteria before the message reaches the service. For JMS-backed channels, configure a [JMS listener service](/connectors/catalog/messaging/java.jms/triggers#service) with `messageSelector` so the service receives only messages whose headers or properties match the selector expression.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Create the JMS-backed event service with the [JMS listener](/docs/connectors/catalog/messaging/java.jms/triggers#listener).
-2. Configure the listener connection with the broker endpoint and credentials through [configurable variables](/docs/reference/config/configuration-management#configurable-variables).
+1. Create the JMS-backed event service with the [JMS listener](/connectors/catalog/messaging/java.jms/triggers#listener).
+2. Configure the listener connection with the broker endpoint and credentials through [configurable variables](/reference/config/configuration-management#configurable-variables).
 3. Set the service queue or topic in `@jms:ServiceConfig`.
 4. Set `messageSelector` to the selector expression, such as `eventType = 'OrderCreated' AND priority = 'high'`.
 5. Add processing steps in the `onMessage` flow. The broker delivers only messages that match the selector.
@@ -65,14 +65,14 @@ service "priority-order-consumer" on orderListener {
 
 ## Flow-level selection
 
-Use flow-level selection with [if/else statements](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) when the consumer must inspect the delivered payload, call another system, or apply rules that cannot be expressed as a broker selector. The service still reads from the shared channel, but the accepted branch contains the processing logic and the unmatched branch is ignored or handled separately.
+Use flow-level selection with [if/else statements](/develop/understand-ide/editors/flow-diagram-editor/control#if) when the consumer must inspect the delivered payload, call another system, or apply rules that cannot be expressed as a broker selector. The service still reads from the shared channel, but the accepted branch contains the processing logic and the unmatched branch is ignored or handled separately.
 
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
 1. Create or open the consumer service that receives messages from the shared channel.
-2. Open the message handler flow and [add a step](/docs/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
-3. Add an [If node](/docs/develop/understand-ide/editors/flow-diagram-editor/control#if) at the point where the flow has the payload fields needed for selection.
+2. Open the message handler flow and [add a step](/develop/understand-ide/editors/flow-diagram-editor/#anatomy-of-the-editor).
+3. Add an [If node](/develop/understand-ide/editors/flow-diagram-editor/control#if) at the point where the flow has the payload fields needed for selection.
 4. Set the condition to the consumer criteria, such as `order.priority == "high" && order.region == "west"`.
 5. Add the processing steps inside the **True** branch.
 6. Leave the **False** branch empty when unmatched messages should be ignored, or add separate handling for rejected messages.

--- a/en/docs/guides/patterns/service-activator.md
+++ b/en/docs/guides/patterns/service-activator.md
@@ -22,13 +22,13 @@ Use request-reply service activation when a message sender expects the activated
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Define the request and response records in [Types](/docs/develop/integration-artifacts/supporting/types).
-2. Add the reusable operation as a [Function](/docs/develop/integration-artifacts/supporting/functions) and select **Make visible across the project** when the function must be called from multiple artifacts.
-3. Create an [HTTP service](/docs/develop/integration-artifacts/service/http#creating-an-http-service) for non-messaging callers.
+1. Define the request and response records in [Types](/develop/integration-artifacts/supporting/types).
+2. Add the reusable operation as a [Function](/develop/integration-artifacts/supporting/functions) and select **Make visible across the project** when the function must be called from multiple artifacts.
+3. Create an [HTTP service](/develop/integration-artifacts/service/http#creating-an-http-service) for non-messaging callers.
 4. Add a resource function with the typed request payload and add a **Call Function** step that invokes the reusable operation.
-5. Add a [RabbitMQ event integration](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service) for message-based callers.
-6. Configure the RabbitMQ queue and listener values with [configurable variables](/docs/reference/config/configuration-management#configurable-variables).
-7. Add the `onRequest` handler from [RabbitMQ event handlers](/docs/develop/integration-artifacts/event/rabbitmq#event-handlers), define the expected message content, add a **Call Function** step, and return the function result.
+5. Add a [RabbitMQ event integration](/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service) for message-based callers.
+6. Configure the RabbitMQ queue and listener values with [configurable variables](/reference/config/configuration-management#configurable-variables).
+7. Add the `onRequest` handler from [RabbitMQ event handlers](/develop/integration-artifacts/event/rabbitmq#event-handlers), define the expected message content, add a **Call Function** step, and return the function result.
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">
@@ -91,11 +91,11 @@ Use one-way command activation when the message channel only needs to trigger th
 <PatternImplementationTabs>
 <TabItem value="ui" label="Visual Designer" default>
 
-1. Reuse the request and response records from [Types](/docs/develop/integration-artifacts/supporting/types).
-2. Reuse the same [Function](/docs/develop/integration-artifacts/supporting/functions) that contains the application operation.
-3. Add a [RabbitMQ event integration](/docs/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service) for the command queue.
-4. Configure the listener, queue, and authentication fields with [configurable variables](/docs/reference/config/configuration-management#configurable-variables).
-5. Add the `onMessage` handler from [RabbitMQ event handlers](/docs/develop/integration-artifacts/event/rabbitmq#event-handlers) and define the expected message content.
+1. Reuse the request and response records from [Types](/develop/integration-artifacts/supporting/types).
+2. Reuse the same [Function](/develop/integration-artifacts/supporting/functions) that contains the application operation.
+3. Add a [RabbitMQ event integration](/develop/integration-artifacts/event/rabbitmq#creating-a-rabbitmq-service) for the command queue.
+4. Configure the listener, queue, and authentication fields with [configurable variables](/reference/config/configuration-management#configurable-variables).
+5. Add the `onMessage` handler from [RabbitMQ event handlers](/develop/integration-artifacts/event/rabbitmq#event-handlers) and define the expected message content.
 6. In the handler flow, add a **Call Function** step for the shared operation and add any flow-level error handling required by the command contract.
 
 </TabItem>


### PR DESCRIPTION
### Purpose

Corrected internal links in guide markdown pages that used the outdated /docs/... prefix for this docs site routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed internal documentation links across migration guides and pattern guides to ensure proper navigation and reference consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->