### PR TITLE
Add deploy to wso2 cloud button for quick start guides

### DIFF
--- a/en/docs/get-started/build-ai-agent.md
+++ b/en/docs/get-started/build-ai-agent.md
@@ -144,6 +144,18 @@ Type `Hello` to check if it works.
 </TabItem>
 </Tabs>
 
+## Step 5: Deploy to WSO2 Cloud
+
+Deploy your integration to WSO2 Cloud - Integration Platform in any of the following ways:
+
+- If you're using the cloud editor, see [Save and deploy](/deploy/cloud/deploy-from-cloud-editor/#save-and-deploy).
+- If you're using the WSO2 Integrator IDE, see [Deploy from the IDE](/deploy/cloud/push-from-ide).
+- If you'd rather skip the build and try a ready-made sample, one-click deploy it:
+
+    <a href="https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/quickstart/aiagent" target="_blank">
+        <img src="https://openindevant.choreoapps.dev/images/DeployDevant.svg" alt="Deploy to WSO2 Cloud" />
+    </a>
+
 ## What's next
 
 - [Build an automation](build-automation.md) — Build a scheduled job

--- a/en/docs/get-started/build-automation.md
+++ b/en/docs/get-started/build-automation.md
@@ -116,15 +116,6 @@ Save this as `automation.bal`, then click the **Run** button in the top toolbar.
 </TabItem>
 </Tabs>
 
-## Scheduling automations
-
-Periodic invocation is configured in an external system once the automation is deployed. Available options include:
-
-- **Cron job**: schedule the automation from a `cron` entry on a Unix or Linux host.
-- **Kubernetes**: define a `CronJob` resource to run the automation on a recurring schedule.
-- **VM**: use a host scheduler such as Windows Task Scheduler or `systemd` timers.
-- **WSO2 Integration Platform**: configure the schedule in the WSO2 Integration Platform when the integration is pushed to the cloud.
-
 ## Step 5: Deploy to WSO2 Cloud
 
 Deploy your integration to WSO2 Cloud - Integration Platform in any of the following ways:
@@ -136,6 +127,15 @@ Deploy your integration to WSO2 Cloud - Integration Platform in any of the follo
     <a href="https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/quickstart/automation" target="_blank">
         <img src="https://openindevant.choreoapps.dev/images/DeployDevant.svg" alt="Deploy to WSO2 Cloud" />
     </a>
+
+## Scheduling automations
+
+Periodic invocation is configured in an external system once the automation is deployed. Available options include:
+
+- **Cron job**: schedule the automation from a `cron` entry on a Unix or Linux host.
+- **Kubernetes**: define a `CronJob` resource to run the automation on a recurring schedule.
+- **VM**: use a host scheduler such as Windows Task Scheduler or `systemd` timers.
+- **WSO2 Integration Platform**: configure the schedule in the WSO2 Integration Platform when the integration is pushed to the cloud.
 
 ## What's next
 

--- a/en/docs/get-started/build-automation.md
+++ b/en/docs/get-started/build-automation.md
@@ -125,6 +125,18 @@ Periodic invocation is configured in an external system once the automation is d
 - **VM**: use a host scheduler such as Windows Task Scheduler or `systemd` timers.
 - **WSO2 Integration Platform**: configure the schedule in the WSO2 Integration Platform when the integration is pushed to the cloud.
 
+## Step 5: Deploy to WSO2 Cloud
+
+Deploy your integration to WSO2 Cloud - Integration Platform in any of the following ways:
+
+- If you're using the cloud editor, see [Save and deploy](/deploy/cloud/deploy-from-cloud-editor/#save-and-deploy).
+- If you're using the WSO2 Integrator IDE, see [Deploy from the IDE](/deploy/cloud/push-from-ide).
+- If you'd rather skip the build and try a ready-made sample, one-click deploy it:
+
+    <a href="https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/quickstart/automation" target="_blank">
+        <img src="https://openindevant.choreoapps.dev/images/DeployDevant.svg" alt="Deploy to WSO2 Cloud" />
+    </a>
+
 ## What's next
 
 - [Build an Integration as API](build-integration-api.md) — Build an HTTP service

--- a/en/docs/get-started/build-event-driven-integration.md
+++ b/en/docs/get-started/build-event-driven-integration.md
@@ -139,18 +139,7 @@ Save this as `main.bal`, then click the **Run** button in the top toolbar. Once 
 </TabItem>
 </Tabs>
 
