### PR TITLE
docs: fix typos and grammar in integration docs

### DIFF
--- a/en/docs/connectors/catalog/built-in/ftp/trigger-reference.md
+++ b/en/docs/connectors/catalog/built-in/ftp/trigger-reference.md
@@ -133,7 +133,7 @@ An `ftp:Service` is a Ballerina service attached to an `ftp:Listener`. It monito
 | `onError` | <code>remote function onError(ftp:Error err, ftp:Caller caller) returns error?</code> | Invoked when the runtime cannot bind a file's content to the typed parameter of a format-specific handler. For example, an `onFileJson` handler receiving malformed JSON. `caller` is optional. |
 
 :::note
-The `|` in the content parameter lists the supported alternative types. The parameter should only be decalred with **one** of them. For example, `onFile` can be declared with `byte[]` *or* `stream<byte[], error?>`, not both at once.
+The `|` in the content parameter lists the supported alternative types. The parameter should only be declared with **one** of them. For example, `onFile` can be declared with `byte[]` *or* `stream<byte[], error?>`, not both at once.
 
 Multiple format-specific handlers (`onFile`, `onFileText`, `onFileJson`, `onFileXml`, `onFileCsv`) can coexist on the same service to route different file types to different methods using `@ftp:FunctionConfig`'s `fileNamePattern`. `onFileDelete` and `onError`can be added alongside any of them.
 :::

--- a/en/docs/deploy-operate/observe/recipe-datadog-setup.md
+++ b/en/docs/deploy-operate/observe/recipe-datadog-setup.md
@@ -100,7 +100,7 @@ Then follow the steps below to configure metrics and tracing data publishing to 
 ## Step 3: Import Prometheus and Jaeger Extensions
 
 To include the Prometheus and Jaeger extensions into the executable, the `ballerinax/prometheus` and `ballerinax/jaeger`
-modules need to be imported into your integration. Open the file explorer in WSO2 Integrator and add the below to the `main.bal` file.
+modules need to be imported into your integration. Open the file explorer in WSO2 Integrator and add the following content to the `main.bal` file.
 
 ```ballerina
 import ballerinax/prometheus as _;

--- a/en/docs/deploy-operate/observe/recipe-datadog-setup.md
+++ b/en/docs/deploy-operate/observe/recipe-datadog-setup.md
@@ -100,7 +100,7 @@ Then follow the steps below to configure metrics and tracing data publishing to 
 ## Step 3: Import Prometheus and Jaeger Extensions
 
 To include the Prometheus and Jaeger extensions into the executable, the `ballerinax/prometheus` and `ballerinax/jaeger`
-modules need to be imported into your integration. Open the the file explorer in WSO2 Integrator add the below to the `main.bal` file.
+modules need to be imported into your integration. Open the file explorer in WSO2 Integrator and add the below to the `main.bal` file.
 
 ```ballerina
 import ballerinax/prometheus as _;

--- a/en/docs/develop/integration-artifacts/event/salesforce-events.md
+++ b/en/docs/develop/integration-artifacts/event/salesforce-events.md
@@ -92,7 +92,7 @@ service salesforce:CdcService on salesforceListener {
 
 In the **Configure** panel, set **Auth** to a record expression with relevant fields with optional values to set any of the values below. Click **Save Changes** to apply.
 
-   ![Salesforce Configiration](/img/develop/integration-artifacts/event/salesforce-events/salesforce-configuration.gif)
+   ![Salesforce Configuration](/img/develop/integration-artifacts/event/salesforce-events/salesforce-configuration.gif)
 
 </TabItem>
 <TabItem value="code" label="Ballerina Code">


### PR DESCRIPTION
## Purpose
Fixes three minor spelling and grammar errors in the WSO2 Integrator documentation:
- "Configiration" → "Configuration" in the Salesforce events page image alt text
- "decalred" → "declared" in the FTP trigger reference
- Duplicate word ("the the") and a conjunction on sentence in the Datadog observability setup step

Resolves: N/A (trivial documentation typo/grammar fixes; no related issue)

## Goals
Correct the spelling and grammar errors so the affected pages read clearly and accurately. No functional or structural changes to the docs.

## Approach
Edited the three affected Markdown files directly. Each fix is a separate commit scoped to a single file. Changes were limited to the erroneous text only; surrounding existing content was left unchanged in line with the scope limitation in the documentation guidelines.

## User stories
N/A

## Release note
Fixed minor spelling and grammar errors in the integration documentation.

## Documentation
This PR updates the documentation itself. Affected pages:
- [Salesforce events](https://wso2.com/integration-platform/docs/develop/integration-artifacts/event/salesforce-events)
- [FTP trigger reference](https://wso2.com/integration-platform/docs/connectors/catalog/built-in/ftp/trigger-reference)
- [Datadog setup recipe](https://wso2.com/integration-platform/docs/deploy-operate/observe/recipe-datadog-setup)

## Training
N/A

## Certification
N/A 

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A - documentation-only change
 - Ran FindSecurityBugs plugin and verified report? N/A - no code changes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling and grammar in multiple guides, including the FTP `onFile` callback-shape note (“declared”) and improved wording in the Datadog setup recipe.
  * Fixed image alt text typo in the Salesforce events documentation (“Salesforce Configuration”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->