### PR TITLE
Simplify CI/CD samples: remove Docker and Kubernetes sections

### DIFF
--- a/en/docs/deploy-operate/cicd/azure-devops.md
+++ b/en/docs/deploy-operate/cicd/azure-devops.md
@@ -5,21 +5,16 @@ description: CI/CD pipeline with Azure DevOps for WSO2 Integrator.
 
 # Azure DevOps
 
-Automate build, test, and deployment of your WSO2 Integrator projects using Azure DevOps Pipelines.
+Automate build and test of your WSO2 Integrator projects using Azure DevOps Pipelines.
 
 ## Overview
 
-Azure DevOps Pipelines provides a fully managed CI/CD service that integrates with Git repositories. For WSO2 Integrator projects built on Ballerina, a typical pipeline includes building the Ballerina package, running tests, creating a Docker image, and deploying to a target environment such as Azure Kubernetes Service (AKS) or Azure Container Apps.
+Azure DevOps Pipelines provides a fully managed CI/CD service that integrates with Git repositories. For WSO2 Integrator projects built on Ballerina, a pipeline runs tests and builds the package using the official `ballerina/ballerina` Docker image — no installation steps required.
 
 ## Prerequisites
 
-Before configuring the pipeline, ensure the following are in place:
-
 - An Azure DevOps organization and project
 - A Git repository containing your WSO2 Integrator (Ballerina) project
-- An Azure Container Registry (ACR) for storing Docker images
-- A target deployment environment (AKS cluster, Container Apps, or VM)
-- A service connection configured in Azure DevOps for your Azure subscription
 
 ## Pipeline configuration
 
@@ -31,171 +26,39 @@ trigger:
   branches:
     include:
       - main
-      - release/*
 
-variables:
-  acrName: "myregistry.azurecr.io"
-  imageName: "wso2-integrator-app"
-  imageTag: "$(Build.BuildId)"
+pool:
+  vmImage: "ubuntu-latest"
 
-stages:
-  - stage: Build
-    displayName: "Build & Test"
-    jobs:
-      - job: BuildJob
-        pool:
-          vmImage: "ubuntu-latest"
-        container: ballerina/ballerina:latest
-        steps:
-          - script: bal build
-            displayName: "Build Ballerina project"
-
-          - script: bal test
-            displayName: "Run tests"
-
-          - task: PublishTestResults@2
-            inputs:
-              testResultsFormat: "JUnit"
-              testResultsFiles: "**/target/report/**/TEST-*.xml"
-            condition: always()
-            displayName: "Publish test results"
-
-  - stage: Docker
-    displayName: "Build & Push Docker Image"
-    dependsOn: Build
-    jobs:
-      - job: DockerJob
-        pool:
-          vmImage: "ubuntu-latest"
-        container: ballerina/ballerina:latest
-        steps:
-          - script: bal build
-            displayName: "Build Ballerina project"
-
-          - task: Docker@2
-            inputs:
-              containerRegistry: "AzureContainerRegistryConnection"
-              repository: "$(imageName)"
-              command: "buildAndPush"
-              Dockerfile: "target/docker/$(imageName)/Dockerfile"
-              tags: |
-                $(imageTag)
-                latest
-            displayName: "Build and push Docker image"
-
-  - stage: Deploy
-    displayName: "Deploy to AKS"
-    dependsOn: Docker
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-    jobs:
-      - deployment: DeployToAKS
-        environment: "production"
-        pool:
-          vmImage: "ubuntu-latest"
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - task: KubernetesManifest@0
-                  inputs:
-                    action: "deploy"
-                    kubernetesServiceConnection: "AKSConnection"
-                    namespace: "integrations"
-                    manifests: |
-                      k8s/deployment.yaml
-                      k8s/service.yaml
-                    containers: |
-                      $(acrName)/$(imageName):$(imageTag)
-                  displayName: "Deploy to AKS"
-```
-
-## Build step details
-
-The build stage runs inside the `ballerina/ballerina:latest` container, which provides Ballerina and the required JDK with no installation steps. The `bal build` command resolves dependencies from Ballerina Central, compiles the code, and produces artifacts in the `target/` directory.
-
-If your project uses a `Cloud.toml` file for Docker or Kubernetes artifact generation, `bal build` also generates the corresponding Dockerfile and Kubernetes manifests automatically.
-
-```yaml
 container: ballerina/ballerina:latest
+
 steps:
