### PR TITLE
Fix broken links in connector catalog

### DIFF
--- a/en/src/components/ConnectorCatalog/index.tsx
+++ b/en/src/components/ConnectorCatalog/index.tsx
@@ -110,7 +110,7 @@ export default function ConnectorCatalog({ connectors, categories }: Props) {
       {resultCount > 0 ? (
         <div className={styles.grid}>
           {filtered.map((c) => (
-            <a key={c.name + c.link} href={c.link.endsWith('/') ? c.link : `${c.link}/`} className={styles.card}>
+            <a key={c.name + c.link} href={`catalog/${c.link.endsWith('/') ? c.link : `${c.link}/`}`} className={styles.card}>
               <div className={styles.cardHeader}>
                 {c.icon ? (
                   <img


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated connector card links to use a standardized URL format with `catalog/` prefix and consistent trailing slashes for improved navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->