### PR TITLE
fix: RabbitMQ 4.x compatibility - declare queue as durable

### DIFF
--- a/en/docs/develop/integration-artifacts/event/rabbitmq.md
+++ b/en/docs/develop/integration-artifacts/event/rabbitmq.md
@@ -98,6 +98,7 @@ service on rabbitmqListener {
 |---|---|---|---|
 | `queueName` | `string` | Required | Name of the queue to consume from |
 | `autoAck` | `boolean` | `true` | When `false`, messages must be manually acknowledged using `rabbitmq:Caller` |
+| `config` | `rabbitmq:QueueConfig?` | — | Queue declaration settings. Set `{ durable: true }` for compatibility with RabbitMQ 4.x, which disables transient non-exclusive queues by default. |
 
 </TabItem>
 </Tabs>

--- a/en/docs/get-started/build-event-driven-integration.md
+++ b/en/docs/get-started/build-event-driven-integration.md
@@ -56,6 +56,26 @@ In the cloud editor, you're already inside a project. Skip to Step 2.
 5. Set **Queue Name** to `Orders`.
 6. Select **Create**.
 
+:::caution RabbitMQ 4.x compatibility
+
+RabbitMQ 4.x deprecated transient non-exclusive queues. The visual designer creates a transient queue by default, which causes the following error on startup:
+
+```
+error: I/O Error occurred while declaring the queue: Feature `transient_nonexcl_queues` is deprecated.
+```
+
+After clicking **Create**, open `main.bal` and add the following annotation above the `service` declaration:
+
+```ballerina
+@rabbitmq:ServiceConfig {
+    queueName: "Orders",
+    config: {
+        durable: true
+    }
+}
+```
+:::
+
 <ThemedImage
     alt="Add a RabbitMQ Event Integration Artifact"
     sources={{
@@ -122,6 +142,12 @@ import ballerinax/rabbitmq;
 
 listener rabbitmq:Listener rabbitmqListener = new ("localhost", 5672);
 
+@rabbitmq:ServiceConfig {
+    queueName: "Orders",
+    config: {
+        durable: true
+    }
+}
 service "Orders" on rabbitmqListener {
     remote function onMessage(rabbitmq:AnydataMessage message, rabbitmq:Caller caller) returns error? {
         do {
@@ -169,4 +195,3 @@ Deploy your integration to WSO2 Cloud - Integration Platform in any of the follo
 - [RabbitMQ](../develop/integration-artifacts/event/rabbitmq.md) — Full RabbitMQ listener and publisher reference
 - [MQTT](../develop/integration-artifacts/event/mqtt.md) — Handle MQTT messages from IoT and messaging devices
 - [CDC for PostgreSQL](../develop/integration-artifacts/event/cdc-postgresql.md) — React to database changes with change data capture
-

--- a/en/docs/get-started/build-event-driven-integration.md
+++ b/en/docs/get-started/build-event-driven-integration.md
@@ -60,7 +60,7 @@ In the cloud editor, you're already inside a project. Skip to Step 2.
 
 RabbitMQ 4.x deprecated transient non-exclusive queues. The visual designer creates a transient queue by default, which causes the following error on startup:
 
-```
+```bash
 error: I/O Error occurred while declaring the queue: Feature `transient_nonexcl_queues` is deprecated.
 ```
 


### PR DESCRIPTION
## Problem

RabbitMQ 4.x deprecated transient non-exclusive queues (`transient_nonexcl_queues`), which are disabled by default. The quick start guide uses `rabbitmq:4.2-management` as the recommended Docker image but the generated code creates a transient queue, causing this error on startup:

```
error: I/O Error occurred while declaring the queue: Feature `transient_nonexcl_queues` is deprecated.
By default, this feature is not permitted anymore.
```

## Changes

**`en/docs/get-started/build-event-driven-integration.md`**
- Added a `:::caution` block after the "Create" step in the Visual Designer tab explaining the RabbitMQ 4.x incompatibility and showing the fix
- Updated the Ballerina Code tab example to include `@rabbitmq:ServiceConfig { queueName: "Orders", config: { durable: true } }`

**`en/docs/develop/integration-artifacts/event/rabbitmq.md`**
- Added the `config` field (`rabbitmq:QueueConfig?`) to the `@rabbitmq:ServiceConfig` fields table, which was previously undocumented

## Test plan

- [x] Verified fix locally with `ballerinax/rabbitmq:3.5.0` against `rabbitmq:4.2-management` Docker image — service starts without error and consumes messages correctly
- [x] Confirmed `@rabbitmq:ServiceConfig` field names against connector source (`ballerinax/rabbitmq:3.5.0` — `listener.bal`, `rabbitmq_commons.bal`)

---

## AI usage note

- **AI-assisted:** Yes
- **Tool:** Claude (claude-sonnet-4-6)
- **How used:** Drafted doc changes and identified the correct `config` field name by inspecting the installed connector source
- **Human verification:** Ran the integration locally against a live RabbitMQ 4.2 instance, published a test message, and confirmed the `Received order` log appeared without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RabbitMQ integration guide with queue configuration options for enhanced control over queue declaration settings.
  * Added RabbitMQ 4.x compatibility guidance with recommended durable queue configuration to address deprecated queue behaviors.
  * Included caution notes and configuration examples to help users resolve startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->