+  - script: bal test
+    displayName: "Run tests"
+
   - script: bal build
     displayName: "Build Ballerina project"
 ```
 
 ## Test step details
 
-Running `bal test` executes all test functions in your project. The job runs inside the same `ballerina/ballerina:latest` container so no additional setup is needed.
+The pipeline runs inside the `ballerina/ballerina:latest` container, which provides Ballerina and the required JDK with no installation steps.
 
 ```yaml
-- script: bal test
-  displayName: "Run tests"
+container: ballerina/ballerina:latest
+
+steps:
+  - script: bal test
+    displayName: "Run tests"
 ```
 
-Test results are written in JUnit XML format under `target/report/`, which the `PublishTestResults` task picks up automatically.
+## Build step details
 
-## Deploy step details
-
-The deployment stage uses Kubernetes manifests stored in your repository. A minimal deployment manifest for your integration service:
+The build step compiles the Ballerina project and produces artifacts in the `target/` directory.
 
 ```yaml
-# k8s/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: wso2-integrator-app
-  namespace: integrations
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: wso2-integrator-app
-  template:
-    metadata:
-      labels:
-        app: wso2-integrator-app
-    spec:
-      containers:
-        - name: app
-          image: myregistry.azurecr.io/wso2-integrator-app:latest
-          ports:
-            - containerPort: 9090
-          env:
-            - name: BAL_CONFIG_FILES
-              value: "/config/Config.toml"
-          volumeMounts:
-            - name: config
-              mountPath: /config
-      volumes:
-        - name: config
-          configMap:
-            name: integrator-config
-```
-
-## Secrets management
-
-Store sensitive values such as registry credentials, database passwords, and API keys as Azure DevOps pipeline variables or variable groups. Mark variables as secret to prevent them from appearing in logs.
-
-```yaml
-variables:
-  - group: "integrator-secrets"
-  - name: dbPassword
-    value: $(DB_PASSWORD)
-```
-
-Reference these in your `Config.toml` via environment variable overrides at runtime:
-
-```toml
-[myModule]
-dbPassword = "${DB_PASSWORD}"
-```
-
-In the pipeline, pass secrets as environment variables to the container:
-
-```yaml
-- script: bal test
-  env:
-    DB_PASSWORD: $(dbPassword)
-  displayName: "Run tests with secrets"
+- script: bal build
+  displayName: "Build Ballerina project"
 ```
 
 ## What's next

--- a/en/docs/deploy-operate/cicd/azure-devops.md
+++ b/en/docs/deploy-operate/cicd/azure-devops.md
@@ -9,7 +9,7 @@ Automate build and test of your WSO2 Integrator projects using Azure DevOps Pipe
 
 ## Overview
 
-Azure DevOps Pipelines provides a fully managed CI/CD service that integrates with Git repositories. For WSO2 Integrator projects built on Ballerina, a pipeline runs tests and builds the package using the official `ballerina/ballerina` Docker image — no installation steps required.
+Azure DevOps Pipelines provides a fully managed CI/CD service that integrates with Git repositories. For WSO2 Integrator projects built on Ballerina, a pipeline runs tests and builds the package using the official `ballerina/ballerina` Docker image with no manual installation steps required.
 
 ## Prerequisites
 

--- a/en/docs/deploy-operate/cicd/github-actions.md
+++ b/en/docs/deploy-operate/cicd/github-actions.md
@@ -5,36 +5,30 @@ description: CI/CD pipeline with GitHub Actions for WSO2 Integrator.
 
 # GitHub Actions
 
-Automate build, test, and deployment of your WSO2 Integrator projects using GitHub Actions workflows.
+Automate build and test of your WSO2 Integrator projects using GitHub Actions workflows.
 
 ## Overview
 
-GitHub Actions uses YAML workflow files stored in `.github/workflows/` to define CI/CD pipelines. For WSO2 Integrator projects, a workflow uses the [`setup-ballerina`](https://github.com/ballerina-platform/setup-ballerina/) action to install Ballerina, then builds the project, runs tests, creates a Docker image, and deploys to a target environment.
+GitHub Actions uses YAML workflow files stored in `.github/workflows/` to define CI/CD pipelines. For WSO2 Integrator projects, a workflow uses the [`setup-ballerina`](https://github.com/ballerina-platform/setup-ballerina/) action to install Ballerina, then runs tests and builds the project.
 
 ## Prerequisites
 
 - A GitHub repository containing your WSO2 Integrator (Ballerina) project
-- A container registry (GitHub Container Registry, Docker Hub, or a cloud provider registry)
-- Deployment target configured (Kubernetes, cloud service, or WSO2 Devant)
-- Repository secrets configured under **Settings > Secrets and variables > Actions**
+- GitHub Actions enabled on the repository
 
 ## Workflow configuration
 
-Create `.github/workflows/deploy.yml` in your repository:
+Create `.github/workflows/ci.yml` in your repository:
 
 ```yaml
