### PR TITLE
Fix broken links in tools section

### DIFF
--- a/en/docs/develop/tools/integration-tools/asyncapi-tool.md
+++ b/en/docs/develop/tools/integration-tools/asyncapi-tool.md
@@ -233,4 +233,4 @@ bal asyncapi -i service.bal --mode export -o specs/asyncapi.yaml
 
 - [gRPC Tool](grpc-tool.md) -- Generate gRPC services from Protocol Buffer definitions
 - [OpenAPI Tool](openapi-tool.md) -- Generate REST services and clients
-- [Error Handling](/docs/develop/understand-ide/editors/flow-diagram-editor/error-handling) -- Handle event processing failures gracefully
+- [Error Handling](/develop/understand-ide/editors/flow-diagram-editor/error-handling) -- Handle event processing failures gracefully

--- a/en/docs/develop/tools/integration-tools/edi-tool.md
+++ b/en/docs/develop/tools/integration-tools/edi-tool.md
@@ -223,4 +223,4 @@ Generated packages can be published to Ballerina Central and reused across proje
 
 - [Health Tool](health-tool.md) — Generate healthcare integration code
 - [XSD Tool](xsd-tool.md) — Generate types from XML schemas
-- [Data transformation](/docs/develop/transform/edi) — Transform EDI data in Ballerina
+- [Data transformation](/develop/transform/edi) — Transform EDI data in Ballerina

--- a/en/docs/develop/tools/integration-tools/graphql-tool.md
+++ b/en/docs/develop/tools/integration-tools/graphql-tool.md
@@ -266,4 +266,4 @@ Client generation from GraphQL schemas is currently supported only through the B
 
 - [AsyncAPI Tool](asyncapi-tool.md) — Generate event-driven services from AsyncAPI specs
 - [OpenAPI Tool](openapi-tool.md) — Generate REST services and clients
-- [Flow Diagram Editor](/docs/develop/understand-ide/editors/flow-diagram-editor/) — Switch to pro-code to write advanced GraphQL resolver logic
+- [Flow Diagram Editor](/develop/understand-ide/editors/flow-diagram-editor/) — Switch to pro-code to write advanced GraphQL resolver logic

--- a/en/docs/develop/tools/integration-tools/grpc-tool.md
+++ b/en/docs/develop/tools/integration-tools/grpc-tool.md
@@ -360,4 +360,4 @@ bal grpc --input <proto-file> [options]
 
 - [OpenAPI Tool](openapi-tool.md) — Generate REST services and clients
 - [WSDL Tool](wsdl-tool.md) — Generate SOAP clients from WSDL files
-- [Error Handling](/docs/develop/understand-ide/editors/flow-diagram-editor/error-handling) — Handle gRPC errors and deadlines
+- [Error Handling](/develop/understand-ide/editors/flow-diagram-editor/error-handling) — Handle gRPC errors and deadlines

--- a/en/docs/develop/tools/integration-tools/health-tool.md
+++ b/en/docs/develop/tools/integration-tools/health-tool.md
@@ -330,4 +330,4 @@ bal health fhir -m <mode> [options]
 
 - [EDI Tool](edi-tool.md) — Generate B2B data exchange code
 - [OpenAPI Tool](openapi-tool.md) — Expose healthcare services as REST APIs
-- [Configuration management](/docs/reference/config/configuration-management) — Manage healthcare endpoint configuration
+- [Configuration management](/reference/config/configuration-management) — Manage healthcare endpoint configuration

--- a/en/docs/develop/tools/integration-tools/openapi-tool.md
+++ b/en/docs/develop/tools/integration-tools/openapi-tool.md
@@ -331,4 +331,4 @@ Once your service is built, export its OpenAPI specification and share it with c
 
 - [GraphQL Tool](graphql-tool.md) — Generate GraphQL services from SDL schemas
 - [gRPC Tool](grpc-tool.md) — Generate gRPC services from Protocol Buffer definitions
-- [Flow Diagram editor](/docs/develop/understand-ide/editors/flow-diagram-editor/) — Build logic visually on top of generated stubs
+- [Flow Diagram editor](/develop/understand-ide/editors/flow-diagram-editor/) — Build logic visually on top of generated stubs

--- a/en/docs/develop/tools/integration-tools/persist-tool.md
+++ b/en/docs/develop/tools/integration-tools/persist-tool.md
@@ -279,5 +279,5 @@ bal persist push --datastore <datastore> --module <module>
 ## What's next
 
 - [Scan Tool](../other/scan-tool.md) — Analyze Ballerina code for security and quality issues
-- [Configuration management](/docs/reference/config/configuration-management) — Manage data store credentials with configurable variables
-- [Connector catalog](/docs/connectors/catalog/) — Browse database connectors and other connectivity options
+- [Configuration management](/reference/config/configuration-management) — Manage data store credentials with configurable variables
+- [Connector catalog](/connectors/catalog/) — Browse database connectors and other connectivity options

--- a/en/docs/develop/tools/integration-tools/wsdl-tool.md
+++ b/en/docs/develop/tools/integration-tools/wsdl-tool.md
@@ -274,4 +274,4 @@ bal wsdl -i service.wsdl --soap-version 1.2
 
 - [XSD Tool](xsd-tool.md) -- Generate record types from XML Schema definitions
 - [OpenAPI Tool](openapi-tool.md) -- Generate REST services and clients
-- [Configuration Management](/docs/reference/config/configuration-management) -- Manage SOAP endpoint configuration per environment
+- [Configuration Management](/reference/config/configuration-management) -- Manage SOAP endpoint configuration per environment

--- a/en/docs/develop/tools/integration-tools/xsd-tool.md
+++ b/en/docs/develop/tools/integration-tools/xsd-tool.md
@@ -215,4 +215,4 @@ The tool maps XSD types to Ballerina types as follows:
 
 - [WSDL Tool](wsdl-tool.md) -- Generate SOAP clients that use these XML types
 - [OpenAPI Tool](openapi-tool.md) -- Generate REST services and clients
-- [Data Transformation](/docs/develop/transform/xml) -- Transform XML data with Ballerina
+- [Data Transformation](/develop/transform/xml) -- Transform XML data with Ballerina


### PR DESCRIPTION
## Purpose

$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference links across integration tools documentation (AsyncAPI, EDI, GraphQL, gRPC, Health, OpenAPI, Persist, WSDL, and XSD tools) to use consistent URL paths in "What's next" sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->