### PR TITLE
fix: prevent zoom wrapper from breaking linked image buttons

### DIFF
--- a/en/src/theme/MDXComponents/A.tsx
+++ b/en/src/theme/MDXComponents/A.tsx
@@ -1,0 +1,13 @@
+import React, { type ComponentProps } from 'react';
+import OriginalA from '@theme-original/MDXComponents/A';
+import { InsideAnchorContext } from './AnchorContext';
+
+type Props = ComponentProps<typeof OriginalA>;
+
+export default function AWrapper(props: Props): React.ReactElement {
+  return (
+    <InsideAnchorContext.Provider value={true}>
+      <OriginalA {...props} />
+    </InsideAnchorContext.Provider>
+  );
+}

--- a/en/src/theme/MDXComponents/AnchorContext.tsx
+++ b/en/src/theme/MDXComponents/AnchorContext.tsx
@@ -1,0 +1,4 @@
+import { createContext, useContext } from 'react';
+
+export const InsideAnchorContext = createContext(false);
+export const useInsideAnchor = () => useContext(InsideAnchorContext);

--- a/en/src/theme/MDXComponents/Img.tsx
+++ b/en/src/theme/MDXComponents/Img.tsx
@@ -1,13 +1,15 @@
 import React, { type ComponentProps } from 'react';
 import OriginalImg from '@theme-original/MDXComponents/Img';
+import { useInsideAnchor } from './AnchorContext';
 
 type Props = ComponentProps<typeof OriginalImg>;
 
 export default function ImgWrapper(props: Props): React.ReactElement {
+  const insideAnchor = useInsideAnchor();
   const src = typeof (props as { src?: unknown }).src === 'string'
     ? ((props as { src: string }).src)
     : undefined;
-  if (!src) return <OriginalImg {...props} />;
+  if (!src || insideAnchor) return <OriginalImg {...props} />;
   return (
     <a
       href={src}


### PR DESCRIPTION
Resolves [#526](https://github.com/wso2/docs-integrator/issues/526)

The swizzled `ImgWrapper` component (added in `1e5fd9a7`) unconditionally wraps every image in an anchor pointing to the image's own `src`. When an image is already inside a markdown link — as with the "Deploy to WSO2 Integration Platform" button on connector example pages — this produces nested `<a>` tags, which is invalid HTML. Browsers recover by emptying the outer anchor, so clicks open the SVG image instead of the intended URL.

Fix by introducing a React context (`InsideAnchorContext`) that the swizzled MDX anchor component sets to `true` for all its children. `ImgWrapper` reads this context and skips its own wrapper when the image is already inside a link, preserving the zoom behaviour for all standalone images.

## Purpose

The "Deploy to WSO2 Integration Platform" button present on all 119 connector catalog example pages was broken on the hosted docs site. Clicking the button opened the button's SVG image (`https://openindevant.choreoapps.dev/images/DeployDevant-White.svg`) in a new tab instead of navigating to the WSO2 Integration Platform deployment console.

The button had been working correctly since it was first introduced in January 2026. It was silently broken by commit `1e5fd9a7` (*"Enable zoom in image functionality"*, May 8 2026), which swizzled the Docusaurus `img` component to wrap every image in a self-referencing anchor for click-to-zoom. That component had no awareness of images already nested inside links, causing a nested `<a>` tag violation that browsers resolve by discarding the outer anchor — making the intended destination unreachable.

## Goals

- Restore correct click-through behaviour for the "Deploy to WSO2 Integration Platform" button across all 119 affected connector catalog example pages, without modifying any markdown content files
- Ensure the existing click-to-zoom feature continues to work correctly for all standalone images that are not wrapped in links

## Approach

The root cause is that `ImgWrapper` has no way to know whether the image it is rendering is already inside an anchor. The fix uses a React context to establish that signal at render time — no DOM inspection, no `useEffect`, no flash of incorrect content, and fully compatible with Docusaurus's server-side rendering.

Three files are added or modified under `en/src/theme/MDXComponents/`:

**`AnchorContext.tsx`** (new file)
Defines a React context with a default value of `false`. Exports the context object and a `useInsideAnchor()` hook for consumers to read it cleanly.

**`A.tsx`** (new file)
Swizzles the Docusaurus MDX `<a>` component. Wraps Docusaurus's original anchor implementation with `InsideAnchorContext.Provider value={true}`, so any component rendered inside a markdown link automatically sees `insideAnchor = true`. All existing link behaviour (external link handling, active-link styling, `href`, `target`, `rel`) is fully delegated to `OriginalA` — this component is a transparent pass-through that only adds the context signal.

**`Img.tsx`** (modified)
Adds one import (`useInsideAnchor`) and extends the existing early-return guard with an `|| insideAnchor` check. When an image is rendered inside a link, the component returns the original `<img>` directly without its zoom wrapper — leaving the outer anchor's `href` intact and clickable. When an image is rendered standalone (the common case for diagrams and screenshots), the context value is `false` (the default) and the zoom wrapper is added exactly as before.

## Release note

Fixed a regression where the "Deploy to WSO2 Integration Platform" button on all connector catalog example pages navigated to the button's SVG image instead of the WSO2 Integration Platform deployment console when clicked on the hosted docs site. The issue was introduced by the click-to-zoom image feature and affected all 119 connector example pages.

## Documentation

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML validation issue where images inside anchor links were creating nested anchor elements, improving link behavior and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->