-# .github/workflows/deploy.yml
-name: Build and Deploy
+# .github/workflows/ci.yml
+name: CI
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/wso2-integrator-app
 
 jobs:
   build-and-test:
@@ -49,88 +43,16 @@ jobs:
         with:
           version: "2201.13.4"
 
-      - name: Build
-        run: bal build
-
-      - name: Run tests
+      - name: Test
         run: bal test
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts
-          path: target/bin/*.jar
-
-  docker:
-    name: Build & Push Docker Image
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.4
-        with:
-          version: "2201.13.4"
-
-      - name: Build project
+      - name: Build
         run: bal build
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: target/docker/wso2-integrator-app/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-
-  deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    needs: docker
-    environment: production
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v3
-
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > $HOME/.kube/config
-
-      - name: Deploy
-        run: |
-          kubectl set image deployment/wso2-integrator-app \
-            app=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-          kubectl rollout status deployment/wso2-integrator-app --timeout=300s
 ```
-
-## Build step details
-
-The build job uses the [`setup-ballerina`](https://github.com/ballerina-platform/setup-ballerina/) action to install the specified Ballerina version (including the required JDK), then runs `bal build` to compile the project. Build artifacts (the executable JAR) are uploaded for downstream jobs and for manual download.
-
-If your project includes a `Cloud.toml`, the build also generates Docker and Kubernetes artifacts under `target/docker/` and `target/kubernetes/`.
 
 ## Test step details
 
-Tests run against the compiled project. The `setup-ballerina` action ensures the correct Ballerina version is available without manual installation steps.
+The [`setup-ballerina`](https://github.com/ballerina-platform/setup-ballerina/) action installs the specified Ballerina version (including the required JDK) with no manual installation steps.
 
 ```yaml
 - name: Set up Ballerina
@@ -138,83 +60,17 @@ Tests run against the compiled project. The `setup-ballerina` action ensures the
   with:
     version: "2201.13.4"
 
-- name: Run tests
+- name: Test
   run: bal test
 ```
 
-To display test results directly in pull request checks, add a test reporting action:
+## Build step details
+
+The build step compiles the Ballerina project and produces artifacts in the `target/` directory.
 
 ```yaml
-- name: Publish test report
-  if: always()
-  uses: dorny/test-reporter@v1
-  with:
-    name: Ballerina Tests
-    path: target/report/**/TEST-*.xml
-    reporter: java-junit
-```
-
-## Deploy step details
-
-The deploy job runs after a successful Docker push and uses `kubectl` to roll out the new image. Configure the `production` environment under **Settings > Environments** to add optional approval gates before the deploy runs.
-
-## Secrets management
-
-Configure repository and environment secrets under **Settings > Secrets and variables > Actions**:
-
-| Secret | Scope | Description |
-|---|---|---|
-| `GITHUB_TOKEN` | Repository (automatic) | Used for GHCR authentication |
-| `KUBE_CONFIG` | Environment | Base64-encoded kubeconfig file |
-| `DB_PASSWORD` | Environment | Database connection password |
-| `API_KEY` | Environment | External service API key |
-
-## Pull request workflow
-
-For pull requests, only the build and test jobs run. Docker build and deployment stages are skipped due to the `if` condition:
-
-```yaml
-if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-```
-
-This provides fast feedback on code changes without triggering deployments.
-
-## Reusable workflow
-
-For organizations managing multiple Ballerina projects, extract the common pipeline into a reusable workflow:
-
-```yaml
-# .github/workflows/ballerina-ci.yml
-name: Ballerina CI (Reusable)
-
-on:
-  workflow_call:
-    inputs:
-      bal-version:
-        required: false
-        type: string
-        default: "2201.13.4"
-
-jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ballerina-platform/setup-ballerina@v1.1.4
-        with:
-          version: ${{ inputs.bal-version }}
-      - run: bal build
-      - run: bal test
-```
-
-Call it from other repositories:
-
-```yaml
-jobs:
-  ci:
-    uses: my-org/.github/.github/workflows/ballerina-ci.yml@main
-    with:
-      bal-version: "2201.13.4"
+- name: Build
+  run: bal build
 ```
 
 ## What's next

--- a/en/docs/deploy-operate/cicd/jenkins.md
+++ b/en/docs/deploy-operate/cicd/jenkins.md
@@ -5,23 +5,18 @@ description: CI/CD pipeline with Jenkins for WSO2 Integrator.
 
 # Jenkins
 
-Automate build, test, and deployment of your WSO2 Integrator projects using Jenkins declarative pipelines.
+Automate build and test of your WSO2 Integrator projects using Jenkins declarative pipelines.
 
 ## Overview
 
-Jenkins provides a flexible CI/CD platform that can be self-hosted or run in the cloud. For WSO2 Integrator projects, a Jenkins pipeline compiles the Ballerina project, runs tests, builds a Docker image, and deploys to your target infrastructure. This guide uses a declarative `Jenkinsfile` checked into your repository.
+Jenkins provides a flexible CI/CD platform that can be self-hosted or run in the cloud. For WSO2 Integrator projects, a Jenkins pipeline runs tests and builds the Ballerina project using the official `ballerina/ballerina` Docker image as the build agent.
 
 ## Prerequisites
 
 - Jenkins server (version 2.387 or later) with the following plugins installed:
   - Pipeline plugin
   - Docker Pipeline plugin
-  - Kubernetes CLI plugin (for K8s deployments)
-  - JUnit plugin (for test result visualization)
-- Java 17 installed on build agents
-- Ballerina distribution installed on build agents (or installed during the pipeline)
-- A container registry accessible from the Jenkins server
-- Credentials configured in Jenkins for the registry and deployment target
+- Docker available on the Jenkins build agents
 
 ## Pipeline configuration
 
@@ -30,31 +25,16 @@ Create a `Jenkinsfile` at the root of your repository:
 ```groovy
 // Jenkinsfile
 pipeline {
-    agent any
-
-    environment {
-        BAL_VERSION     = '2201.10.0'
-        DOCKER_REGISTRY = 'registry.example.com'
-        IMAGE_NAME      = 'wso2-integrator-app'
-        IMAGE_TAG       = "${env.BUILD_NUMBER}"
-        DOCKER_CREDS    = credentials('docker-registry-creds')
-        KUBECONFIG      = credentials('kubeconfig-production')
-    }
-
-    tools {
-        jdk 'JDK17'
+    agent {
+        docker {
+            image 'ballerina/ballerina:latest'
+        }
     }
 
     stages {
-        stage('Install Ballerina') {
+        stage('Test') {
             steps {
-                sh '''
-                    if ! command -v bal &> /dev/null; then
-                        wget -q https://dist.ballerina.io/downloads/${BAL_VERSION}/ballerina-${BAL_VERSION}-swan-lake-linux-x64.deb
-                        sudo dpkg -i ballerina-${BAL_VERSION}-swan-lake-linux-x64.deb
-                    fi
-                    bal version
-                '''
+                sh 'bal test'
             }
         }
 
@@ -62,155 +42,34 @@ pipeline {
             steps {
                 sh 'bal build'
             }
-            post {
-                success {
-                    archiveArtifacts artifacts: 'target/bin/*.jar', fingerprint: true
-                }
-            }
-        }
-
-        stage('Test') {
-            steps {
-                sh 'bal test --code-coverage'
-            }
-            post {
-                always {
-                    junit testResults: 'target/report/**/TEST-*.xml', allowEmptyResults: true
-                    publishHTML(target: [
-                        reportDir: 'target/report/test_results',
-                        reportFiles: 'index.html',
-                        reportName: 'Ballerina Test Report'
-                    ])
-                }
-            }
-        }
-
-        stage('Docker Build & Push') {
-            when {
-                branch 'main'
-            }
-            steps {
-                sh """
-                    docker login -u ${DOCKER_CREDS_USR} -p ${DOCKER_CREDS_PSW} ${DOCKER_REGISTRY}
-                    docker build -t ${DOCKER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} \
-                                 -t ${DOCKER_REGISTRY}/${IMAGE_NAME}:latest \
-                                 -f target/docker/${IMAGE_NAME}/Dockerfile .
-                    docker push ${DOCKER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}
-                    docker push ${DOCKER_REGISTRY}/${IMAGE_NAME}:latest
-                """
-            }
-        }
-
-        stage('Deploy to Staging') {
-            when {
-                branch 'main'
-            }
-            steps {
-                sh """
-                    kubectl --kubeconfig=${KUBECONFIG} set image \
-                        deployment/${IMAGE_NAME} app=${DOCKER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} \
-                        -n staging
-                    kubectl --kubeconfig=${KUBECONFIG} rollout status \
-                        deployment/${IMAGE_NAME} -n staging --timeout=300s
-                """
-            }
-        }
-
-        stage('Deploy to Production') {
-            when {
-                branch 'main'
-            }
-            input {
-                message 'Deploy to production?'
-                ok 'Yes, deploy'
-            }
-            steps {
-                sh """
-                    kubectl --kubeconfig=${KUBECONFIG} set image \
-                        deployment/${IMAGE_NAME} app=${DOCKER_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} \
-                        -n production
-                    kubectl --kubeconfig=${KUBECONFIG} rollout status \
-                        deployment/${IMAGE_NAME} -n production --timeout=300s
-                """
-            }
         }
     }
+}
+```
 
-    post {
-        failure {
-            mail to: 'team@example.com',
-                 subject: "Pipeline Failed: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-                 body: "Check the build at ${env.BUILD_URL}"
-        }
-        cleanup {
-            cleanWs()
-        }
+## Test stage details
+
+The pipeline uses the `ballerina/ballerina:latest` Docker image as its agent, so Ballerina and the required JDK are available with no installation steps.
+
+```groovy
+agent {
+    docker {
+        image 'ballerina/ballerina:latest'
     }
 }
 ```
 
 ## Build stage details
 
-The build stage compiles the Ballerina project and produces an executable JAR in `target/bin/`. When your project has a `Cloud.toml`, it also generates Docker and Kubernetes artifacts.
-
-The `archiveArtifacts` step stores the built JAR in Jenkins for traceability and manual download.
-
-## Test stage details
-
-The test stage runs all test functions and publishes results in two formats:
-
-- **JUnit XML** -- Displayed in the Jenkins build summary with pass/fail counts
-- **HTML Report** -- A detailed test report viewable from the build page
+The build stage compiles the Ballerina project and produces artifacts in the `target/` directory.
 
 ```groovy
-stage('Test') {
+stage('Build') {
     steps {
-        sh 'bal test --code-coverage'
-    }
-    post {
-        always {
-            junit testResults: 'target/report/**/TEST-*.xml', allowEmptyResults: true
-        }
+        sh 'bal build'
     }
 }
 ```
-
-## Deploy stage details
-
-The pipeline deploys to staging automatically on every push to `main`. Production deployment requires manual approval via the `input` directive, which pauses the pipeline until an authorized user confirms.
-
-For rollback scenarios, keep previous image tags available in your registry. Rolling back is a single `kubectl set image` command pointing to the prior tag.
-
-## Secrets management
-
-Use Jenkins Credentials to store sensitive values. Reference them in the pipeline using the `credentials()` helper:
-
-| Credential ID | Type | Usage |
-|---|---|---|
-| `docker-registry-creds` | Username/Password | Container registry login |
-| `kubeconfig-production` | Secret file | Kubernetes cluster access |
-| `db-password` | Secret text | Database password |
-| `api-key` | Secret text | External API key |
-
-Pass secrets as environment variables to your Ballerina runtime:
-
-```groovy
-stage('Deploy') {
-    environment {
-        DB_PASSWORD = credentials('db-password')
-    }
-    steps {
-        sh 'kubectl create secret generic app-secrets --from-literal=DB_PASSWORD=${DB_PASSWORD} -n production --dry-run=client -o yaml | kubectl apply -f -'
-    }
-}
-```
-
-## Multibranch pipeline
-
-For teams using feature branches, configure a Jenkins Multibranch Pipeline that automatically discovers branches and runs the pipeline for each one. The `when` directives in the Jenkinsfile control which stages run for which branches:
-
-- **Feature branches**: Build and Test only
-- **Main branch**: Build, Test, Docker, and Deploy
 
 ## What's next
 


### PR DESCRIPTION
## Summary

Simplifies the GitHub Actions, Azure DevOps, and Jenkins CI/CD samples to match the GitLab sample — `bal test` and `bal build` only, with no Docker build/push or Kubernetes deployment sections.

- **GitHub Actions**: single `build-and-test` job using `setup-ballerina@v1.1.4`
- **Azure DevOps**: flat steps pipeline using `ballerina/ballerina:latest` container
- **Jenkins**: declarative pipeline using `ballerina/ballerina:latest` as Docker agent

## Test plan

- [ ] Verify all three samples render correctly in docs
- [ ] YAML syntax validated locally (all blocks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified Azure DevOps, GitHub Actions, and Jenkins CI/CD guides to focus on running tests and builds in CI
  * Replaced multi-stage/deployment-focused examples with minimal CI workflows and clarified prerequisites
  * Removed deployment-, registry-, and environment-specific instructions to streamline CI setup and reduce complexity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/docs-integrator/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->