-## Supported event sources
-
-| Broker | Ballerina Package |
-|---|---|
-| **Apache Kafka** | `ballerinax/kafka` |
-| **RabbitMQ** | `ballerinax/rabbitmq` |
-| **MQTT** | `ballerinax/mqtt` |
-| **Azure Service Bus** | `ballerinax/azure.servicebus` |
-| **Salesforce** | `ballerinax/salesforce` |
-| **GitHub Webhooks** | `ballerinax/github` |
-
-## Step 5: Deploy to WSO2 Cloud
+## Step 6: Deploy to WSO2 Cloud
 
 Deploy your integration to WSO2 Cloud - Integration Platform in any of the following ways:
 
@@ -161,6 +150,17 @@ Deploy your integration to WSO2 Cloud - Integration Platform in any of the follo
     <a href="https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/quickstart/orderprocessor" target="_blank">
         <img src="https://openindevant.choreoapps.dev/images/DeployDevant.svg" alt="Deploy to WSO2 Cloud" />
     </a>
+
+## Supported event sources
+
+| Broker | Ballerina Package |
+|---|---|
+| **Apache Kafka** | `ballerinax/kafka` |
+| **RabbitMQ** | `ballerinax/rabbitmq` |
+| **MQTT** | `ballerinax/mqtt` |
+| **Azure Service Bus** | `ballerinax/azure.servicebus` |
+| **Salesforce** | `ballerinax/salesforce` |
+| **GitHub Webhooks** | `ballerinax/github` |
 
 ## What's next
 

--- a/en/docs/get-started/build-event-driven-integration.md
+++ b/en/docs/get-started/build-event-driven-integration.md
@@ -150,6 +150,18 @@ Save this as `main.bal`, then click the **Run** button in the top toolbar. Once 
 | **Salesforce** | `ballerinax/salesforce` |
 | **GitHub Webhooks** | `ballerinax/github` |
 
+## Step 5: Deploy to WSO2 Cloud
+
+Deploy your integration to WSO2 Cloud - Integration Platform in any of the following ways:
+
+- If you're using the cloud editor, see [Save and deploy](/deploy/cloud/deploy-from-cloud-editor/#save-and-deploy).
+- If you're using the WSO2 Integrator IDE, see [Deploy from the IDE](/deploy/cloud/push-from-ide).
+- If you'd rather skip the build and try a ready-made sample, one-click deploy it:
+
+    <a href="https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/quickstart/orderprocessor" target="_blank">
+        <img src="https://openindevant.choreoapps.dev/images/DeployDevant.svg" alt="Deploy to WSO2 Cloud" />
+    </a>
+
 ## What's next
 
 - [Kafka](../develop/integration-artifacts/event/kafka.md) — Consume and produce Kafka messages

--- a/en/docs/get-started/build-integration-api.md
+++ b/en/docs/get-started/build-integration-api.md
@@ -178,7 +178,7 @@ Confirm the response shows `200 OK` with a `Hello World` body.
 </TabItem>
 </Tabs>
 
-## Step 5: Deploy to WSO2 Cloud
+## Step 8: Deploy to WSO2 Cloud
 
 Deploy your integration to WSO2 Cloud - Integration Platform in any of the following ways:
 

--- a/en/docs/get-started/build-integration-api.md
+++ b/en/docs/get-started/build-integration-api.md
@@ -178,6 +178,18 @@ Confirm the response shows `200 OK` with a `Hello World` body.
 </TabItem>
 </Tabs>
 
+## Step 5: Deploy to WSO2 Cloud
+
+Deploy your integration to WSO2 Cloud - Integration Platform in any of the following ways:
+
+- If you're using the cloud editor, see [Save and deploy](/deploy/cloud/deploy-from-cloud-editor/#save-and-deploy).
+- If you're using the WSO2 Integrator IDE, see [Deploy from the IDE](/deploy/cloud/push-from-ide).
+- If you'd rather skip the build and try a ready-made sample, one-click deploy it:
+
+    <a href="https://console.devant.dev/new?gh=wso2/integration-samples/tree/main/integrator-default-profile/quickstart/helloworldapi" target="_blank">
+        <img src="https://openindevant.choreoapps.dev/images/DeployDevant.svg" alt="Deploy to WSO2 Cloud" />
+    </a>
+
 ## What's next
 
 - [Build an automation](build-automation.md) — Build a scheduled job


### PR DESCRIPTION
$subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WSO2 Cloud deployment instructions to quick-start guides for AI Agent, Automation, Event-Driven Integration, and Integration API, including deployment via cloud editor, IDE, and one-click deployment options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->