### PR TITLE
docs: document ICP backend endpoint settings for custom hostname

### DIFF
--- a/en/docs/manage/icp/reverse-proxy.md
+++ b/en/docs/manage/icp/reverse-proxy.md
@@ -22,6 +22,18 @@ The ICP console is a single-page application whose API endpoints are read from `
 
 Restart ICP after saving the file for the changes to take effect.
 
+## Update the backend configuration
+
+In addition to the frontend config, update the backend endpoint settings in `conf/deployment.toml` to reflect the external hostname:
+
+```toml
+backendGraphqlEndpoint       = "https://icp.example.com/graphql"
+backendAuthBaseUrl           = "https://icp.example.com/auth"
+backendObservabilityEndpoint = "https://icp.example.com/icp/observability"
+```
+
+These values default to `https://localhost:9446` and must match the externally accessible URL whenever ICP is accessed through a hostname other than `localhost`. Restart ICP after saving the file.
+
 ## Update runtime connections
 
 WSO2 Integrator runtimes send heartbeats to ICP over a dedicated registration port. If runtimes connect to ICP through the proxy, update `serverUrl` in the runtime's `Config.toml`:

--- a/en/docs/manage/icp/reverse-proxy.md
+++ b/en/docs/manage/icp/reverse-proxy.md
@@ -8,23 +8,9 @@ keywords: [wso2 integrator, integration control plane, icp, reverse proxy, nginx
 
 ICP serves the console and API on port `9446` using HTTPS with a self-signed certificate. In production, you typically place a reverse proxy in front of ICP to handle TLS termination, expose a standard port, and integrate with your network infrastructure. This page covers the ICP-specific configuration required when a reverse proxy is in use.
 
-## Update the console frontend
-
-The ICP console is a single-page application whose API endpoints are read from `www/config.json` at startup. Update this file to point to the external proxy URL:
-
-```json
-{
-  "VITE_GRAPHQL_URL": "https://icp.example.com/graphql",
-  "VITE_AUTH_BASE_URL": "https://icp.example.com/auth",
-  "VITE_OBSERVABILITY_URL": "https://icp.example.com/icp/observability"
-}
-```
-
-Restart ICP after saving the file for the changes to take effect.
-
 ## Update the backend configuration
 
-In addition to the frontend config, update the backend endpoint settings in `conf/deployment.toml` to reflect the external hostname:
+Update the backend endpoint settings in `conf/deployment.toml` to reflect the external hostname:
 
 ```toml
 backendGraphqlEndpoint       = "https://icp.example.com/graphql"
@@ -32,7 +18,7 @@ backendAuthBaseUrl           = "https://icp.example.com/auth"
 backendObservabilityEndpoint = "https://icp.example.com/icp/observability"
 ```
 
-These values default to `https://localhost:9446` and must match the externally accessible URL whenever ICP is accessed through a hostname other than `localhost`. Restart ICP after saving the file.
+These values default to `https://localhost:9446`. ICP automatically propagates them to the console frontend on startup, so `www/config.json` does not need to be edited manually. Restart ICP after saving the file.
 
 ## Update runtime connections
 

--- a/en/docs/reference/icp/server-configuration.md
+++ b/en/docs/reference/icp/server-configuration.md
@@ -7,7 +7,7 @@ description: Complete key reference for ICP Server configuration settings in dep
 
 All values are set in `<ICP_HOME>/conf/deployment.toml`. Commented-out keys show default values.
 
-## Server Settings
+## Server settings
 
 | Key                                  | Type      | Default     | Description                                                           |
 | ------------------------------------ | --------- | ----------- | --------------------------------------------------------------------- |
@@ -19,7 +19,7 @@ All values are set in `<ICP_HOME>/conf/deployment.toml`. Commented-out keys show
 | `schedulerIntervalSeconds`           | `int`     | `60`        | How often ICP checks for inactive runtimes and marks them as offline |
 | `refreshTokenCleanupIntervalSeconds` | `int`     | `86400`     | How often expired refresh tokens are purged from the database         |
 
-## Backend Endpoint Settings
+## Backend endpoint settings
 
 These values default to `localhost:9446` and must be updated when ICP is accessed through a different hostname or behind a reverse proxy.
 
@@ -29,7 +29,7 @@ These values default to `localhost:9446` and must be updated when ICP is accesse
 | `backendAuthBaseUrl`            | `string` | `"https://localhost:9446/auth"`               | Base URL of the ICP authentication service           |
 | `backendObservabilityEndpoint`  | `string` | `"https://localhost:9446/icp/observability"`  | URL of the ICP observability endpoint                |
 
-## Authentication Settings
+## Authentication settings
 
 | Key                          | Type      | Default                    | Description                                                       |
 | ---------------------------- | --------- | -------------------------- | ----------------------------------------------------------------- |

--- a/en/docs/reference/icp/server-configuration.md
+++ b/en/docs/reference/icp/server-configuration.md
@@ -19,6 +19,16 @@ All values are set in `<ICP_HOME>/conf/deployment.toml`. Commented-out keys show
 | `schedulerIntervalSeconds`           | `int`     | `60`        | How often ICP checks for inactive runtimes and marks them as offline |
 | `refreshTokenCleanupIntervalSeconds` | `int`     | `86400`     | How often expired refresh tokens are purged from the database         |
 
+## Backend Endpoint Settings
+
+These values default to `localhost:9446` and must be updated when ICP is accessed through a different hostname or behind a reverse proxy.
+
+| Key                             | Type     | Default                                       | Description                                          |
+| ------------------------------- | -------- | --------------------------------------------- | ---------------------------------------------------- |
+| `backendGraphqlEndpoint`        | `string` | `"https://localhost:9446/graphql"`            | URL of the ICP GraphQL API endpoint                  |
+| `backendAuthBaseUrl`            | `string` | `"https://localhost:9446/auth"`               | Base URL of the ICP authentication service           |
+| `backendObservabilityEndpoint`  | `string` | `"https://localhost:9446/icp/observability"`  | URL of the ICP observability endpoint                |
+
 ## Authentication Settings
 
 | Key                          | Type      | Default                    | Description                                                       |


### PR DESCRIPTION
## Summary

- Adds `backendGraphqlEndpoint`, `backendAuthBaseUrl`, and `backendObservabilityEndpoint` to the **Server Configuration** reference (`server-configuration.md`) as a new \"Backend Endpoint Settings\" section with their defaults and descriptions.
- Adds an **\"Update the backend configuration\"** section to the **reverse proxy guide** (`reverse-proxy.md`) showing the `deployment.toml` snippet users need to update when ICP is accessed through a hostname other than `localhost`.

## Test plan

- [ ] Verify the new table renders correctly in the server configuration reference page
- [ ] Verify the new section appears between the frontend config and runtime connections sections in the reverse proxy guide
- [ ] Check that the `deployment.toml` code block formatting is correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Guidance added to update backend endpoint settings to use externally reachable reverse-proxy hostnames/URLs (instead of localhost) for GraphQL, auth base URL, and observability endpoints.
  * Notes that these backend settings are applied to the console frontend on startup (no manual frontend edits required) and that ICP must be restarted after saving changes.
  * Reference docs expanded with default values and hostname/customization guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->