### PR TITLE
Fix the redirection issue in the connector catelog

### DIFF
--- a/en/src/components/ConnectorCatalog/index.tsx
+++ b/en/src/components/ConnectorCatalog/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
 
 interface Connector {
@@ -110,7 +111,7 @@ export default function ConnectorCatalog({ connectors, categories }: Props) {
       {resultCount > 0 ? (
         <div className={styles.grid}>
           {filtered.map((c) => (
-            <a key={c.name + c.link} href={c.link} className={styles.card}>
+            <Link key={c.name + c.link} to={c.link.endsWith('/') ? c.link : `${c.link}/`} className={styles.card}>
               <div className={styles.cardHeader}>
                 {c.icon ? (
                   <img
@@ -128,7 +129,7 @@ export default function ConnectorCatalog({ connectors, categories }: Props) {
               </div>
               <p className={styles.cardDesc}>{c.description}</p>
               <span className={styles.cardLink}>Learn more →</span>
-            </a>
+            </Link>
           ))}
         </div>
       ) : (

--- a/en/src/components/ConnectorCatalog/index.tsx
+++ b/en/src/components/ConnectorCatalog/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
 
 interface Connector {
@@ -111,7 +110,7 @@ export default function ConnectorCatalog({ connectors, categories }: Props) {
       {resultCount > 0 ? (
         <div className={styles.grid}>
           {filtered.map((c) => (
-            <Link key={c.name + c.link} to={c.link.endsWith('/') ? c.link : `${c.link}/`} className={styles.card}>
+            <a key={c.name + c.link} href={c.link.endsWith('/') ? c.link : `${c.link}/`} className={styles.card}>
               <div className={styles.cardHeader}>
                 {c.icon ? (
                   <img
@@ -129,7 +128,7 @@ export default function ConnectorCatalog({ connectors, categories }: Props) {
               </div>
               <p className={styles.cardDesc}>{c.description}</p>
               <span className={styles.cardLink}>Learn more →</span>
-            </Link>
+            </a>
           ))}
         </div>
       ) : (


### PR DESCRIPTION
  Summary

  - Added trailing slash to connector card links in the catalog to prevent redirect loops caused by Docusaurus's canonical URL enforcement.

  Test plan

  - Click connector cards in the catalog and confirm they navigate directly without a redirect.
  - Run npm run build in en/ and confirm no broken-link errors.